### PR TITLE
A few fixups

### DIFF
--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -1260,7 +1260,7 @@ Struct_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyObj
             PyExc_TypeError,
             "Extra positional arguments provided"
         );
-        return NULL;
+        goto error;
     }
 
     should_untrack = PyObject_IS_GC(self);
@@ -1275,7 +1275,7 @@ Struct_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyObj
                     "Argument '%U' given by name and position",
                     field
                 );
-                return NULL;
+                goto error;
             }
             Py_INCREF(val);
             nkwargs -= 1;
@@ -1290,12 +1290,12 @@ Struct_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyObj
                 "Missing required argument '%U'",
                 field
             );
-            return NULL;
+            goto error;
         }
         else {
             val = maybe_deepcopy_default(PyTuple_GET_ITEM(defaults, i - npos));
             if (val == NULL)
-                return NULL;
+                goto error;
         }
         Struct_set_index(self, i, val);
         if (should_untrack) {
@@ -1307,11 +1307,15 @@ Struct_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyObj
             PyExc_TypeError,
             "Extra keyword arguments provided"
         );
-        return NULL;
+        goto error;
     }
     if (should_untrack)
         PyObject_GC_UnTrack(self);
     return self;
+
+error:
+    Py_DECREF(self);
+    return NULL;
 }
 
 static int

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -2572,20 +2572,6 @@ Encoder_encode(Encoder *self, PyObject *const *args, Py_ssize_t nargs)
     return res;
 }
 
-static PyObject *
-Encoder_default(PyObject *self, void *closure) {
-    PyObject *out = ((Encoder*)self)->state.enc_hook;
-    if (out == NULL)
-        out = Py_None;
-    Py_INCREF(out);
-    return out;
-}
-
-static PyGetSetDef Encoder_getset[] = {
-    {"enc_hook", (getter) Encoder_default, NULL, "`enc_hook` callback", NULL},
-    {NULL},
-};
-
 static struct PyMethodDef Encoder_methods[] = {
     {
         "encode", (PyCFunction) Encoder_encode, METH_FASTCALL,
@@ -2602,6 +2588,13 @@ static struct PyMethodDef Encoder_methods[] = {
     {NULL, NULL}                /* sentinel */
 };
 
+static PyMemberDef Encoder_members[] = {
+    {"enc_hook", T_OBJECT, offsetof(Encoder, state.enc_hook), READONLY, "The Encoder enc_hook"},
+    {"write_buffer_size", T_PYSSIZET, offsetof(Encoder, state.write_buffer_size),
+        READONLY, "The Encoder write buffer size"},
+    {NULL},
+};
+
 static PyTypeObject Encoder_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "msgspec.core.Encoder",
@@ -2614,7 +2607,7 @@ static PyTypeObject Encoder_Type = {
     .tp_new = PyType_GenericNew,
     .tp_init = (initproc)Encoder_init,
     .tp_methods = Encoder_methods,
-    .tp_getset = Encoder_getset,
+    .tp_members = Encoder_members,
 };
 
 PyDoc_STRVAR(msgspec_encode__doc__,

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -244,6 +244,14 @@ class TestEncoderMisc:
         b = sys.getsizeof(msgspec.Encoder(write_buffer_size=128))
         assert b > a
 
+    def test_write_buffer_size_attribute(self):
+        enc1 = msgspec.Encoder(write_buffer_size=64)
+        enc2 = msgspec.Encoder(write_buffer_size=128)
+        enc3 = msgspec.Encoder(write_buffer_size=1)
+        assert enc1.write_buffer_size == 64
+        assert enc2.write_buffer_size == 128
+        assert enc3.write_buffer_size == 32
+
     def test_encode_no_enc_hook(self):
         class Foo:
             pass
@@ -396,7 +404,7 @@ class TestDecoderMisc:
         with pytest.raises(TypeError):
             msgspec.Decoder(ext_hook=1)
 
-    def test_decoder_enc_hook_attribute(self):
+    def test_decoder_dec_hook_attribute(self):
         def dec_hook(typ, obj):
             pass
 


### PR DESCRIPTION
- Fixes a memory leak in `Struct` constructors if an error occurred
- Some hygiene around attribute access on Encoder objects