### PR TITLE
Speedup Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Set up Environment
         if: github.event_name != 'release'
-        run: echo 'CIBW_SKIP="${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64"' >> $GITHUB_ENV
+        run: echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
         uses: pypa/cibuildwheel@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Set up Environment
         if: github.event_name != 'release'
-        run: echo "CIBW_SKIP='${CIBW_SKIP} cp38-*_aarch64 cp39-*_aarch64 *-musllinux_*'" >> $GITHUB_ENV
+        run: echo 'CIBW_SKIP="${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64"' >> $GITHUB_ENV
 
       - name: Build & Test Wheels
         uses: pypa/cibuildwheel@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,15 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
 
+    env:
+      CIBW_TEST_REQUIRES: "pytest msgpack"
+      CIBW_TEST_COMMAND: "pytest {project}/tests"
+      CIBW_BUILD: "cp38-* cp39-* cp310-*"
+      CIBW_SKIP: "*-win32 *_i686 *_s390x *_ppc64le"
+      CIBW_ARCHS_MACOS: "x86_64 arm64"
+      CIBW_ARCHS_LINUX: "x86_64 aarch64"
+      CIBW_TEST_SKIP: "*_arm64 *-musllinux_*"
+
     steps:
       - uses: actions/checkout@v2
 
@@ -56,18 +65,14 @@ jobs:
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v1
         with:
-            platforms: all
+          platforms: all
+
+      - name: Set up Environment
+        if: github.event_name != 'release'
+        run: echo "CIBW_SKIP='${CIBW_SKIP} cp38-*_aarch64 cp39-*_aarch64 *-musllinux_*'" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
         uses: pypa/cibuildwheel@v2.4.0
-        env:
-          CIBW_TEST_REQUIRES: "pytest msgpack"
-          CIBW_TEST_COMMAND: "pytest {project}/tests"
-          CIBW_BUILD: "cp38-* cp39-* cp310-*"
-          CIBW_SKIP: "*-win32 *_i686 *_s390x *_ppc64le"
-          CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_TEST_SKIP: "*_arm64"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
While we publish a large number of pre-built wheels, we don't need to
build and test all of them for every PR. This PR reduces the non-release
builds to:
- Completely skip musllinux
- Skip aarch64 except for cpython 3.10

Follow-up from #104.