### PR TITLE
A few small fixups

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -307,10 +307,10 @@ type in MessagePack.
     b'"85+Eng=="'
 
     >>> msgspec.json.decode(msg, type=bytes)
-    b'"85+Eng=="'
+    b'\xf0\x9d\x84\x9e'
 
     >>> msgspec.json.decode(msg, type=bytearray)
-    bytearray(b'"85+Eng=="')
+    bytearray(b'\xf0\x9d\x84\x9e')
 
 ``IntEnum``
 ~~~~~~~~~~~


### PR DESCRIPTION
- Fix memory leak for messages with trailing characters
- Properly forward error for malformed msgpack submessages
- Fix typo in bytes docs
- Fix memory leak when decoding invalid set
- Fix msgpack decode invalid opcode error message