### PR TITLE
Use tuple when decoding untyped messagepack arrays when needed

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -2,3 +2,7 @@
     text-align: center;
     display: inline-block;
 }
+
+.footnote {
+    font-size: small;
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -121,8 +121,12 @@ mapped to Python types as follows:
 - ``float``: `float`
 - ``str``: `str`
 - ``bin``: `bytes`
-- ``array``: `list`
+- ``array``: `list` or `tuple` [#tuple]_
 - ``map``: `dict`
+
+.. [#tuple] Tuples are only used when the array type must be hashable (e.g.
+   keys in a ``dict`` or ``set``). All other array types are deserialized as
+   lists by default.
 
 Messages composed of any combination of these will deserialize successfully
 without any further validation:


### PR DESCRIPTION
Previously if a msgpack array was decoded without type information, we'd default to using a `list`. This meant that messages that used `tuple` for keys would error on decode without type information. We now automatically use `tuple` by default when necessary for decoding an `array` type (e.g. when the value is part of a key in a `dict` or `set`). This allows us to roundtrip more messages successfully without type information, while still relying on standard msgpack types.

An example may clarify this. With this PR, the following behavior occurs:

```python
In [1]: import msgspec

In [2]: data = msgspec.encode({(1, 2): [3, 4]})

In [3]: msgspec.decode(data)  # tuple used for key by default, since it must be hashable
Out[3]: {(1, 2): [3, 4]}

In [4]: data = msgspec.encode({(1, 2), (3, 4)})

In [5]: msgspec.decode(data, type=set)  # same here, since set keys must be hashable
Out[5]: {(1, 2), (3, 4)}

In [6]: data = msgspec.encode((1, 2, 3))

In [7]: msgspec.decode(data)  # list used here though, since the array type doesn't need to be hashable
Out[7]: [1, 2, 3]

In [8]: msgspec.decode(data, type=tuple)  # but type information can still be used
Out[8]: (1, 2, 3)
```