### PR TITLE
Support serializing memoryview objects

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -40,6 +40,7 @@ types:
 - `str`
 - `bytes`
 - `bytearray`
+- `memoryview`
 - `tuple`
 - `list`
 - `dict`

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -406,6 +406,15 @@ class TestEncoderMisc:
         out2 = enc.encode([1, 2, 3])
         assert out1 == out2
 
+    @pytest.mark.parametrize("size", SIZES)
+    def test_encode_memoryview(self, size):
+        """We don't support memoryview as a decode type, just check we can
+        encode them fine"""
+        buf = bytearray(size)
+        msg = msgspec.encode(memoryview(buf))
+        res = msgspec.decode(msg)
+        assert buf == res
+
 
 class TestDecoderMisc:
     def test_decoder_type_attribute(self):


### PR DESCRIPTION
We support encoding memoryview objects as binary blobs, but don't support decoding into `memoryview` objects for typed decoders. We could add support pretty easily, but since:

- memoryviews are usually an optimization to avoid copying (and a copy is necessary on decode)
- mypy will accept passing a `memoryview` to a signature annotated `bytes` already, so encode-side annotations are fine.
 
I don't see decode support as being necessary now. For all uses decoding into a `bytes` or `bytearray` makes more sense IMO.

Fixes #52 (well, kind of. I don't think the original request there makes sense anymore).