### PR TITLE
Adding Linux and Mac ARM wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+            platforms: all
+
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.4.0
         env:
           CIBW_TEST_REQUIRES: "pytest msgpack"
           CIBW_TEST_COMMAND: "pytest {project}/tests"
           CIBW_BUILD: "cp38-* cp39-* cp310-*"
           CIBW_SKIP: "*-win32 *_i686 *_s390x *_ppc64le"
+          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_TEST_SKIP: "*_arm64"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -1121,6 +1121,13 @@ class TestExt:
         assert x != x4
         assert not (x == x4)
 
+    @pytest.mark.parametrize("code", [-128, -2, 0, 2, 127])
+    def test_code_roundtrip(self, code):
+        ext = msgspec.msgpack.Ext(code, b"")
+        assert ext.code == code
+        ext2 = msgspec.msgpack.decode(msgspec.msgpack.encode(ext))
+        assert ext2.code == code
+
     @pytest.mark.parametrize("code", [-129, 128, 2**65])
     def test_code_out_of_range(self, code):
         with pytest.raises(ValueError):


### PR DESCRIPTION
This resolves #103 by adding steps for Linux and Mac ARM wheels in the CI build. I also bumped the version of pypa/cibuildwheel to v2.4.0.

Mac support: https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
Linux support: https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation

I don't have a great way of testing this. :smile: 