### PR TITLE
Improve nogc support

### DIFF
--- a/benchmarks/bench_gc.py
+++ b/benchmarks/bench_gc.py
@@ -1,0 +1,121 @@
+"""This file benchmarks GC collection time for a large number of tiny
+dataclass-like instances.
+
+For each type, the following is measured:
+
+- Time for a single full GC pass over all the data.
+- Amount of memory used to hold all the data
+"""
+import gc
+import sys
+import time
+
+import msgspec
+
+
+def sizeof(x, _seen=None):
+    """Get the recursive sizeof for an object (memoized).
+
+    Not generic, works on types used in this benchmark.
+    """
+    if _seen is None:
+        _seen = set()
+
+    _id = id(x)
+    if _id in _seen:
+        return 0
+
+    _seen.add(_id)
+
+    size = sys.getsizeof(x)
+
+    if isinstance(x, dict):
+        for k, v in x.items():
+            size += sizeof(k, _seen)
+            size += sizeof(v, _seen)
+    if hasattr(x, "__dict__"):
+        size += sizeof(x.__dict__, _seen)
+    if hasattr(x, "__slots__"):
+        for k in x.__slots__:
+            size += sizeof(k, _seen)
+            size += sizeof(getattr(x, k), _seen)
+    return size
+
+
+class Point(msgspec.Struct):
+    x: int
+    y: int
+    z: int
+
+
+class PointNoGC(msgspec.Struct, nogc=True):
+    x: int
+    y: int
+    z: int
+
+
+class PointClass:
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+class PointClassSlots:
+    __slots__ = ("x", "y", "z")
+
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+def bench_gc(cls):
+    # Allocate a dict of structs
+    data = {i: cls(i, i, i) for i in range(1_000_000)}
+
+    # Run a full collection
+    start = time.perf_counter()
+    gc.collect()
+    stop = time.perf_counter()
+    gc_time = (stop - start) * 1e3
+    mibytes = sizeof(data) / (2**20)
+    return gc_time, mibytes
+
+
+def format_table(results):
+    columns = ("", "GC time (ms)", "Memory Used (MiB)")
+
+    rows = []
+    for name, t, mem in results:
+        rows.append((f"**{name}**", f"{t:.2f}", f"{mem:.2f}"))
+
+    widths = tuple(max(max(map(len, x)), len(c)) for x, c in zip(zip(*rows), columns))
+    row_template = ("|" + (" %%-%ds |" * len(columns))) % widths
+    header = row_template % tuple(columns)
+    bar_underline = "+%s+" % "+".join("=" * (w + 2) for w in widths)
+    bar = "+%s+" % "+".join("-" * (w + 2) for w in widths)
+    parts = [bar, header, bar_underline]
+    for r in rows:
+        parts.append(row_template % r)
+        parts.append(bar)
+    return "\n".join(parts)
+
+
+def main():
+    results = []
+    for name, cls in [
+        ("standard class", PointClass),
+        ("standard class with __slots__", PointClassSlots),
+        ("msgspec struct", Point),
+        ("msgspec struct with nogc=True", PointNoGC),
+    ]:
+        print(f"Benchmarking {name}...")
+        gc_time, mibytes = bench_gc(cls)
+        results.append((name, gc_time, mibytes))
+
+    print(format_table(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/perf-tips.rst
+++ b/docs/source/perf-tips.rst
@@ -226,6 +226,20 @@ benefit from using it instead of JSON. And since ``msgspec`` supports both
 protocols with a consistent interface, switching from ``msgspec.json`` to
 ``msgspec.msgpack`` should be fairly painless.
 
+Use ``nogc=True``
+-----------------
+
+Python processes with a large number of long-lived objects, or operations that
+allocate a large number of objects at once may suffer reduced performance due
+to Python's garbage collector (GC). By default, `msgspec.Struct` types
+implement a few optimizations to reduce the load on the GC (and thus reduce the
+frequency and duration of a GC pause). If you find that GC is still a problem,
+and **are certain** that your Struct types may never participate in a reference
+cycle, then you **may** benefit from setting ``nogc=True`` on your Struct
+types.  Depending on workload, this can result in a measurable decrease in
+pause time and frequency due to GC passes. See :ref:`struct-nogc` for more
+details.
+
 Use ``array_like=True``
 -----------------------
 

--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -398,6 +398,8 @@ array, and is used to determine which type in the union to use when decoding.
     Put(key='my key', val='my val')
 
 
+.. _struct-nogc:
+
 Disabling Garbage Collection (Advanced)
 ---------------------------------------
 
@@ -443,12 +445,12 @@ structs referencing containers (lists, dicts, structs, ...) will.
     True
 
 If you *are certain* that your struct types can *never* participate in a
-reference cycle, you *may* find a performance boost from setting ``nogc=True``
-on a struct definition. This boost is tricky to measure in isolation, since it
-should only result in the garbage collector not running as frequently - an
-integration benchmark is recommended to determine if this is worthwhile for
-your workload. A workload is likely to benefit from this optimization in the
-following situations:
+reference cycle, you *may* find a :ref:`performance boost
+<struct-gc-benchmark>` from setting ``nogc=True`` on a struct definition. This
+boost is tricky to measure in isolation, since it should only result in the
+garbage collector not running as frequently - an integration benchmark is
+recommended to determine if this is worthwhile for your workload. A workload is
+likely to benefit from this optimization in the following situations:
 
 - You're allocating a lot of struct objects at once (for example, decoding a
   large object). Setting ``nogc=True`` on these types will reduce the


### PR DESCRIPTION
- Previously GC tracking was disabled for structs with `nogc=True`, but kept the same GC-enabled memory layout. This PR changes nogc structs to truly be non-GC types. This reduces memory usage per instance by 16 bytes. It also lets `dict` and `tuple` instances containing `nogc=True` structs to also not be tracked instances, further reducing GC load.
- Further optimize the allocation code paths for structs. We now no longer needless track structs just to untrack them later, resulting in a micro speedup. We also optimize at import time `tp_setattr` and `tp_free`, rather than branching per-call.
- Add a benchmark for GC usage comparing structs, structs with nogc=True, classes, and classes with `__slots__`. This shows a major reduction in GC pause time for applications with a large number of in-memory `Struct` instances.
- Improve documentation for `nogc` structs.