### PR TITLE
Support string literal types as keys in JSON

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -1348,7 +1348,7 @@ typenode_from_collect_state(TypeNodeCollectState *state, bool err_not_json, bool
         if (temp == NULL) goto error;
         out->extra[e_ind++] = temp;
         /* Check that JSON dict keys are strings */
-        if (temp->types & ~(MS_TYPE_ANY | MS_TYPE_STR)) {
+        if (temp->types & ~(MS_TYPE_ANY | MS_TYPE_STR | MS_TYPE_STRLITERAL)) {
             if (err_not_json) {
                 PyErr_Format(
                     PyExc_TypeError,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -702,7 +702,7 @@ class TestDecoderMisc:
             dec.decode(b'1.5')
 
 
-class TestLiterals:
+class TestBoolAndNone:
     def test_encode_none(self):
         assert msgspec.json.encode(None) == b"null"
 
@@ -1730,6 +1730,13 @@ class TestDict:
             msgspec.DecodeError, match=r"Expected `int`, got `str` - at `\$\[...\]`"
         ):
             dec.decode(b'{"a": "bad"}')
+
+    def test_decode_typed_dict_literal_key(self):
+        dec = msgspec.json.Decoder(Dict[Literal["a", "b"], int])
+        assert dec.decode(b'{"a": 1, "b": 2}') == {"a": 1, "b": 2}
+
+        with pytest.raises(msgspec.DecodeError, match="Invalid enum value 'c'"):
+            dec.decode(b'{"a": 1, "c": 2}')
 
     @pytest.mark.parametrize(
         "s, error",


### PR DESCRIPTION
Previously this was restricted to `str` or `Any` types only, we now also
support string literal types. We could extend this to any type that
encodes as a string, but I'm reluctant to expand the API here unless
asked.

Fixes #76.