### PR TITLE
Add support for renaming fields

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -1,5 +1,5 @@
 from typing import Type
-from typing import Callable, Tuple, Any, Union, TypeVar, ClassVar, overload
+from typing import Callable, Tuple, Any, Union, TypeVar, ClassVar, Literal, overload
 
 # Use `__dataclass_transform__` to catch more errors under pyright. Since we don't expose
 # the underlying metaclass, hide it under an underscore name. See
@@ -29,6 +29,9 @@ class Struct(metaclass=__StructMeta):
         tag: Union[None, bool, str, Callable[[str], str]] = None,
         tag_field: Union[None, str] = None,
         omit_defaults: bool = False,
+        rename: Union[
+            None, Literal["lower", "upper", "camel", "pascal"], Callable[[str], str]
+        ] = None,
         frozen: bool = False,
         array_like: bool = False,
         nogc: bool = False,

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -3060,7 +3060,7 @@ StructMeta_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     }
     if (arg_tag != NULL && arg_tag != Py_None) { tag_temp = arg_tag; }
     if (arg_tag_field != NULL && arg_tag_field != Py_None) { tag_field_temp = arg_tag_field; }
-    if (arg_rename != NULL && arg_rename != Py_None) { rename = arg_rename; }
+    if (arg_rename != NULL ) { rename = arg_rename == Py_None ? NULL : arg_rename; }
     frozen = STRUCT_MERGE_OPTIONS(frozen, arg_frozen);
     array_like = STRUCT_MERGE_OPTIONS(array_like, arg_array_like);
     nogc = STRUCT_MERGE_OPTIONS(nogc, arg_nogc);

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -39,6 +39,39 @@ def check_struct_omit_defaults() -> None:
     reveal_type(t.y)  # assert "str" in typ
 
 
+def check_struct_rename() -> None:
+    class TestLower(msgspec.Struct, rename="lower"):
+        x: int
+
+    class TestUpper(msgspec.Struct, rename="upper"):
+        x: int
+
+    class TestCamel(msgspec.Struct, rename="camel"):
+        x: int
+
+    class TestPascal(msgspec.Struct, rename="pascal"):
+        x: int
+
+    class TestCallable(msgspec.Struct, rename=lambda x: x.title()):
+        x: int
+
+    class TestNone(msgspec.Struct, rename=None):
+        x: int
+
+    o = sum(
+        [
+            TestLower(1).x,
+            TestUpper(2).x,
+            TestCamel(3).x,
+            TestPascal(4).x,
+            TestCallable(5).x,
+            TestNone(6).x,
+        ]
+    )
+
+    reveal_type(o)  # assert "int" in typ
+
+
 def check_struct_array_like() -> None:
     class Test(msgspec.Struct, array_like=True):
         x: int

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1028,6 +1028,25 @@ class TestRename:
         assert field in str(rec.value)
         assert "must not contain" in str(rec.value)
 
+    def test_rename_inherit(self):
+        class Base(Struct, rename="upper"):
+            pass
+
+        class Test1(Base):
+            x: int
+
+        assert Test1.__struct_encode_fields__ == ("X",)
+
+        class Test2(Base, rename="camel"):
+            my_field: int
+
+        assert Test2.__struct_encode_fields__ == ("myField",)
+
+        class Test3(Base, rename=None):
+            my_field: int
+
+        assert Test3.__struct_encode_fields__ == ("my_field",)
+
     def test_rename_fields_only_used_for_encode_and_decode(self):
         """Check that the renamed fields don't show up elsewhere"""
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1018,6 +1018,16 @@ class TestRename:
                 aa2: int
                 ab1: int
 
+    @pytest.mark.parametrize("field", ["foo\\bar", 'foo"bar', "foo\tbar"])
+    def test_rename_field_invalid_characters(self, field):
+        with pytest.raises(ValueError) as rec:
+
+            class Test(Struct, rename=lambda x: field):
+                x: int
+
+        assert field in str(rec.value)
+        assert "must not contain" in str(rec.value)
+
     def test_rename_fields_only_used_for_encode_and_decode(self):
         """Check that the renamed fields don't show up elsewhere"""
 


### PR DESCRIPTION
Adds a `rename` option to a struct definition. This takes either a string describing a rename method (``"lower"``, ``"upper"``,
``"camel"``, or ``"pascal"`` for lowercase, UPPERCASE, camelCase, or PascalCase respectively), or a callable from str -> str that will be called on every field name. Renamed fields are used for encoding/decoding only, and are intended for cases where you need the JSON field names to be something different than what you wish to use in Python (a common case would be applying camelCase to encoded JSON, but using snake_case in python).

Example:

```python
In [1]: import msgspec

In [2]: class Example(msgspec.Struct, rename="camel"):
   ...:     field_one: int
   ...:     field_two: str
   ...: 

In [3]: ex = Example(1, field_two="two")  # in python code the field names are the same

In [4]: ex
Out[4]: Example(field_one=1, field_two='two')

In [5]: s = msgspec.json.encode(ex)  # The renamed fields are used when encoding/decoding

In [6]: s
Out[6]: b'{"fieldOne":1,"fieldTwo":"two"}'

In [7]: msgspec.json.decode(s, type=Example)
Out[7]: Example(field_one=1, field_two='two')

In [8]: msgspec.json.decode(b'{"fieldOne":1}', type=Example)  # The renamed fields are also used in DecodeError messages
---------------------------------------------------------------------------
DecodeError                               Traceback (most recent call last)
Input In [8], in <cell line: 1>()
----> 1 msgspec.json.decode(b'{"fieldOne":1}', type=Example)

DecodeError: Object missing required field `fieldTwo`
```

Todo:

- [x] Docs
- [x] A second review of new C code