### PR TITLE
Don't include debug symbols in packaged wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "x86_64 aarch64"
       CIBW_TEST_SKIP: "*_arm64 *-musllinux_*"
+      CIBW_ENVIRONMENT: "CFLAGS=-g0"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`cibuildwheel` just uses the default sysconfig flags, which set `-g` in
the manylinux wheels. We don't want this debug info. This reduces the
size of the built wheels down from ~1.1 MiB to a more reasonable ~200
KiB.