### PR TITLE
Micro-optimize `decode(type=Struct)`

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -6600,9 +6600,15 @@ msgspec_msgpack_decode(PyObject *self, PyObject *const *args, Py_ssize_t nargs, 
     }
     state.ext_hook = ext_hook;
 
-    /* Only build TypeNode if required */
+    /* Allocated Any & Struct type nodes (simple, common cases) on the stack,
+     * everything else on the heap */
     state.type = NULL;
-    if (type != NULL && type != st->typing_any) {
+    if (type == NULL || type == st->typing_any) {
+    }
+    else if (Py_TYPE(type) == &StructMetaType) {
+        if (StructMeta_prep_types(type, false, NULL) < 0) return NULL;
+    }
+    else {
         state.type = TypeNode_Convert(type, false, NULL);
         if (state.type == NULL) return NULL;
     }
@@ -6615,9 +6621,18 @@ msgspec_msgpack_decode(PyObject *self, PyObject *const *args, Py_ssize_t nargs, 
         state.input_end = state.input_pos + buffer.len;
         if (state.type != NULL) {
             res = mpack_decode(&state, state.type, NULL, false);
-        } else {
+        }
+        else if (type == NULL || type == st->typing_any) {
             TypeNode type_any = {MS_TYPE_ANY};
             res = mpack_decode(&state, &type_any, NULL, false);
+        }
+        else {
+            struct {
+                uint32_t types;
+                Py_ssize_t fixtuple_size;
+                void* extra[1];
+            } type_obj = {MS_TYPE_STRUCT, 0, {type}};
+            res = mpack_decode(&state, (TypeNode*)(&type_obj), NULL, false);
         }
         PyBuffer_Release(&buffer);
         if (res != NULL && mpack_has_trailing_characters(&state)) {
@@ -8576,9 +8591,15 @@ msgspec_json_decode(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyO
     state.scratch_capacity = 0;
     state.scratch_len = 0;
 
-    /* Only build TypeNode if required */
+    /* Allocated Any & Struct type nodes (simple, common cases) on the stack,
+     * everything else on the heap */
     state.type = NULL;
-    if (type != NULL && type != st->typing_any) {
+    if (type == NULL || type == st->typing_any) {
+    }
+    else if (Py_TYPE(type) == &StructMetaType) {
+        if (StructMeta_prep_types(type, true, NULL) < 0) return NULL;
+    }
+    else {
         state.type = TypeNode_Convert(type, true, NULL);
         if (state.type == NULL) return NULL;
     }
@@ -8592,9 +8613,18 @@ msgspec_json_decode(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyO
 
         if (state.type != NULL) {
             res = json_decode(&state, state.type, NULL);
-        } else {
+        }
+        else if (type == NULL || type == st->typing_any) {
             TypeNode type_any = {MS_TYPE_ANY};
             res = json_decode(&state, &type_any, NULL);
+        }
+        else {
+            struct {
+                uint32_t types;
+                Py_ssize_t fixtuple_size;
+                void* extra[1];
+            } type_obj = {MS_TYPE_STRUCT, 0, {type}};
+            res = json_decode(&state, (TypeNode*)(&type_obj), NULL);
         }
 
         if (res != NULL && json_has_trailing_characters(&state)) {

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -471,6 +471,28 @@ class TestDecodeFunction:
     def test_decode_type_any(self):
         assert msgspec.json.decode(b"[1, 2, 3]", type=Any) == [1, 2, 3]
 
+    def test_decode_type_struct(self):
+        class Point(msgspec.Struct):
+            x: int
+            y: int
+
+        for _ in range(2):
+            assert msgspec.json.decode(b'{"x":1,"y":2}', type=Point) == Point(1, 2)
+
+    def test_decode_type_struct_not_json_compatible(self):
+        class Test(msgspec.Struct):
+            x: Dict[int, str]
+
+        with pytest.raises(TypeError, match="not supported"):
+            msgspec.json.decode(b'{"x": {1: "two"}}', type=Test)
+
+    def test_decode_type_struct_invalid_type(self):
+        class Test(msgspec.Struct):
+            x: 1
+
+        with pytest.raises(TypeError):
+            msgspec.json.decode(b'{}', type=Test)
+
     def test_decode_invalid_type(self):
         with pytest.raises(TypeError, match="Type '1' is not supported"):
             msgspec.json.decode(b"[]", type=1)

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -204,6 +204,30 @@ class TestDecodeFunction:
     def test_decode_type_any(self):
         assert msgspec.msgpack.decode(self.buf, type=Any) == [1, 2, 3]
 
+    def test_decode_type_struct(self):
+        class Point(msgspec.Struct):
+            x: int
+            y: int
+
+        msg = msgspec.msgpack.encode(Point(1, 2))
+
+        for _ in range(2):
+            assert msgspec.msgpack.decode(msg, type=Point) == Point(1, 2)
+
+    def test_decode_type_struct_not_json_compatible(self):
+        class Test(msgspec.Struct):
+            x: Dict[int, str]
+
+        msg = msgspec.msgpack.encode(Test({1: "two"}))
+        msgspec.msgpack.decode(msg, type=Test) == Test({1, "two"})
+
+    def test_decode_type_struct_invalid_type(self):
+        class Test(msgspec.Struct):
+            x: 1
+
+        with pytest.raises(TypeError):
+            msgspec.msgpack.decode(b'{}', type=Test)
+
     def test_decode_invalid_type(self):
         with pytest.raises(TypeError, match="Type '1' is not supported"):
             msgspec.msgpack.decode(self.buf, type=1)


### PR DESCRIPTION
For the common case of `msgspec.json.decode(msg, type=Struct)`, we can
allocate the `TypeNode` on the stack and have a faster init path,
reducing overhead per call. This still isn't as fast as creating a
`Decoder` once and using `Decoder.decode`, but it brings things closer.
On my machine, decoding a simple `Point(x=1, y=2)` struct takes the
following times:

- `decode` (master): 240 ns
- `decode` (this PR): 150 ns
- `Decoder.decode`: 120 ns