### PR TITLE
Support `Union` types

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -7,6 +7,7 @@ import gc
 import msgpack
 import msgspec
 import orjson
+import ormsgpack
 import pydantic
 import proto_bench
 
@@ -249,6 +250,24 @@ def bench_orjson(n, no_gc, validate=False):
     return bench(orjson.dumps, loads, n, no_gc=no_gc)
 
 
+def bench_ormsgpack(n, no_gc, validate=False):
+    if validate:
+        if n == 1:
+
+            def loads(b):
+                return PersonModel(**ormsgpack.unpackb(b))
+
+        else:
+
+            def loads(b):
+                return PeopleModel(items=ormsgpack.unpackb(b)).items
+
+    else:
+        loads = ormsgpack.unpackb
+
+    return bench(ormsgpack.packb, loads, n, no_gc=no_gc)
+
+
 def bench_pyrobuf(n, no_gc, validate=False):
     def convert_one(addresses=None, email=None, telephone=None, **kwargs):
         p = proto_bench.Person()
@@ -283,6 +302,7 @@ def bench_pyrobuf(n, no_gc, validate=False):
 BENCHMARKS = [
     ("orjson", bench_orjson),
     ("msgpack", bench_msgpack),
+    ("ormsgpack", bench_ormsgpack),
     ("msgspec", bench_msgspec),
     ("msgspec asarray", bench_msgspec_asarray),
     ("pyrobuf", bench_pyrobuf),

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -30,7 +30,8 @@ efficient to create an `Encoder` and `Decoder` once, and then use
 Supported Types
 ---------------
 
-Msgspec currently supports serializing/deserializing the following types:
+Msgspec currently supports serializing/deserializing the following concrete
+types:
 
 - `None`
 - `bool`
@@ -150,6 +151,7 @@ acceptible:
 - `datetime.datetime`
 - `typing.Any`
 - `typing.Optional`
+- `typing.Union`
 - `msgspec.Ext`
 - `enum.Enum` derived types
 - `enum.IntEnum` derived types

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -547,21 +547,21 @@ class TestDecoderMisc:
             (Deque, "typing.Deque"),
             (Deque[int], str(Deque[int])),
             (List[Optional[Dict[str, Person]]], "List[Optional[Dict[str, Person]]]"),
+            (Union[int, float], "Union[int, float]"),
+            (Union[Person, str, int], "Union[int, str, Person]"),
         ],
     )
     def test_decoder_repr(self, typ, typstr):
         dec = msgspec.Decoder(typ)
         assert repr(dec) == f"Decoder({typstr})"
 
-        dec = msgspec.Decoder(Optional[typ])
-        assert repr(dec) == f"Decoder(Optional[{typstr}])"
+        if "Union" not in typstr:
+            dec = msgspec.Decoder(Optional[typ])
+            assert repr(dec) == f"Decoder(Optional[{typstr}])"
 
     def test_decoder_unsupported_type(self):
         with pytest.raises(TypeError):
             msgspec.Decoder(1)
-
-        with pytest.raises(TypeError):
-            msgspec.Decoder(Union[int, float])
 
     def test_decoder_validates_struct_definition_unsupported_types(self):
         """Struct definitions aren't validated until first use"""

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1049,7 +1049,7 @@ class TestTypedDecoder:
 
         with pytest.raises(
             msgspec.DecodingError,
-            match="Error decoding `PersonAA`: expected `struct`, got `int`",
+            match="Error decoding `PersonAA`: expected `asarray struct`, got `int`",
         ):
             dec.decode(enc.encode(1))
 
@@ -1094,7 +1094,6 @@ class TestTypedDecoder:
         dec = msgspec.Decoder(Person)
         array_dec = msgspec.Decoder(PersonAA)
 
-        assert array_dec.decode(map_msg) == array_sol
         assert array_dec.decode(array_msg) == array_sol
         assert dec.decode(map_msg) == sol
         with pytest.raises(
@@ -1102,6 +1101,11 @@ class TestTypedDecoder:
             match="Error decoding `Person`: expected `struct`, got `list`",
         ):
             dec.decode(array_msg)
+        with pytest.raises(
+            msgspec.DecodingError,
+            match="Error decoding `PersonAA`: expected `asarray struct`, got `dict`",
+        ):
+            array_dec.decode(map_msg)
 
     @pytest.mark.parametrize("asarray", [False, True])
     def test_struct_gc_maybe_untracked_on_decode(self, asarray):


### PR DESCRIPTION
This adds support for `Union` types (with a few restrictions). Specifically only one of each of the following types may appear within a single union:
- Array-like collections (tuple, list, ...)
- Map-like collections (dict, Struct, ...)
- IntEnum or int
- Enum or str

This has a mild (negligible) performance degradation for typed decoders, and a slightly larger performance degradation for untyped decoding. I think this is fine, as most users should use the typed decoders anyway, since `Struct` types in general make things much faster.