### PR TITLE
Fixup decode(..., type=Struct) optimization

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -7068,11 +7068,12 @@ msgspec_msgpack_decode(PyObject *self, PyObject *const *args, Py_ssize_t nargs, 
             res = mpack_decode(&state, &type_any, NULL, false);
         }
         else {
+            bool array_like = ((StructMetaObject *)type)->array_like == OPT_TRUE;
             struct {
                 uint32_t types;
                 Py_ssize_t fixtuple_size;
                 void* extra[1];
-            } type_obj = {MS_TYPE_STRUCT, 0, {type}};
+            } type_obj = {array_like ? MS_TYPE_STRUCT_ARRAY : MS_TYPE_STRUCT, 0, {type}};
             res = mpack_decode(&state, (TypeNode*)(&type_obj), NULL, false);
         }
         PyBuffer_Release(&buffer);
@@ -9265,11 +9266,12 @@ msgspec_json_decode(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyO
             res = json_decode(&state, &type_any, NULL);
         }
         else {
+            bool array_like = ((StructMetaObject *)type)->array_like == OPT_TRUE;
             struct {
                 uint32_t types;
                 Py_ssize_t fixtuple_size;
                 void* extra[1];
-            } type_obj = {MS_TYPE_STRUCT, 0, {type}};
+            } type_obj = {array_like ? MS_TYPE_STRUCT_ARRAY : MS_TYPE_STRUCT, 0, {type}};
             res = json_decode(&state, (TypeNode*)(&type_obj), NULL);
         }
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -471,13 +471,16 @@ class TestDecodeFunction:
     def test_decode_type_any(self):
         assert msgspec.json.decode(b"[1, 2, 3]", type=Any) == [1, 2, 3]
 
-    def test_decode_type_struct(self):
-        class Point(msgspec.Struct):
+    @pytest.mark.parametrize("array_like", [False, True])
+    def test_decode_type_struct(self, array_like):
+        class Point(msgspec.Struct, array_like=array_like):
             x: int
             y: int
 
+        msg = msgspec.json.encode(Point(1, 2))
+
         for _ in range(2):
-            assert msgspec.json.decode(b'{"x":1,"y":2}', type=Point) == Point(1, 2)
+            assert msgspec.json.decode(msg, type=Point) == Point(1, 2)
 
     def test_decode_type_struct_not_json_compatible(self):
         class Test(msgspec.Struct):
@@ -491,7 +494,7 @@ class TestDecodeFunction:
             x: 1
 
         with pytest.raises(TypeError):
-            msgspec.json.decode(b'{}', type=Test)
+            msgspec.json.decode(b"{}", type=Test)
 
     def test_decode_invalid_type(self):
         with pytest.raises(TypeError, match="Type '1' is not supported"):

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -204,8 +204,9 @@ class TestDecodeFunction:
     def test_decode_type_any(self):
         assert msgspec.msgpack.decode(self.buf, type=Any) == [1, 2, 3]
 
-    def test_decode_type_struct(self):
-        class Point(msgspec.Struct):
+    @pytest.mark.parametrize("array_like", [False, True])
+    def test_decode_type_struct(self, array_like):
+        class Point(msgspec.Struct, array_like=array_like):
             x: int
             y: int
 
@@ -226,7 +227,7 @@ class TestDecodeFunction:
             x: 1
 
         with pytest.raises(TypeError):
-            msgspec.msgpack.decode(b'{}', type=Test)
+            msgspec.msgpack.decode(b"{}", type=Test)
 
     def test_decode_invalid_type(self):
         with pytest.raises(TypeError, match="Type '1' is not supported"):


### PR DESCRIPTION
Between the original PR (#77) being made and merged a change went in that
broke the optimization (specifically, the type code for struct types was
split into `MS_TYPE_STRUCT` and `MS_TYPE_STRUCT_ARRAY`). This fixes the
bug, and expands the tests to provide a more localized check for this
behavior.