### PR TITLE
Use `asan` and `ubsan` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,11 @@ jobs:
         env:
           PYTHONMALLOC: "malloc"
           ASAN_OPTIONS: "detect_leaks=0"
-        run: py.test -m "not mypy and not pyright"
+        run: |
+          set -xe
+          export LD_PRELOAD=`gcc -print-file-name=libasan.so`
+          echo $LD_PRELOAD
+          py.test -s -m "not mypy and not pyright"
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Install Dependencies
         run: |
@@ -41,6 +41,19 @@ jobs:
 
       - name: pyright
         run: py.test tests/test_pyright.py
+
+      - name: Rebuild with sanitizers
+        env:
+          MSGSPEC_SANITIZE: "true"
+        run: |
+          python setup.py clean --all
+          pip install -e .
+
+      - name: Run tests with sanitizers
+        env:
+          PYTHONMALLOC: "malloc"
+          ASAN_OPTIONS: "detect_leaks=0"
+        run: py.test -m "not mypy and not pyright"
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install pytest mypy pyright
+          pip install pytest mypy pyright msgpack
 
       - name: Build Msgspec
         run: |
@@ -54,9 +54,7 @@ jobs:
           PYTHONMALLOC: "malloc"
           ASAN_OPTIONS: "detect_leaks=0"
         run: |
-          set -xe
           export LD_PRELOAD=`gcc -print-file-name=libasan.so`
-          echo $LD_PRELOAD
           py.test -s -m "not mypy and not pyright"
 
   build_wheels:

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -3524,17 +3524,16 @@ error:
 static int
 StructMeta_traverse(StructMetaObject *self, visitproc visit, void *arg)
 {
-    int out;
-    Py_ssize_t i, nfields;
     Py_VISIT(self->struct_fields);
     Py_VISIT(self->struct_defaults);
     Py_VISIT(self->struct_encode_fields);
     Py_VISIT(self->struct_tag);  /* May be a function */
     Py_VISIT(self->rename);  /* May be a function */
     if (self->struct_types != NULL) {
-        nfields = PyTuple_GET_SIZE(self->struct_fields);
-        for (i = 0; i < nfields; i++) {
-            out = TypeNode_traverse(self->struct_types[i], visit, arg);
+        assert(self->struct_fields != NULL);
+        Py_ssize_t nfields = PyTuple_GET_SIZE(self->struct_fields);
+        for (Py_ssize_t i = 0; i < nfields; i++) {
+            int out = TypeNode_traverse(self->struct_types[i], visit, arg);
             if (out != 0) return out;
         }
     }
@@ -9438,9 +9437,10 @@ json_decode_extended_float(JSONDecoderState *self) {
     if (MS_UNLIKELY(c == '0')) {
         /* Ensure at most one leading zero */
         self->input_pos++;
+        /* This _can't_ happen, since it would have been caught in the fast routine first:
         c = json_peek_or_null(self);
-        /* This _can't_ happen, since it would have been caught in the fast routine first */
-        /*if (MS_UNLIKELY(is_digit(c))) return json_err_invalid(self, "invalid number");*/
+        if (MS_UNLIKELY(is_digit(c))) return json_err_invalid(self, "invalid number");
+        */
     }
     else {
         /* Parse the integer part of the number. */

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -858,7 +858,7 @@ StrLookup_NewFullArgs(PyObject *arg, PyObject *tag_field, bool array_like) {
     else {
         items = PySequence_Tuple(arg);
         if (items == NULL) return NULL;
-        nitems = PyTuple_GET_SIZE(arg);
+        nitems = PyTuple_GET_SIZE(items);
     }
 
     /* Must have at least one item */
@@ -2913,7 +2913,7 @@ StructMeta_rename_fields(PyObject *fields, PyObject *rename)
         );
         goto error;
     }
-    Py_DECREF(out_set);
+    Py_CLEAR(out_set);
 
     /* Ensure all renamed fields contain characters that don't require quoting
      * in JSON. This isn't strictly required, but usage of such characters is
@@ -8612,8 +8612,8 @@ json_decode_datetime(
 
     /* Ensure all numbers are valid */
     if (year == 0) goto invalid;
-    if (day == 0 || day > days_in_month(year, month)) goto invalid;
     if (month == 0 || month > 12) goto invalid;
+    if (day == 0 || day > days_in_month(year, month)) goto invalid;
     if (hour > 23) goto invalid;
     if (minute > 59) goto invalid;
     if (second > 59) goto invalid;

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,11 @@ ignore =
     W504,  # line break after binary operator
 max-line-length = 100
 
+[tool:pytest]
+markers =
+    mypy
+    pyright
+
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,23 @@ import versioneer
 from setuptools import setup
 from setuptools.extension import Extension
 
-DEBUG = os.environ.get("MSGSPEC_DEBUG", False)
+SANITIZE = os.environ.get("MSGSPEC_SANITIZE", False)
+DEBUG = os.environ.get("MSGSPEC_DEBUG", SANITIZE)
 
+extra_compile_args = []
+extra_link_args = []
 if DEBUG:
-    extra_compile_args = ["-O0", "-g", "-UNDEBUG"]
-else:
-    extra_compile_args = []
+    extra_compile_args.extend(["-O0", "-g", "-UNDEBUG"])
+if SANITIZE:
+    extra_compile_args.extend(["-fsanitize=address", "-fsanitize=undefined"])
+    extra_link_args.extend(["-lasan", "-lubsan"])
 
 ext_modules = [
     Extension(
         "msgspec._core",
         [os.path.join("msgspec", "_core.c")],
         extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args,
     )
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools.extension import Extension
 DEBUG = os.environ.get("MSGSPEC_DEBUG", False)
 
 if DEBUG:
-    extra_compile_args = ["-O0", "-g"]
+    extra_compile_args = ["-O0", "-g", "-UNDEBUG"]
 else:
     extra_compile_args = []
 

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -3,6 +3,8 @@ import os
 
 import pytest
 
+pytestmark = pytest.mark.mypy
+
 api = pytest.importorskip("mypy.api")
 
 PATH = os.path.join(os.path.dirname(__file__), "basic_typing_examples.py")

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -4,6 +4,8 @@ import subprocess
 
 import pytest
 
+pytestmark = pytest.mark.pyright
+
 pyright = pytest.importorskip("pyright")
 
 PATH = os.path.join(os.path.dirname(__file__), "basic_typing_examples.py")


### PR DESCRIPTION
- Add `asan`/`ubsan` build & tests to CI
- Fixes bugs found when running with `asan`/`ubsan`, as well as silencing some warnings found by running clang's static analysis locally.