### PR TITLE
Add `dec_hook` to `Decoder`/`decode`

### DIFF
--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -3472,7 +3472,7 @@ mp_decode_type_custom(DecoderState *self, bool generic, TypeNodeObj* type, TypeN
     else {
         out = obj;
     }
-    
+
     /* Generic classes must be checked based on __origin__ */
     if (generic) {
         MsgspecState *st = msgspec_get_global_state();

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -112,7 +112,7 @@ msgspec_get_state(PyObject *module)
 /* Find the module instance imported in the currently running sub-interpreter
    and get its state. */
 static MsgspecState *
-msgspec_get_global_state()
+msgspec_get_global_state(void)
 {
     return msgspec_get_state(PyState_FindModule(&msgspecmodule));
 }
@@ -602,10 +602,13 @@ to_type_node(PyObject * obj, bool optional) {
     /* Attempt to extract __origin__/__args__ from the obj as a typing object */
     if ((origin = PyObject_GetAttr(obj, st->str___origin__)) == NULL ||
             (args = PyObject_GetAttr(obj, st->str___args__)) == NULL) {
-        /* Not a parametrized type, must be a custom type */
+        /* Not a parametrized generic, must be a custom type */
         PyErr_Clear();
         if (PyType_Check(obj)) {
             out = TypeNodeObj_New(TYPE_CUSTOM, optional, obj);
+        }
+        else if (origin != NULL) {
+            out = TypeNodeObj_New(TYPE_CUSTOM_GENERIC, optional, obj);
         }
         goto done;
     }
@@ -2730,7 +2733,7 @@ Decoder_repr(Decoder *self) {
 }
 
 static Py_ssize_t
-mp_err_truncated()
+mp_err_truncated(void)
 {
     PyErr_SetString(msgspec_get_global_state()->DecodingError, "input data was truncated");
     return -1;

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -2628,10 +2628,10 @@ PyDoc_STRVAR(Decoder__doc__,
 "    the default MessagePack types.\n"
 "dec_hook : Callable, optional\n"
 "    An optional callback for handling decoding custom types. Should have the\n"
-"    signature ``dec_hook(obj: Any, type: Type) -> Any``, where ``obj`` is the\n"
-"    decoded object decoded using basic MessagePack types, and ``type`` is the\n"
-"    expected message type. This hook should transform ``obj`` into type\n"
-"    ``type``, or raise a ``TypeError`` if unsupported.\n"
+"    signature ``dec_hook(type: Type, obj: Any) -> Any``, where ``type`` is the\n"
+"    expected message type, and ``obj`` is the decoded representation composed\n"
+"    of only basic MessagePack types. This hook should transform ``obj`` into\n"
+"    type ``type``, or raise a ``TypeError`` if unsupported.\n"
 "ext_hook : Callable, optional\n"
 "    An optional callback for decoding MessagePack extensions. Should have the\n"
 "    signature ``ext_hook(code: int, data: memoryview) -> Any``. If provided,\n"
@@ -3464,7 +3464,7 @@ mp_decode_type_custom(DecoderState *self, bool generic, TypeNodeObj* type, TypeN
         return NULL;
 
     if (self->dec_hook != NULL) {
-        out = PyObject_CallFunctionObjArgs(self->dec_hook, obj, type->arg, NULL);
+        out = PyObject_CallFunctionObjArgs(self->dec_hook, type->arg, obj, NULL);
         Py_DECREF(obj);
         if (out == NULL)
             return NULL;
@@ -4033,10 +4033,10 @@ PyDoc_STRVAR(msgspec_decode__doc__,
 "    the default MessagePack types.\n"
 "dec_hook : Callable, optional\n"
 "    An optional callback for handling decoding custom types. Should have the\n"
-"    signature ``dec_hook(obj: Any, type: Type) -> Any``, where ``obj`` is the\n"
-"    decoded object decoded using basic MessagePack types, and ``type`` is the\n"
-"    expected message type. This hook should transform ``obj`` into type\n"
-"    ``type``, or raise a ``TypeError`` if unsupported.\n"
+"    signature ``dec_hook(type: Type, obj: Any) -> Any``, where ``type`` is the\n"
+"    expected message type, and ``obj`` is the decoded representation composed\n"
+"    of only basic MessagePack types. This hook should transform ``obj`` into\n"
+"    type ``type``, or raise a ``TypeError`` if unsupported.\n"
 "ext_hook : Callable, optional\n"
 "    An optional callback for decoding MessagePack extensions. Should have the\n"
 "    signature ``ext_hook(code: int, data: memoryview) -> Any``. If provided,\n"

--- a/msgspec/core.pyi
+++ b/msgspec/core.pyi
@@ -2,6 +2,10 @@ from typing import Any, Type, TypeVar, Generic, Optional, Callable, Union, overl
 
 T = TypeVar("T")
 
+enc_hook_sig = Optional[Callable[[Any], Any]]
+ext_hook_sig = Optional[Callable[[int, memoryview], Any]]
+dec_hook_sig = Optional[Callable[[Type, Any], Any]]
+
 class Ext:
     code: int
     data: Union[bytes, bytearray, memoryview]
@@ -12,31 +16,36 @@ class Ext:
 class Decoder(Generic[T]):
     @overload
     def __init__(
-        self: Decoder[Any], ext_hook: Optional[Callable[[int, memoryview], Any]] = None
+        self: Decoder[Any],
+        dec_hook: dec_hook_sig = None,
+        ext_hook: ext_hook_sig = None,
     ) -> None: ...
     @overload
     def __init__(
         self: Decoder[T],
         type: Type[T] = ...,
-        ext_hook: Optional[Callable[[int, memoryview], Any]] = None,
+        dec_hook: dec_hook_sig = None,
+        ext_hook: ext_hook_sig = None,
     ) -> None: ...
     def decode(self, data: bytes) -> T: ...
 
 class Encoder:
     def __init__(
-        self, *, enc_hook: Callable[[Any], Any] = ..., write_buffer_size: int = ...
+        self,
+        *,
+        enc_hook: enc_hook_sig = None,
+        write_buffer_size: int = ...,
     ): ...
     def encode(self, obj: Any) -> bytes: ...
 
 @overload
-def decode(
-    buf: bytes, ext_hook: Optional[Callable[[int, memoryview], Any]] = None
-) -> Any: ...
+def decode(buf: bytes, ext_hook: ext_hook_sig = None) -> Any: ...
 @overload
 def decode(
     buf: bytes,
     *,
     type: Type[T] = ...,
-    ext_hook: Optional[Callable[[int, memoryview], Any]] = None
+    dec_hook: dec_hook_sig = None,
+    ext_hook: ext_hook_sig = None,
 ) -> T: ...
-def encode(obj: Any, *, enc_hook: Callable[[Any], Any] = ...) -> bytes: ...
+def encode(obj: Any, *, enc_hook: enc_hook_sig = None) -> bytes: ...

--- a/tests/mypy_examples.py
+++ b/tests/mypy_examples.py
@@ -1,6 +1,6 @@
 # fmt: off
 import pickle
-from typing import List, Any
+from typing import List, Any, Type
 import msgspec
 
 
@@ -64,6 +64,14 @@ def check_encode_enc_hook() -> None:
 
 def check_Encoder_enc_hook() -> None:
     msgspec.Encoder(enc_hook=lambda x: None)
+
+
+def check_decode_dec_hook() -> None:
+    def dec_hook(typ: Type, obj: Any) -> Any:
+        return typ(obj)
+
+    msgspec.decode(b"test", dec_hook=dec_hook)
+    msgspec.Decoder(dec_hook=dec_hook)
 
 
 def check_decode_ext_hook() -> None:

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Set, List, Tuple, Optional, Any
+from typing import Dict, Set, List, Tuple, Optional, Any, Union
 import enum
 import gc
 import math
@@ -139,7 +139,7 @@ class TestEncodeFunction:
         with pytest.raises(TypeError, match="Extra positional arguments"):
             msgspec.encode(1, 2, 3)
 
-        with pytest.raises(TypeError, match="Invalid keyword argument 'bad'"):
+        with pytest.raises(TypeError, match="Extra keyword arguments"):
             msgspec.encode(1, bad=1)
 
         with pytest.raises(TypeError, match="Extra keyword arguments"):
@@ -362,13 +362,13 @@ class TestDecoderMisc:
             msgspec.Decoder(1)
 
         with pytest.raises(TypeError):
-            msgspec.Decoder(slice)
+            msgspec.Decoder(Union[int, float])
 
     def test_decoder_validates_struct_definition_unsupported_types(self):
         """Struct definitions aren't validated until first use"""
 
         class Test(msgspec.Struct):
-            a: slice
+            a: 1
 
         with pytest.raises(TypeError):
             msgspec.Decoder(Test)

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections import OrderedDict
-from typing import Dict, Set, List, Tuple, Optional, Any, Union, NamedTuple
+from typing import Dict, Set, List, Tuple, Optional, Any, Union, NamedTuple, Deque
 import enum
 import gc
 import math
@@ -403,15 +402,15 @@ class TestDecoderMisc:
         ) == str(rec.value)
 
     def test_decode_dec_hook_wrong_type_generic(self):
-        dec = msgspec.Decoder(type=OrderedDict[str, int], dec_hook=lambda t, o: o)
-        buf = msgspec.encode({"a": 1, "b": 2})
+        dec = msgspec.Decoder(type=Deque[int], dec_hook=lambda t, o: o)
+        buf = msgspec.encode([1, 2, 3])
 
         with pytest.raises(msgspec.DecodingError) as rec:
             dec.decode(buf)
 
         assert (
-            "Error decoding `collections.OrderedDict[str, int]`: expected "
-            "`collections.OrderedDict`, got `dict`"
+            "Error decoding `typing.Deque[int]`: expected "
+            "`collections.deque`, got `list`"
         ) == str(rec.value)
 
     def test_decode_dec_hook_isinstance_errors(self):
@@ -458,24 +457,12 @@ class TestDecoderMisc:
             (Person, "Person"),
             (FruitInt, "FruitInt"),
             (FruitStr, "FruitStr"),
-            (OrderedDict, "collections.OrderedDict"),
+            (Deque, "typing.Deque"),
+            (Deque[int], str(Deque[int])),
             (List[Optional[Dict[str, Person]]], "List[Optional[Dict[str, Person]]]"),
         ],
     )
     def test_decoder_repr(self, typ, typstr):
-        dec = msgspec.Decoder(typ)
-        assert repr(dec) == f"Decoder({typstr})"
-
-        dec = msgspec.Decoder(Optional[typ])
-        assert repr(dec) == f"Decoder(Optional[{typstr}])"
-
-    def test_decoder_repr_custom_generic(self):
-        try:
-            typ = OrderedDict[str, int]
-        except Exception:
-            pytest.skip(reason="OrderedDict isn't a generic type in this version")
-
-        typstr = str(typ)
         dec = msgspec.Decoder(typ)
         assert repr(dec) == f"Decoder({typstr})"
 

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -459,11 +459,23 @@ class TestDecoderMisc:
             (FruitInt, "FruitInt"),
             (FruitStr, "FruitStr"),
             (OrderedDict, "collections.OrderedDict"),
-            (OrderedDict[str, int], str(OrderedDict[str, int])),
             (List[Optional[Dict[str, Person]]], "List[Optional[Dict[str, Person]]]"),
         ],
     )
     def test_decoder_repr(self, typ, typstr):
+        dec = msgspec.Decoder(typ)
+        assert repr(dec) == f"Decoder({typstr})"
+
+        dec = msgspec.Decoder(Optional[typ])
+        assert repr(dec) == f"Decoder(Optional[{typstr}])"
+
+    def test_decoder_repr_custom_generic(self):
+        try:
+            typ = OrderedDict[str, int]
+        except Exception:
+            pytest.skip(reason="OrderedDict isn't a generic type in this version")
+
+        typstr = str(typ)
         dec = msgspec.Decoder(typ)
         assert repr(dec) == f"Decoder({typstr})"
 


### PR DESCRIPTION
Adds a new `dec_hook` callback supporting type conversions between
builtin msgpack types and arbitrary python types. This hook should have
the following signature:

```python
def dec_hook(obj: Any, type: Type) -> Any:
    ...
```

This receives an object composed of builtin msgpack types (e.g. dict,
list, int, ...) and the expected decode type (as described by the
decoder's type parameter). It should attempt to convert the value to the
provided type, or raise a type error appropriately. When combined with
`enc_hook` on the encoder, this lets users serialize arbitrary custom
objects without resorting to extension types.

For example, to serialize/deserialize a `NamedTuple` you might write
the following:

```python
import msgspec
from typing import NamedTuple

class Point(NamedTuple):
    x: int
    y: int

def enc_hook(obj):
    if isinstance(obj, tuple):
        # convert the named tuple to a supported type
        # in this case it's a tuple like `(1, 2)`
        return tuple(obj)
    raise TypeError(f"Type {type(obj).__name__} is not supported")

def dec_hook(obj, type):
    if issubclass(type, tuple):
        # convert the builtin type (e.g. `[1, 2]`) to
        # the custom type (`Point(x=1, y=2)`)
        return type(*obj)
    raise TypeError(f"Type {type.__name__} is not supported")

enc = msgspec.Encoder(enc_hook=enc_hook)
dec = msgspec.Decoder(Point, dec_hook=dec_hook)

msg = enc.encode(Point(1, 2))
x = dec.decode(msg)
print(x)  # Point(x=1, y=2)
```

There's still a few TODO items, but this is mostly functional already
- [x] Tests
~- [ ] Docs~
- [x] Better support `GenericAlias` objects for custom types