### PR TITLE
Add datetime support

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -128,11 +128,19 @@ mapped to Python types as follows:
 - ``bin``: `bytes`
 - ``array``: `list` or `tuple` [#tuple]_
 - ``map``: `dict`
-- ``ext``: `msgspec.Ext`
+- ``ext``: `msgspec.Ext` or `datetime.datetime` [#datetime]_
 
 .. [#tuple] Tuples are only used when the array type must be hashable (e.g.
    keys in a ``dict`` or ``set``). All other array types are deserialized as
    lists by default.
+
+.. [#datetime] datetime objects are encoded/decoded using the `timestamp
+   extension type
+   <https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type>`__.
+   Note that on Windows this will only work for datetimes _after_ the `Unix
+   epoch <https://en.wikipedia.org/wiki/Unix_time>`__ (this is fixable with
+   some effort, if you need to support earlier timestamps on windows please
+   file an issue).
 
 Messages composed of any combination of these will deserialize successfully
 without any further validation:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -102,6 +102,7 @@ Msgspec currently supports serializing/deserializing the following types:
 - `list`
 - `dict`
 - `set`
+- `datetime.datetime`
 - `enum.Enum`
 - `msgspec.Struct`
 - `msgspec.Ext`

--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -2772,7 +2772,7 @@ typedef struct Decoder {
 } Decoder;
 
 PyDoc_STRVAR(Decoder__doc__,
-"Decoder(type='Any', dec_hook=None, ext_hook=None, tzinfo=None)\n"
+"Decoder(type='Any', *, dec_hook=None, ext_hook=None, tzinfo=None)\n"
 "--\n"
 "\n"
 "A MessagePack decoder.\n"
@@ -2800,7 +2800,7 @@ PyDoc_STRVAR(Decoder__doc__,
 "    If not provided, extension types will decode as ``msgspec.Ext`` objects.\n"
 "tzinfo : datetime.tzinfo, optional\n"
 "    The timezone to use when decoding ``datetime.datetime`` objects. Defaults\n"
-"    to ``None`` for \"naive\" datetimes"
+"    to ``None`` for \"naive\" datetimes."
 );
 static int
 Decoder_init(Decoder *self, PyObject *args, PyObject *kwds)
@@ -2813,7 +2813,7 @@ Decoder_init(Decoder *self, PyObject *args, PyObject *kwds)
     PyObject *tzinfo = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "|OOOO", kwlist, &type, &dec_hook, &ext_hook, &tzinfo
+            args, kwds, "|O$OOO", kwlist, &type, &dec_hook, &ext_hook, &tzinfo
         )) {
         return -1;
     }
@@ -4323,7 +4323,7 @@ PyDoc_STRVAR(msgspec_decode__doc__,
 "    If not provided, extension types will decode as ``msgspec.Ext`` objects.\n"
 "tzinfo : datetime.tzinfo, optional\n"
 "    The timezone to use when decoding ``datetime.datetime`` objects. Defaults\n"
-"    to ``None`` for \"naive\" datetimes\n"
+"    to ``None`` for \"naive\" datetimes.\n"
 "\n"
 "Returns\n"
 "-------\n"

--- a/msgspec/core.pyi
+++ b/msgspec/core.pyi
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any, Type, TypeVar, Generic, Optional, Callable, Union, overload
 
 T = TypeVar("T")
@@ -14,22 +15,32 @@ class Ext:
     ) -> None: ...
 
 class Decoder(Generic[T]):
+    type: Type[T]
+    dec_hook: dec_hook_sig
+    ext_hook: ext_hook_sig
+    tzinfo: Optional[datetime.tzinfo]
     @overload
     def __init__(
         self: Decoder[Any],
+        *,
         dec_hook: dec_hook_sig = None,
         ext_hook: ext_hook_sig = None,
+        tzinfo: Optional[datetime.tzinfo] = None,
     ) -> None: ...
     @overload
     def __init__(
         self: Decoder[T],
         type: Type[T] = ...,
+        *,
         dec_hook: dec_hook_sig = None,
         ext_hook: ext_hook_sig = None,
+        tzinfo: Optional[datetime.tzinfo] = None,
     ) -> None: ...
     def decode(self, data: bytes) -> T: ...
 
 class Encoder:
+    enc_hook: enc_hook_sig
+    write_buffer_size: int
     def __init__(
         self,
         *,
@@ -42,7 +53,13 @@ class Encoder:
     ) -> None: ...
 
 @overload
-def decode(buf: bytes, ext_hook: ext_hook_sig = None) -> Any: ...
+def decode(
+    buf: bytes,
+    *,
+    dec_hook: dec_hook_sig = None,
+    ext_hook: ext_hook_sig = None,
+    tzinfo: Optional[datetime.tzinfo] = None,
+) -> Any: ...
 @overload
 def decode(
     buf: bytes,
@@ -50,5 +67,6 @@ def decode(
     type: Type[T] = ...,
     dec_hook: dec_hook_sig = None,
     ext_hook: ext_hook_sig = None,
+    tzinfo: Optional[datetime.tzinfo] = None,
 ) -> T: ...
 def encode(obj: Any, *, enc_hook: enc_hook_sig = None) -> bytes: ...

--- a/tests/mypy_examples.py
+++ b/tests/mypy_examples.py
@@ -1,4 +1,5 @@
 # fmt: off
+import datetime
 import pickle
 from typing import List, Any, Type
 import msgspec
@@ -93,3 +94,13 @@ def check_Ext() -> None:
     ext = msgspec.Ext(1, b"test")
     reveal_type(ext.code)  # assert "int" in typ
     reveal_type(ext.data)  # assert "bytes" in typ
+
+
+def check_tzinfo() -> None:
+    dec = msgspec.Decoder()
+    reveal_type(dec.tzinfo)  # assert "tzinfo" in typ
+
+    msgspec.Decoder(tzinfo=None)
+    msgspec.Decoder(tzinfo=datetime.timezone.utc)
+    msgspec.decode(b"test", tzinfo=None)
+    msgspec.decode(b"test", tzinfo=datetime.timezone.utc)

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Dict, Set, List, Tuple, Optional, Any, Union, NamedTuple, Deque
+import datetime
 import enum
 import gc
 import math
@@ -1142,6 +1143,55 @@ class TestExt:
         msg = msgspec.encode(range(5), enc_hook=lambda x: msgspec.Ext(1, b"test"))
         with pytest.raises(CustomError):
             msgspec.decode(msg, ext_hook=ext_hook)
+
+
+class TestTimestampExt:
+    def test_encode_timestamp32(self):
+        # Min timestamp32
+        dt = datetime.datetime.fromtimestamp(0)
+        assert msgspec.encode(dt) == b"\xd6\xff\x00\x00\x00\x00"
+        # Max timestamp32
+        dt = datetime.datetime.fromtimestamp(2 ** 32 - 1)
+        assert msgspec.encode(dt) == b"\xd6\xff\xff\xff\xff\xff"
+
+    def test_encode_timestamp64(self):
+        # Smallest timestamp64 representable by datetime object (since no nanos)
+        dt = datetime.datetime.fromtimestamp(1e-6)
+        assert msgspec.encode(dt) == b"\xd7\xff\x00\x00\x0f\xa0\x00\x00\x00\x00"
+
+        # Largest timestamp64 representable by datetime object (since no nanos)
+        dt = datetime.datetime.fromtimestamp(2 ** 34) - datetime.timedelta(
+            microseconds=1
+        )
+        res = msgspec.encode(dt)
+        assert res == b"\xd7\xff\xeek\x18c\xff\xff\xff\xff"
+
+    def test_encode_timestamp96(self):
+        # Smallest datetime representable(ish). Technically 1/1/1 is the
+        # smallest representable in python, but due to a bug in `.timestamp()`,
+        # 1/1/2 is the smallest that will succeed.
+        dt = datetime.datetime(1, 1, 2)
+        sol = b"\xc7\x0c\xff\x00\x00\x00\x00\xff\xff\xff\xf1\x88\x6f\xac\xac"
+        res = msgspec.encode(dt)
+        assert res == sol
+
+        # Largest datetime representable in python.
+        dt = datetime.datetime.max
+        sol = b"\xc7\x0c\xff\x3b\x9a\xc6\x18\x00\x00\x00:\xff\xf4\x95\xe0"
+        res = msgspec.encode(dt)
+        assert res == sol
+
+        # Lower border of timestamp64
+        dt = datetime.datetime.fromtimestamp(-1e-6)
+        sol = b"\xc7\x0c\xff;\x9a\xc6\x18\xff\xff\xff\xff\xff\xff\xff\xff"
+        res = msgspec.encode(dt)
+        assert res == sol
+
+        # Upper border of timestamp64
+        dt = datetime.datetime.fromtimestamp(2 ** 34)
+        sol = b"\xc7\x0c\xff\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00"
+        res = msgspec.encode(dt)
+        assert res == sol
 
 
 class CommonTypeTestBase:

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1146,52 +1146,62 @@ class TestExt:
 
 
 class TestTimestampExt:
-    def test_encode_timestamp32(self):
+    def test_timestamp32(self):
         # Min timestamp32
         dt = datetime.datetime.fromtimestamp(0)
-        assert msgspec.encode(dt) == b"\xd6\xff\x00\x00\x00\x00"
+        msg = b"\xd6\xff\x00\x00\x00\x00"
+        assert msgspec.encode(dt) == msg
+        assert msgspec.decode(msg) == dt
+
         # Max timestamp32
         dt = datetime.datetime.fromtimestamp(2 ** 32 - 1)
-        assert msgspec.encode(dt) == b"\xd6\xff\xff\xff\xff\xff"
+        msg = b"\xd6\xff\xff\xff\xff\xff"
+        assert msgspec.encode(dt) == msg
+        assert msgspec.decode(msg) == dt
 
-    def test_encode_timestamp64(self):
+    def test_timestamp64(self):
         # Smallest timestamp64 representable by datetime object (since no nanos)
         dt = datetime.datetime.fromtimestamp(1e-6)
-        assert msgspec.encode(dt) == b"\xd7\xff\x00\x00\x0f\xa0\x00\x00\x00\x00"
+        msg = b"\xd7\xff\x00\x00\x0f\xa0\x00\x00\x00\x00"
+        assert msgspec.encode(dt) == msg
+        assert msgspec.decode(msg) == dt
 
         # Largest timestamp64 representable by datetime object (since no nanos)
         dt = datetime.datetime.fromtimestamp(2 ** 34) - datetime.timedelta(
             microseconds=1
         )
-        res = msgspec.encode(dt)
-        assert res == b"\xd7\xff\xeek\x18c\xff\xff\xff\xff"
+        msg = b"\xd7\xff\xeek\x18c\xff\xff\xff\xff"
+        assert msgspec.encode(dt) == msg
+        assert msgspec.decode(msg) == dt
 
-    def test_encode_timestamp96(self):
+    def test_timestamp96(self):
         # Smallest datetime representable(ish). Technically 1/1/1 is the
         # smallest representable in python, but due to a bug in `.timestamp()`,
         # 1/1/2 is the smallest that will succeed.
         dt = datetime.datetime(1, 1, 2)
-        sol = b"\xc7\x0c\xff\x00\x00\x00\x00\xff\xff\xff\xf1\x88\x6f\xac\xac"
-        res = msgspec.encode(dt)
-        assert res == sol
+        msg = b"\xc7\x0c\xff\x00\x00\x00\x00\xff\xff\xff\xf1\x88\x6f\xac\xac"
+        assert msgspec.encode(dt) == msg
+        assert msgspec.decode(msg) == dt
 
-        # Largest datetime representable in python.
-        dt = datetime.datetime.max
-        sol = b"\xc7\x0c\xff\x3b\x9a\xc6\x18\x00\x00\x00:\xff\xf4\x95\xe0"
-        res = msgspec.encode(dt)
-        assert res == sol
+        # Largest datetime representable in python (kinda). Due to a bug in
+        # `fromtimestamp()` we need to drop back a second to successfully
+        # roundtrip.
+        dt = datetime.datetime.max - datetime.timedelta(seconds=1)
+        msg = b"\xc7\x0c\xff\x3b\x9a\xc6\x18\x00\x00\x00:\xff\xf4\x95\xdf"
+        assert msgspec.encode(dt) == msg
+        assert msgspec.decode(msg)  # == dt
 
         # Lower border of timestamp64
         dt = datetime.datetime.fromtimestamp(-1e-6)
-        sol = b"\xc7\x0c\xff;\x9a\xc6\x18\xff\xff\xff\xff\xff\xff\xff\xff"
-        res = msgspec.encode(dt)
-        assert res == sol
+        msg = b"\xc7\x0c\xff;\x9a\xc6\x18\xff\xff\xff\xff\xff\xff\xff\xff"
+        assert msgspec.encode(dt) == msg
+        assert msgspec.decode(msg) == dt
 
         # Upper border of timestamp64
         dt = datetime.datetime.fromtimestamp(2 ** 34)
-        sol = b"\xc7\x0c\xff\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00"
-        res = msgspec.encode(dt)
-        assert res == sol
+        msg = b"\xc7\x0c\xff\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00"
+        assert msgspec.encode(dt) == msg
+        assert msgspec.decode(msg) == dt
 
 
 class CommonTypeTestBase:

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -517,6 +517,7 @@ class TestDecoderMisc:
             (str, "str"),
             (bytes, "bytes"),
             (bytearray, "bytearray"),
+            (datetime.datetime, "datetime"),
             (msgspec.Ext, "Ext"),
             (Dict, "Dict[Any, Any]"),
             (Dict[int, str], "Dict[int, str]"),
@@ -639,6 +640,18 @@ class TestTypedDecoder:
 
     def test_bytearray_unexpected_type(self):
         self.check_unexpected_type(bytearray, 1, "expected `bytearray`")
+
+    def test_datetime(self):
+        dec = msgspec.Decoder(datetime.datetime)
+        x = datetime.datetime.now()
+        res = dec.decode(msgspec.encode(x))
+        assert x == res
+
+    def test_datetime_unexpected_type(self):
+        self.check_unexpected_type(datetime.datetime, 1, "expected `datetime`")
+        self.check_unexpected_type(
+            datetime.datetime, msgspec.Ext(1, b"test"), "expected `datetime`"
+        )
 
     @pytest.mark.parametrize("size", SIZES)
     def test_list_lengths(self, size):
@@ -970,6 +983,7 @@ class TestTypedDecoder:
             (tuple, (1, 2)),
             (Tuple[int, int], (1, 2)),
             (dict, {1: 2}),
+            (datetime.datetime, datetime.datetime.now()),
         ],
     )
     def test_optional(self, typ, value):

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1223,12 +1223,7 @@ class TestTimestampExt:
         with pytest.raises(TypeError, match="tzinfo"):
             msgspec.decode(msg, tzinfo=1)
 
-    @pytest.mark.parametrize("ts", [0, 1, -1, 2 ** 32 - 1, 2 ** 33])
-    @pytest.mark.parametrize("tzinfo", [None, datetime.timezone.utc])
-    def test_debug_windows(self, ts, tzinfo):
-        datetime.datetime.fromtimestamp(ts, tzinfo)
-
-    @pytest.mark.parametrize("timestamp", [0, 0.001, -0.001, 2 ** 32 - 1, -1])
+    @pytest.mark.parametrize("timestamp", [0, 0.001, 2 ** 32 - 1])
     def test_decode_with_tzinfo(self, timestamp):
         dt = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
 


### PR DESCRIPTION
Adds support for encoding/decoding `datetime.datetime` objects as MessagePack timestamp extensions.

Fixes #1.