### PR TITLE
Speedup decoding of IntEnums

### DIFF
--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,0 +1,146 @@
+import enum
+import gc
+import sys
+import weakref
+
+import pytest
+
+import msgspec
+
+
+class TestIntEnum:
+    def test_empty_errors(self):
+        class Empty(enum.IntEnum):
+            pass
+
+        with pytest.raises(TypeError, match="Enum types must have at least one item"):
+            msgspec.msgpack.Decoder(Empty)
+
+    def test_int_lookup_reused(self):
+        class Test(enum.IntEnum):
+            A = 1
+            B = 2
+
+        dec = msgspec.msgpack.Decoder(Test)  # noqa
+        count = sys.getrefcount(Test.__msgspec_lookup__)
+        dec2 = msgspec.msgpack.Decoder(Test)
+        count2 = sys.getrefcount(Test.__msgspec_lookup__)
+        assert count2 == count + 1
+
+        # Reference count decreases when decoder is dropped
+        del dec2
+        gc.collect()
+        count3 = sys.getrefcount(Test.__msgspec_lookup__)
+        assert count == count3
+
+    def test_int_lookup_gc(self):
+        class Test(enum.IntEnum):
+            A = 1
+            B = 2
+
+        dec = msgspec.msgpack.Decoder(Test)
+        assert gc.is_tracked(Test.__msgspec_lookup__)
+
+        # Deleting all references and running GC cleans up cycle
+        ref = weakref.ref(Test)
+        del Test
+        del dec
+        gc.collect()
+        assert ref() is None
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [0, 1, 2, 2 ** 64],
+            [0, 1, 2, -(2 ** 63) - 1],
+            [0, 1, 2, 2 ** 63 + 1, -(2 ** 64)],
+        ],
+    )
+    def test_int_lookup_values_out_of_range(self, values):
+        myenum = enum.IntEnum("myenum", [(f"x{i}", v) for i, v in enumerate(values)])
+
+        with pytest.raises(OverflowError):
+            msgspec.msgpack.Decoder(myenum)
+
+    def test_msgspec_lookup_overwritten(self):
+        class Test(enum.IntEnum):
+            A = 1
+
+        Test.__msgspec_lookup__ = 1
+
+        with pytest.raises(RuntimeError, match="__msgspec_lookup__"):
+            msgspec.msgpack.Decoder(Test)
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [0],
+            [1],
+            [-1],
+            [3, 4, 5, 2, 1],
+            [4, 3, 1, 2, 7],
+            [-4, -3, -2, -1, 0, 1, 2, 3, 4],
+            [-4, -3, -1, -2, -7],
+            [-4, -3, 1, 0, -2, -1],
+            [2 ** 63 - 1, 2 ** 63 - 2, 2 ** 63 - 3],
+            [-(2 ** 63) + 1, -(2 ** 63) + 2, -(2 ** 63) + 3],
+        ],
+    )
+    def test_compact(self, values):
+        myenum = enum.IntEnum("myenum", [(f"x{i}", v) for i, v in enumerate(values)])
+        dec = msgspec.msgpack.Decoder(myenum)
+
+        assert hasattr(myenum, "__msgspec_lookup__")
+
+        for val in myenum:
+            msg = msgspec.msgpack.encode(val)
+            val2 = dec.decode(msg)
+            assert val == val2
+
+        for bad in [-1000, min(values) - 1, max(values) + 1, 1000]:
+            with pytest.raises(msgspec.DecodeError):
+                dec.decode(msgspec.msgpack.encode(bad))
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [-(2 ** 63), 2 ** 63 - 1, 0],
+            [-(2 ** 63), 2 ** 64 - 1, 0],
+            [2 ** 64 - 2, 2 ** 64 - 3, 2 ** 64 - 1],
+            [2 ** 64 - 2, 2 ** 64 - 3, 2 ** 64 - 1, 0, 2, 3, 4, 5, 6],
+        ],
+    )
+    def test_hashtable(self, values):
+        myenum = enum.IntEnum("myenum", [(f"x{i}", v) for i, v in enumerate(values)])
+        dec = msgspec.msgpack.Decoder(myenum)
+
+        assert hasattr(myenum, "__msgspec_lookup__")
+
+        for val in myenum:
+            msg = msgspec.msgpack.encode(val)
+            val2 = dec.decode(msg)
+            assert val == val2
+
+        for bad in [-2000, -1, 1, 2000]:
+            with pytest.raises(msgspec.DecodeError):
+                dec.decode(msgspec.msgpack.encode(bad))
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [8, 16, 24, 32, 40, 48],
+            [-8, -16, -24, -32, -40, -48],
+        ],
+    )
+    def test_hashtable_collisions(self, values):
+        myenum = enum.IntEnum("myenum", [(f"x{i}", v) for i, v in enumerate(values)])
+        dec = msgspec.msgpack.Decoder(myenum)
+
+        for val in myenum:
+            msg = msgspec.msgpack.encode(val)
+            val2 = dec.decode(msg)
+            assert val == val2
+
+        for bad in [0, 7, 9, 56, -min(values), -max(values), 2 ** 64 - 1, -(2 ** 63)]:
+            with pytest.raises(msgspec.DecodeError):
+                dec.decode(msgspec.msgpack.encode(bad))


### PR DESCRIPTION
This adds an optimized lookup for IntEnum types. For small/compact
ranges of values this uses a direct index with an offset. For larger
ranges (where a direct index would result in too much wasted space) a
simple hashmap is used. To avoid recreating the lookup table multiple
times, it's stored on the enum class itself as the `__msgspec_lookup__`
attribute.

This switches the decoding process from:

- Decode int64_t/uint64_t value
- Create python int from this value
- Get `IntEnum` class
- Lookup python int on `IntEnum` class

to

- Decode int64_t/uint64_t value
- Get lookup table (already stored in the decoder `TypeNode` tree)
- Lookup value in lookup table

On my machine this results in:

- ~12x improvement in decode speed for compact ranges (1, 2, 3, 4, ...)
of enums (as fast or faster than decoding an integer).
- ~6x improvement in decode speed for wider ranges that require a
hashtable (slightly slower than decoding an integer).

This makes using enums more useful, as they don't add any slowdown over
raw literal values.

This also makes it more efficient to add `Literal` support (#65) for integer
literals later (to be done in a later PR).