### PR TITLE
Support Python 3.10 type unions

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -692,6 +692,15 @@ class TestDecoderMisc:
         with pytest.raises(msgspec.DecodeError):
             dec.decode(b'[1, 2, 3]"trailing"')
 
+    @pytest.mark.skipif(sys.version_info[:2] < (3, 10), reason="3.10 only")
+    def test_310_union_types(self):
+        dec = msgspec.json.Decoder(int | str | None)
+        assert dec.decode(b'1') == 1
+        assert dec.decode(b'"abc"') == "abc"
+        assert dec.decode(b'null') is None
+        with pytest.raises(msgspec.DecodeError):
+            dec.decode(b'1.5')
+
 
 class TestLiterals:
     def test_encode_none(self):

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -640,6 +640,16 @@ class TestDecoderMisc:
         with pytest.raises(msgspec.DecodeError):
             dec.decode(msg)
 
+    @pytest.mark.skipif(sys.version_info[:2] < (3, 10), reason="3.10 only")
+    def test_310_union_types(self):
+        dec = msgspec.msgpack.Decoder(int | str | None)
+        assert dec.decode(msgspec.msgpack.encode(1)) == 1
+        assert dec.decode(msgspec.msgpack.encode("abc")) == "abc"
+        assert dec.decode(msgspec.msgpack.encode(None)) is None
+        msg = msgspec.msgpack.encode(1.5)
+        with pytest.raises(msgspec.DecodeError):
+            dec.decode(msg)
+
 
 class TestTypedDecoder:
     def check_unexpected_type(self, dec_type, val, msg):


### PR DESCRIPTION
I thought these already worked, but they didn't. Type unions using the
`int | None` syntax create a `types.UnionType` object, not a
`typing.Union` object. Unfortunately `types.UnionType` doesn't define
`__origin__` (like all other generic types do), so this wasn't being
properly handled by the previous logic. This PR fixes this and adds a
test for Python 3.10+.