### PR TITLE
No need to copy frozen structs used as defaults

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -3437,6 +3437,12 @@ maybe_deepcopy_default(PyObject *obj) {
         return PySet_New(NULL);
     }
 
+    /* Frozen structs are immutable and can be used without copying */
+    if ((Py_TYPE(type) == &StructMetaType) && ((StructMetaObject *)type)->frozen == OPT_TRUE) {
+        Py_INCREF(obj);
+        return obj;
+    }
+
     MsgspecState *mod = msgspec_get_global_state();
     if (PyType_IsSubtype(type, mod->EnumType)) {
         Py_INCREF(obj);

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -478,6 +478,11 @@ def test_struct_compare_errors():
         t2 != t
 
 
+class FrozenPoint(Struct, frozen=True):
+    x: int
+    y: int
+
+
 @pytest.mark.parametrize(
     "default",
     [
@@ -498,6 +503,7 @@ def test_struct_compare_errors():
         datetime.date.today(),
         datetime.timedelta(seconds=2),
         datetime.datetime.now(),
+        FrozenPoint(1, 2),
     ],
 )
 def test_struct_immutable_defaults_use_instance(default):


### PR DESCRIPTION
A frozen struct instance can be used directly as a default value without creating a copy.