### PR TITLE
Add Extension Type support

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -24,6 +24,13 @@ Struct
     :members:
 
 
+Ext
+---
+
+.. autoclass:: Ext
+    :members:
+
+
 Functions
 ---------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ Highlights
   excellent editor integration.
 - ``msgspec`` is **flexible**. Unlike other libraries like ``msgpack`` or
   ``json``, ``msgspec`` natively supports a wider range of Python builtin
-  types.
+  types. Support for additional types can also be added through :ref:`extensions`.
 - ``msgspec`` supports :ref:`"schema evolution" <schema-evolution>`. Messages can
   be sent between clients with different schemas without error.
 
@@ -104,6 +104,10 @@ Msgspec currently supports serializing/deserializing the following types:
 - `set`
 - `enum.Enum`
 - `msgspec.Struct`
+- `msgspec.Ext`
+
+Support for serializing additional types can be added through the use of the
+``default`` callback on the `Encoder`, or by defining custom :ref:`extensions`.
 
 .. _typed-deserialization:
 
@@ -123,6 +127,7 @@ mapped to Python types as follows:
 - ``bin``: `bytes`
 - ``array``: `list` or `tuple` [#tuple]_
 - ``map``: `dict`
+- ``ext``: `msgspec.Ext`
 
 .. [#tuple] Tuples are only used when the array type must be hashable (e.g.
    keys in a ``dict`` or ``set``). All other array types are deserialized as
@@ -190,6 +195,7 @@ acceptible:
 - `set` / `typing.Set`
 - `typing.Any`
 - `typing.Optional`
+- `msgspec.Ext`
 - `enum.Enum` derived types
 - `enum.IntEnum` derived types
 - `msgspec.Struct` derived types
@@ -280,6 +286,129 @@ deserialization, it also can improve performance. Depending on the schema,
 deserializing a message into a `Struct` can be *roughly twice as fast* as
 deserializing it into a `dict`.
 
+.. _extensions:
+
+Extensions
+~~~~~~~~~~
+
+The MessagePack specification provides support for defining custom
+`Extensions <https://github.com/msgpack/msgpack/blob/master/spec.md#extension-types>`__.
+Extensions consist of:
+
+- An integer code (between 0 and 127, inclusive) representing the "type" of the
+  extension.
+- An arbitrary byte buffer of data (up to ``(2^32) - 1`` in length).
+
+By default extensions are serialized to/from `Ext` objects.
+
+.. code-block:: python
+
+    >>> ext = msgspec.Ext(1, b"some data")  # an extension object, with type code 1
+    >>> msg = msgspec.encode(ext)
+    >>> ext2 = msgspec.decode(msg)
+    >>> ext == ext2  # deserializes as an Ext object
+    True
+
+While manually creating `Ext` objects from buffers can be useful, usually the
+user wants to map extension types to/from their own custom objects. This can be
+accomplished by defining two callback functions:
+
+- ``default`` in `Encoder`, for transforming custom types into values
+  that ``msgspec`` already knows how to serialize.
+- ``ext_hook`` in `Decoder`, for converting extensions back into those
+  custom types.
+
+These should have the following signatures:
+
+.. code-block:: python
+
+    def default(obj: Any) -> Any:
+        """Given an object that msgspec doesn't know how to serialize by
+        default, convert it into an object that it does know how to
+        serialize"""
+        pass
+
+    def ext_hook(code: int, data: memoryview) -> Any:
+        """Given an extension type code and data buffer, deserialize whatever
+        custom object the extension type represents"""
+        pass
+
+
+For example, perhaps you wanted to serialize `complex` number objects as an
+extension type.  These objects can be represented as tuples of two floats (one
+"real" and one "imaginary"). If we represent each float as 8 bytes (a
+"double"), then any complex number can be fully represented by a 16 byte
+buffer.
+
+.. code-block::
+
+    +---------+---------+
+    |  real   |  imag   |
+    +---------+---------+
+      8 bytes   8 bytes 
+    
+
+Here we define ``default`` and ``ext_hook`` callbacks to convert `complex`
+objects to/from this binary representation as a MessagePack extension.
+
+.. code-block:: python
+
+    import msgspec
+    import struct
+    from typing import Any
+
+    # All extension types need a unique integer designator so the decoder knows
+    # which type they're decoding. Here we arbitrarily choose 1, but any integer
+    # between 0 and 127 (inclusive) would work.
+    COMPLEX_TYPE_CODE = 1
+
+    def default(obj: Any) -> Any:
+        if isinstance(obj, complex):
+            # encode the complex number into a 16 byte buffer
+            data = struct.pack('dd', obj.real, obj.imag)
+
+            # Return an `Ext` object so msgspec serializes it as an extension type.
+            return msgspec.Ext(COMPLEX_TYPE_CODE, data)
+        else:
+            # Raise a TypeError for other types
+            raise TypeError(f"Objects of type {type(obj)} are not supported")
+
+
+    def ext_hook(code: int, data: memoryview) -> Any:
+        if code == COMPLEX_TYPE_CODE:
+            # This extension type represents a complex number, decode the data
+            # buffer accordingly.
+            real, imag = struct.unpack('dd', data)
+            return complex(real, imag)
+        else:
+            # Raise a TypeError for other extension type codes
+            raise TypeError(f"Extension type code {code} is not supported")
+
+
+    # Create an encoder and a decoder using the custom callbacks
+    enc = msgspec.Encoder(default=default)
+    dec = msgspec.Decoder(ext_hook=ext_hook)
+
+    # Define a message that contains complex numbers
+    msg = {"roots": [0, 0.75, 1 + 0.5j, 1 - 0.5j]}
+
+    # Encode and decode the message to show that things work
+    buf = enc.encode(msg)
+    msg2 = dec.decode(buf)
+    assert msg == msg2  # True
+
+
+.. note::
+
+    Note that the ``data`` argument to ``ext_hook`` is a `memoryview`. This
+    view is attached to the larger buffer containing the complete message being
+    decoded. As such, you'll want to ensure that you don't keep a reference to
+    the underlying buffer, otherwise you may accidentally persist the larger
+    message buffer around for longer than necessary, resulting in increased
+    memory usage.
+
+
+
 .. _schema-evolution:
 
 Schema Evolution
@@ -299,6 +428,8 @@ For schema evolution to work smoothly, you need to follow a few guidelines:
 
 1. Any new fields on a `Struct` must specify default values.
 2. Don't change the type annotations for existing messages or fields
+3. Don't change the type codes or implementations for any defined
+   :ref:`Extensions`
 
 For example, suppose we wanted to add a new ``email`` field to our ``Person``
 struct. To do so, we add it at the end of the definition, with a default value.
@@ -333,7 +464,6 @@ efficiently skipped without decoding.
     >>> old_msg = msgspec.encode(harry)
     >>> new_dec.decode(old_msg) # deserializing an old msg with a new decoder
     Person2(first='Harry', last='Potter', address='4 Privet Drive', phone=None, email=None)
-
 
 .. _type annotations: https://docs.python.org/3/library/typing.html
 .. _quickle: https://jcristharif.com/quickle/

--- a/msgspec/__init__.py
+++ b/msgspec/__init__.py
@@ -2,7 +2,7 @@ from .core import (
     Struct,
     Encoder,
     Decoder,
-    ExtType,
+    Ext,
     MsgspecError,
     EncodingError,
     DecodingError,

--- a/msgspec/__init__.py
+++ b/msgspec/__init__.py
@@ -2,6 +2,7 @@ from .core import (
     Struct,
     Encoder,
     Decoder,
+    ExtType,
     MsgspecError,
     EncodingError,
     DecodingError,

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -2953,6 +2953,14 @@ mp_skip_map(DecoderState *self, Py_ssize_t size) {
 }
 
 static int
+mp_skip_ext(DecoderState *self, Py_ssize_t size) {
+    char *s;
+    if (size < 0) return -1;
+    if (size == 0) return 0;
+    return mp_read(self, &s, size + 1);
+}
+
+static int
 mp_skip(DecoderState *self) {
     char *s;
     char op;
@@ -3011,6 +3019,22 @@ mp_skip(DecoderState *self) {
             return mp_skip_map(self, mp_decode_size2(self));
         case MP_MAP32:
             return mp_skip_map(self, mp_decode_size4(self));
+        case MP_FIXEXT1:
+            return mp_skip_ext(self, 1);
+        case MP_FIXEXT2:
+            return mp_skip_ext(self, 2);
+        case MP_FIXEXT4:
+            return mp_skip_ext(self, 4);
+        case MP_FIXEXT8:
+            return mp_skip_ext(self, 8);
+        case MP_FIXEXT16:
+            return mp_skip_ext(self, 16);
+        case MP_EXT8:
+            return mp_skip_ext(self, mp_decode_size1(self));
+        case MP_EXT16:
+            return mp_skip_ext(self, mp_decode_size2(self));
+        case MP_EXT32:
+            return mp_skip_ext(self, mp_decode_size4(self));
         default:
             PyErr_Format(msgspec_get_global_state()->DecodingError, "invalid opcode, '\\x%02x'.", op);
             return -1;

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -1523,7 +1523,7 @@ typedef struct Ext {
 } Ext;
 
 static PyObject *
-ExtType_New(char code, PyObject *data) {
+Ext_New(char code, PyObject *data) {
     Ext *out = (Ext *)Ext_Type.tp_alloc(&Ext_Type, 0);
     if (out == NULL)
         return NULL;
@@ -1534,7 +1534,10 @@ ExtType_New(char code, PyObject *data) {
     return (PyObject *)out;
 }
 
-PyDoc_STRVAR(ExtType__doc__,
+PyDoc_STRVAR(Ext__doc__,
+"Ext(code, data)\n"
+"--\n"
+"\n"
 "A record representing a MessagePack Extension Type.\n"
 "\n"
 "Parameters\n"
@@ -1545,7 +1548,7 @@ PyDoc_STRVAR(ExtType__doc__,
 "    The byte buffer for this extension."
 );
 static PyObject *
-ExtType_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyObject *kwnames) {
+Ext_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyObject *kwnames) {
     PyObject *pycode, *data;
     char code;
     Py_ssize_t nargs, nkwargs;
@@ -1601,23 +1604,23 @@ ExtType_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyOb
         );
         return NULL;
     }
-    return ExtType_New(code, data);
+    return Ext_New(code, data);
 }
 
 static void
-ExtType_dealloc(Ext *self)
+Ext_dealloc(Ext *self)
 {
     Py_XDECREF(self->data);
 }
 
-static PyMemberDef ExtType_members[] = {
+static PyMemberDef Ext_members[] = {
     {"code", T_BYTE, offsetof(Ext, code), READONLY, "The extension type code"},
     {"data", T_OBJECT_EX, offsetof(Ext, data), READONLY, "The extension data payload"},
     {NULL},
 };
 
 static PyObject *
-ExtType_reduce(PyObject *self, PyObject *unused)
+Ext_reduce(PyObject *self, PyObject *unused)
 {
     return Py_BuildValue("O(bO)", Py_TYPE(self), ((Ext*)self)->code, ((Ext*)self)->data);
 }
@@ -1650,26 +1653,26 @@ Ext_richcompare(PyObject *self, PyObject *other, int op) {
     return out;
 }
 
-static PyMethodDef ExtType_methods[] = {
-    {"__reduce__", ExtType_reduce, METH_NOARGS, "reduce an Ext"},
+static PyMethodDef Ext_methods[] = {
+    {"__reduce__", Ext_reduce, METH_NOARGS, "reduce an Ext"},
     {NULL, NULL},
 };
 
 static PyTypeObject Ext_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "msgspec.Ext",
-    .tp_doc = ExtType__doc__,
+    .tp_doc = Ext__doc__,
     .tp_basicsize = sizeof(Ext),
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | _Py_TPFLAGS_HAVE_VECTORCALL,
     .tp_new = PyType_GenericNew,
-    .tp_dealloc = (destructor) ExtType_dealloc,
+    .tp_dealloc = (destructor) Ext_dealloc,
     .tp_call = PyVectorcall_Call,
-    .tp_vectorcall = (vectorcallfunc) ExtType_vectorcall,
+    .tp_vectorcall = (vectorcallfunc) Ext_vectorcall,
     .tp_vectorcall_offset = offsetof(PyTypeObject, tp_vectorcall),
     .tp_richcompare = Ext_richcompare,
-    .tp_members = ExtType_members,
-    .tp_methods = ExtType_methods
+    .tp_members = Ext_members,
+    .tp_methods = Ext_methods
 };
 
 /*************************************************************************
@@ -2805,7 +2808,7 @@ mp_decode_ext(DecoderState *self, Py_ssize_t size, bool skip_ext_hook) {
     if (self->ext_hook == NULL || skip_ext_hook) {
         data = PyBytes_FromStringAndSize(data_buf, size);
         if (data == NULL) return NULL;
-        return ExtType_New(code, data);
+        return Ext_New(code, data);
     }
 
     pycode = PyLong_FromLong(code);

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -3032,7 +3032,6 @@ static int
 mp_skip_ext(DecoderState *self, Py_ssize_t size) {
     char *s;
     if (size < 0) return -1;
-    if (size == 0) return 0;
     return mp_read(self, &s, size + 1);
 }
 

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -168,6 +168,7 @@ check_positional_nargs(Py_ssize_t nargs, Py_ssize_t min, Py_ssize_t max) {
  ************************************************************************/
 
 static PyTypeObject StructMetaType;
+static PyTypeObject ExtType_Type;
 static int StructMeta_prep_types(PyObject *self);
 
 enum typecode {
@@ -187,6 +188,7 @@ enum typecode {
     TYPE_VARTUPLE,
     TYPE_FIXTUPLE,
     TYPE_DICT,
+    TYPE_EXTTYPE,
 };
 
 typedef struct TypeNode {
@@ -228,6 +230,7 @@ TypeNode_Free(TypeNode *type) {
         case TYPE_STR:
         case TYPE_BYTES:
         case TYPE_BYTEARRAY:
+        case TYPE_EXTTYPE:
             PyMem_Free(type);
             return;
         case TYPE_ENUM:
@@ -276,6 +279,7 @@ TypeNode_traverse(TypeNode *type, visitproc visit, void *arg) {
         case TYPE_STR:
         case TYPE_BYTES:
         case TYPE_BYTEARRAY:
+        case TYPE_EXTTYPE:
             return 0;
         case TYPE_ENUM:
         case TYPE_INTENUM:
@@ -398,6 +402,8 @@ TypeNode_Repr(TypeNode *type) {
             return PyUnicode_FromString(type->optional ? "Optional[bytes]" : "bytes");
         case TYPE_BYTEARRAY:
             return PyUnicode_FromString(type->optional ? "Optional[bytearray]" : "bytearray");
+        case TYPE_EXTTYPE:
+            return PyUnicode_FromString(type->optional ? "Optional[ExtType]" : "ExtType");
         case TYPE_ENUM:
         case TYPE_INTENUM:
         case TYPE_STRUCT: 
@@ -548,6 +554,9 @@ to_type_node(PyObject * obj, bool optional) {
     }
     else if (obj == (PyObject *)(&PyByteArray_Type)) {
         return TypeNode_New(TYPE_BYTEARRAY, optional);
+    }
+    else if (obj == (PyObject *)(&ExtType_Type)) {
+        return TypeNode_New(TYPE_EXTTYPE, optional);
     }
     else if (Py_TYPE(obj) == &StructMetaType) {
         if (StructMeta_prep_types(obj) < 0) return NULL;

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -3322,6 +3322,30 @@ mp_decode_type_binary(DecoderState *self, char op, bool is_bytearray, TypeNode *
     return PyBytes_FromStringAndSize(s, size);
 }
 
+static PyObject *
+mp_decode_type_ext(DecoderState *self, char op, TypeNode *ctx, Py_ssize_t ctx_ind) {
+    switch ((enum mp_code)op) {
+        case MP_FIXEXT1:
+            return mp_decode_ext(self, 1);
+        case MP_FIXEXT2:
+            return mp_decode_ext(self, 2);
+        case MP_FIXEXT4:
+            return mp_decode_ext(self, 4);
+        case MP_FIXEXT8:
+            return mp_decode_ext(self, 8);
+        case MP_FIXEXT16:
+            return mp_decode_ext(self, 16);
+        case MP_EXT8:
+            return mp_decode_ext(self, mp_decode_size1(self));
+        case MP_EXT16:
+            return mp_decode_ext(self, mp_decode_size2(self));
+        case MP_EXT32:
+            return mp_decode_ext(self, mp_decode_size4(self));
+        default:
+            return mp_validation_error(op, "ExtType", ctx, ctx_ind);
+    }
+}
+
 static Py_ssize_t
 mp_decode_map_size(DecoderState *self, char op, char *expected, TypeNode *ctx, Py_ssize_t ctx_ind) {
     if ('\x80' <= op && op <= '\x8f') {
@@ -3661,6 +3685,8 @@ mp_decode_type(
             return mp_decode_type_binary(self, op, false, ctx, ctx_ind);
         case TYPE_BYTEARRAY:
             return mp_decode_type_binary(self, op, true, ctx, ctx_ind);
+        case TYPE_EXTTYPE:
+            return mp_decode_type_ext(self, op, ctx, ctx_ind);
         case TYPE_ENUM:
             return mp_decode_type_enum(self, op, (TypeNodeObj *)type, ctx, ctx_ind);
         case TYPE_INTENUM:

--- a/msgspec/core.pyi
+++ b/msgspec/core.pyi
@@ -4,8 +4,8 @@ T = TypeVar("T")
 
 class Ext:
     code: int
-    data: Union[bytes, bytearray]
-    def __init__(self, code: int, data: Union[bytes, bytearray]) -> None: ...
+    data: Union[bytes, bytearray, memoryview]
+    def __init__(self, code: int, data: Union[bytes, bytearray, memoryview]) -> None: ...
 
 class Decoder(Generic[T]):
     @overload

--- a/msgspec/core.pyi
+++ b/msgspec/core.pyi
@@ -5,7 +5,9 @@ T = TypeVar("T")
 class Ext:
     code: int
     data: Union[bytes, bytearray, memoryview]
-    def __init__(self, code: int, data: Union[bytes, bytearray, memoryview]) -> None: ...
+    def __init__(
+        self, code: int, data: Union[bytes, bytearray, memoryview]
+    ) -> None: ...
 
 class Decoder(Generic[T]):
     @overload

--- a/msgspec/core.pyi
+++ b/msgspec/core.pyi
@@ -1,12 +1,23 @@
-from typing import Any, Type, TypeVar, Generic, Callable, overload
+from typing import Any, Type, TypeVar, Generic, Optional, Callable, Union, overload
 
 T = TypeVar("T")
 
+class Ext:
+    code: int
+    data: Union[bytes, bytearray]
+    def __init__(self, code: int, data: Union[bytes, bytearray]) -> None: ...
+
 class Decoder(Generic[T]):
     @overload
-    def __init__(self: Decoder[Any]) -> None: ...
+    def __init__(
+        self: Decoder[Any], ext_hook: Optional[Callable[[int, memoryview], Any]] = None
+    ) -> None: ...
     @overload
-    def __init__(self: Decoder[T], type: Type[T] = ...) -> None: ...
+    def __init__(
+        self: Decoder[T],
+        type: Type[T] = ...,
+        ext_hook: Optional[Callable[[int, memoryview], Any]] = None,
+    ) -> None: ...
     def decode(self, data: bytes) -> T: ...
 
 class Encoder:
@@ -16,7 +27,14 @@ class Encoder:
     def encode(self, obj: Any) -> bytes: ...
 
 @overload
-def decode(buf: bytes) -> Any: ...
+def decode(
+    buf: bytes, ext_hook: Optional[Callable[[int, memoryview], Any]] = None
+) -> Any: ...
 @overload
-def decode(buf: bytes, *, type: Type[T] = ...) -> T: ...
+def decode(
+    buf: bytes,
+    *,
+    type: Type[T] = ...,
+    ext_hook: Optional[Callable[[int, memoryview], Any]] = None
+) -> T: ...
 def encode(obj: Any, *, default: Callable[[Any], Any] = ...) -> bytes: ...

--- a/tests/mypy_examples.py
+++ b/tests/mypy_examples.py
@@ -1,5 +1,6 @@
 # fmt: off
-from typing import List
+import pickle
+from typing import List, Any
 import msgspec
 
 
@@ -63,3 +64,17 @@ def check_encode_default() -> None:
 
 def check_Encoder_default() -> None:
     msgspec.Encoder(default=lambda x: None)
+
+
+def check_decode_ext_hook() -> None:
+    def ext_hook(code: int, data: memoryview) -> Any:
+        return pickle.loads(data)
+
+    msgspec.decode(b"test", ext_hook=ext_hook)
+    msgspec.Decoder(ext_hook=ext_hook)
+
+
+def check_Ext() -> None:
+    ext = msgspec.Ext(1, b"test")
+    reveal_type(ext.code)  # assert "int" in typ
+    reveal_type(ext.data)  # assert "bytes" in typ

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -706,8 +706,10 @@ class TestTypedDecoder:
             [1, 2],
             {3: 4},
             msgspec.Ext(1, b"12345"),
+            msgspec.Ext(1, b""),
         ],
     )
+    @pytest.mark.skipif(True, reason="Skipping for now to remote debug")
     def test_struct_ignore_extra_fields(self, extra):
         enc = msgspec.Encoder()
         dec = msgspec.Decoder(Person)

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -828,7 +828,7 @@ class TestTypedDecoder:
 
 
 class TestExt:
-    @pytest.mark.parametrize("data", [b"test", bytearray(b"test")])
+    @pytest.mark.parametrize("data", [b"test", bytearray(b"test"), memoryview(b"test")])
     def test_init(self, data):
         x = msgspec.Ext(1, data)
         assert x.code == 1
@@ -880,9 +880,11 @@ class TestExt:
         msgpack_bytes = msgpack.dumps(msgpack.ExtType(code, data))
         assert msgspec_bytes == msgpack_bytes
 
-    def test_serialize_bytearray(self):
-        a = msgspec.encode(msgspec.Ext(1, b"test"))
-        b = msgspec.encode(msgspec.Ext(1, bytearray(b"test")))
+    @pytest.mark.parametrize("typ", [bytearray, memoryview])
+    def test_serialize_other_types(self, typ):
+        buf = b"test"
+        a = msgspec.encode(msgspec.Ext(1, buf))
+        b = msgspec.encode(msgspec.Ext(1, typ(buf)))
         assert a == b
 
     @pytest.mark.parametrize("size", sorted({0, 1, 2, 4, 8, 16, *SIZES}))

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -843,6 +843,16 @@ class TestExtType:
         b = msgspec.encode(msgspec.ExtType(1, bytearray(b"test")))
         assert a == b
 
+    @pytest.mark.parametrize("size", sorted({0, 1, 2, 4, 8, 16, *SIZES}))
+    def test_roundtrip(self, size):
+        data = b"x" * size
+        code = 5
+
+        buf = msgspec.encode(msgspec.ExtType(code, data))
+        out = msgspec.decode(buf)
+        assert out.code == code
+        assert out.data == data
+
 
 class CommonTypeTestBase:
     """Test msgspec untyped encode/decode"""

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -709,7 +709,6 @@ class TestTypedDecoder:
             msgspec.Ext(1, b""),
         ],
     )
-    @pytest.mark.skipif(True, reason="Skipping for now to remote debug")
     def test_struct_ignore_extra_fields(self, extra):
         enc = msgspec.Encoder()
         dec = msgspec.Decoder(Person)

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -828,6 +828,21 @@ class TestExtType:
         assert x2.code == 1
         assert x2.data == b"two"
 
+    @pytest.mark.parametrize("size", sorted({0, 1, 2, 4, 8, 16, *SIZES}))
+    def test_serialize_compatibility(self, size):
+        msgpack = pytest.importorskip("msgpack")
+        data = b"x" * size
+        code = 5
+
+        msgspec_bytes = msgspec.encode(msgspec.ExtType(code, data))
+        msgpack_bytes = msgpack.dumps(msgpack.ExtType(code, data))
+        assert msgspec_bytes == msgpack_bytes
+
+    def test_serialize_bytearray(self):
+        a = msgspec.encode(msgspec.ExtType(1, b"test"))
+        b = msgspec.encode(msgspec.ExtType(1, bytearray(b"test")))
+        assert a == b
+
 
 class CommonTypeTestBase:
     """Test msgspec untyped encode/decode"""

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -677,7 +677,19 @@ class TestTypedDecoder:
             dec.decode(bad)
 
     @pytest.mark.parametrize(
-        "extra", [None, False, True, 1, 2.0, "three", b"four", [1, 2], {3: 4}]
+        "extra",
+        [
+            None,
+            False,
+            True,
+            1,
+            2.0,
+            "three",
+            b"four",
+            [1, 2],
+            {3: 4},
+            msgspec.ExtType(1, b"12345"),
+        ],
     )
     def test_struct_ignore_extra_fields(self, extra):
         enc = msgspec.Encoder()

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -853,6 +853,23 @@ class TestExtType:
         assert out.code == code
         assert out.data == data
 
+    @pytest.mark.parametrize("size", sorted({0, 1, 2, 4, 8, 16, *SIZES}))
+    def test_roundtrip_typed_decoder(self, size):
+        dec = msgspec.Decoder(msgspec.ExtType)
+
+        data = b"x" * size
+        code = 5
+        buf = msgspec.encode(msgspec.ExtType(code, data))
+        out = dec.decode(buf)
+        assert isinstance(out, msgspec.ExtType)
+        assert out.code == code
+        assert out.data == data
+
+    def test_ext_typed_decoder_error(self):
+        dec = msgspec.Decoder(msgspec.ExtType)
+        with pytest.raises(msgspec.DecodingError, match="expected `ExtType`"):
+            assert dec.decode(msgspec.encode(1))
+
 
 class CommonTypeTestBase:
     """Test msgspec untyped encode/decode"""

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -12,7 +12,7 @@ def get_lineno_type(line):
     assert "revealed type" in line.lower()
     _, lineno, msg = line.split(":", 2)
     lineno = int(lineno)
-    pat = re.search("'(.*)'", msg)
+    pat = re.search("[\"'](.*)[\"']", msg)
     typ = pat.groups()[0]
     return lineno, typ
 


### PR DESCRIPTION
This adds support for both encoding and decoding [msgpack extension types](https://github.com/msgpack/msgpack/blob/master/spec.md#ext-format-family). This comes with 2 additional apis:

- A new `msgspec.Ext` type, representing the tuple of `(code: int, data: bytes_like)` that describes a msgpack extension.
- A new `ext_hook` parameter to `msgspec.Decoder`/`msgspec.decode`.

By default msgspec will deserialize all extension objects into `msgspec.Ext` objects. However, if a user specifies a `ext_hook` to `msgspec.Decoder`/`msgspec.decode`, this callback will be used instead to deserialize the extension type. Together with the existing `default` hook in `msgspec.Encoder`/`msgspec.encode`, this lets users fully add extra types to be serialized/deserialized.

For example, say we wanted to define a new extension type with code `42` that contains a buffer of data serialized via `pickle`. If we wanted to apply this to all non-builtin types serialized by msgspec, we could do this as follows:

```python
import msgspec
import pickle
from typing import Any

def default(obj: Any) -> Any:
    """Serialize the object using pickle, and mark it as an extension type with code 42"""
    return msgspec.Ext(42, pickle.dumps(obj))

def ext_hook(code: int, data: memoryview) -> Any:
    if code == 42:
        return pickle.loads(data)
    raise TypeError(f"Unknown extension type with code {code}")

enc = msgspec.Encoder(default=default)
dec = msgspec.Decoder(ext_hook=ext_hook)

buf = enc.encode(range)  # functions normally aren't serializable with msgspec
out = dec.decode(buf)
assert out == range
```

Note that `ext_hook` has the signature `ext_hook(code: int, data: memoryview) -> Any`. Here `data` is a memoryview into larger message buffer. This lets us avoid an extra copy when forwarding the data buffer to `ext_hook`, but it means that if the returned object holds on to a reference to that buffer (instead of doing a copy itself) then the larger message will persist in memory until that object is freed. For most use cases of `ext_hook` I wouldn't expect this issue to come up, but it's worth noting. The performance improvement from avoiding the copy is worth it to add a tiny rare footgun IMO.

Fixes #26.

Still a few todos:

- [x] Make `Ext` accept a `memoryview` for `data`, rather than just `bytes` or `bytearray`
- [x] Add docs