### PR TITLE
Optimize buffer usage in `encode`/`encode_into`

### DIFF
--- a/msgspec/core.c
+++ b/msgspec/core.c
@@ -1875,9 +1875,7 @@ mp_resize(EncoderState *self, Py_ssize_t size)
 {
         int status;
         bool is_bytes = PyBytes_CheckExact(self->output_buffer);
-        while (size > self->max_output_len) {
-            self->max_output_len *= 2;
-        }
+        self->max_output_len = Py_MAX(8, 1.5 * size);
         status = (
             is_bytes ? _PyBytes_Resize(&self->output_buffer, self->max_output_len)
                      : PyByteArray_Resize(self->output_buffer, self->max_output_len)
@@ -2561,12 +2559,6 @@ Encoder_encode_into(Encoder *self, PyObject *const *args, Py_ssize_t nargs)
         if (offset > buf_size) {
             offset = buf_size;
         }
-    }
-
-    /* Handle 0-length bytearrays here, so we can ignore 0 on the fast path */
-    if (buf_size == 0) {
-        if (PyByteArray_Resize(buf, 8) < 0) return NULL;
-        buf_size = 8;
     }
 
     /* Setup buffer */

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -242,9 +242,12 @@ class TestEncoderMisc:
             enc.encode(o)
 
     def test_getsizeof(self):
-        a = sys.getsizeof(msgspec.Encoder(write_buffer_size=64))
-        b = sys.getsizeof(msgspec.Encoder(write_buffer_size=128))
-        assert b > a
+        enc1 = msgspec.Encoder(write_buffer_size=64)
+        enc2 = msgspec.Encoder(write_buffer_size=128)
+        assert sys.getsizeof(enc1) == sys.getsizeof(enc2)  # no buffer allocated yet
+        enc1.encode(None)
+        enc2.encode(None)
+        assert sys.getsizeof(enc1) < sys.getsizeof(enc2)
 
     def test_write_buffer_size_attribute(self):
         enc1 = msgspec.Encoder(write_buffer_size=64)


### PR DESCRIPTION
This applies a few buffer-oriented optimizations to speedup encoding (by
up to a factor of ~2x).

- Move resizing of write buffer to a separate function, and inline
`mp_write`. This allows gcc to do a better job of optimizing small
memcpy operations with little code bloat.

- When returning a `bytes` object from `encode`, don't hit realloc to
shrink the buffer down to the exact output size. Instead, we just shrink
the view presented to Python. This requires a bit of mucking in the
internals of the bytes object, but nothing too onerous. Since the output
of `encode` will usually be immediately written to a socket/file and
then dropped, this shouldn't result in an increase in application memory
usage.