### PR TITLE
Add `defstruct`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,8 @@ Struct
 .. autoclass:: Struct
     :members:
 
+.. autofunction:: defstruct
+
 
 Raw
 ---

--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -542,6 +542,26 @@ array, and is used to determine which type in the union to use when decoding.
     Put(key='my key', val='my val')
 
 
+Runtime Definition
+------------------
+
+In some cases it can be useful to dynamically generate `msgspec.Struct` classes
+at runtime. This can be handled through the use of `msgspec.defstruct`, which
+has a signature similar to `dataclasses.make_dataclass`. See
+`msgspec.defstruct` for more information.
+
+.. code-block:: python
+
+    >>> import msgspec
+
+    >>> Point = msgspec.defstruct("Point", [("x", float), ("y": float)])
+
+    >>> p = Point(1.0, 2.0)
+
+    >>> p
+    Point(x=1.0, y=2.0)
+
+
 .. _struct-nogc:
 
 Disabling Garbage Collection (Advanced)

--- a/msgspec/__init__.py
+++ b/msgspec/__init__.py
@@ -1,5 +1,6 @@
 from ._core import (
     Struct,
+    defstruct,
     Raw,
     MsgspecError,
     EncodeError,

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -1,5 +1,17 @@
-from typing import Type
-from typing import Callable, Tuple, Any, Union, TypeVar, ClassVar, Literal, overload
+from typing import (
+    Type,
+    Callable,
+    Dict,
+    Tuple,
+    Iterable,
+    Optional,
+    Any,
+    Union,
+    TypeVar,
+    ClassVar,
+    Literal,
+    overload,
+)
 
 # Use `__dataclass_transform__` to catch more errors under pyright. Since we don't expose
 # the underlying metaclass, hide it under an underscore name. See
@@ -36,6 +48,24 @@ class Struct(metaclass=__StructMeta):
         array_like: bool = False,
         nogc: bool = False,
     ) -> None: ...
+
+def defstruct(
+    name: str,
+    fields: Iterable[Union[str, Tuple[str, Type], Tuple[str, Type, Any]]],
+    *,
+    bases: Tuple[Type[Struct], ...] = (),
+    module: Optional[str] = None,
+    namespace: Optional[Dict[str, Any]] = None,
+    tag: Union[None, bool, str, Callable[[str], str]] = None,
+    tag_field: Union[None, str] = None,
+    omit_defaults: bool = False,
+    rename: Union[
+        None, Literal["lower", "upper", "camel", "pascal"], Callable[[str], str]
+    ] = None,
+    frozen: bool = False,
+    array_like: bool = False,
+    nogc: bool = False,
+) -> Type[Struct]: ...
 
 # Lie and say `Raw` is a subclass of `bytes`, so mypy will accept it in most
 # places where an object that implements the buffer protocol is valid

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -155,6 +155,54 @@ def check_struct_attributes() -> None:
     for field in p.__struct_fields__:
         reveal_type(field)  # assert "str" in typ
 
+
+##########################################################
+# defstruct                                              #
+##########################################################
+
+
+def check_defstruct() -> None:
+    Test = msgspec.defstruct("Test", ["x", "y"])
+    for field in Test.__struct_fields__:
+        reveal_type(field)  # assert "str" in typ
+    Test(1, y=2)
+
+
+def check_defstruct_field_types() -> None:
+    Test = msgspec.defstruct(
+        "Test",
+        ("x", ("y", int), ("z", str, "default"))
+    )
+
+
+def check_defstruct_bases() -> None:
+    class Base(msgspec.Struct):
+        pass
+
+    Test = msgspec.defstruct("Test", ["x", "y"], bases=(Base,))
+
+
+def check_defstruct_namespace() -> None:
+    msgspec.defstruct("Test", ["x", "y"], namespace={"classval": 1})
+
+
+def check_defstruct_module() -> None:
+    msgspec.defstruct("Test", ["x", "y"], module="mymod")
+
+
+def check_defstruct_config_options() -> None:
+    Test = msgspec.defstruct(
+        "Test",
+        ("x", "y"),
+        omit_defaults=True,
+        frozen=True,
+        array_like=True,
+        nogc=True,
+        tag="mytag",
+        tag_field="mytagfield",
+        rename="lower"
+    )
+
 ##########################################################
 # Raw                                                    #
 ##########################################################

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -23,14 +23,16 @@ def test_mypy():
 
     stdout, stderr, code = api.run([PATH])
     lines = stdout.splitlines()
-    if any("revealed type" not in l.lower() for l in lines):
-        assert False, f"Unexpected mypy error:\n{stdout}"
     for line in lines:
-        lineno, typ = get_lineno_type(line)
-        check = ex_lines[lineno - 1].split("#")[1].strip()
-        try:
-            exec(check, {"typ": typ})
-        except Exception:
-            assert (
-                False
-            ), f"Failed check at {PATH}:{lineno}: {check!r}, where 'typ' is {typ!r}"
+        if "revealed type" in line.lower():
+            lineno, typ = get_lineno_type(line)
+            check = ex_lines[lineno - 1].split("#")[1].strip()
+            try:
+                exec(check, {"typ": typ})
+            except Exception:
+                breakpoint()
+                assert (
+                    False
+                ), f"Failed check at {PATH}:{lineno}: {check!r}, where 'typ' is {typ!r}"
+        elif "success" not in line.lower():
+            assert False, line


### PR DESCRIPTION
Adds a method for dynamically defining new struct types. This is helpful
for situations where types aren't known until runtime, but you still
want to provide type validation when encoding/decoding.