### PR TITLE
Upgrade cibuildwheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build & Test Wheels
-        uses: joerick/cibuildwheel@v1.9.0
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_TEST_REQUIRES: "pytest msgpack"
           CIBW_TEST_COMMAND: "pytest {project}/tests"


### PR DESCRIPTION
Maybe this will fix the missing Python 3.10 wheel builds.