### PR TITLE
Faster json string parsing

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -343,12 +343,12 @@ def bench_pyrobuf(n, no_gc, validate=False):
 BENCHMARKS = [
     ("ujson", bench_ujson),
     ("orjson", bench_orjson),
-    # ("msgpack", bench_msgpack),
-    # ("pyrobuf", bench_pyrobuf),
-    # ("msgspec msgpack", bench_msgspec_msgpack),
-    # ("msgspec msgpack array-like", bench_msgspec_msgpack_array_like),
+    ("msgpack", bench_msgpack),
+    ("pyrobuf", bench_pyrobuf),
+    ("msgspec msgpack", bench_msgspec_msgpack),
+    ("msgspec msgpack array-like", bench_msgspec_msgpack_array_like),
     ("msgspec json", bench_msgspec_json),
-    # ("msgspec json array-like", bench_msgspec_json_array_like),
+    ("msgspec json array-like", bench_msgspec_json_array_like),
 ]
 
 

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -343,12 +343,12 @@ def bench_pyrobuf(n, no_gc, validate=False):
 BENCHMARKS = [
     ("ujson", bench_ujson),
     ("orjson", bench_orjson),
-    ("msgpack", bench_msgpack),
-    ("pyrobuf", bench_pyrobuf),
-    ("msgspec msgpack", bench_msgspec_msgpack),
-    ("msgspec msgpack array-like", bench_msgspec_msgpack_array_like),
+    # ("msgpack", bench_msgpack),
+    # ("pyrobuf", bench_pyrobuf),
+    # ("msgspec msgpack", bench_msgspec_msgpack),
+    # ("msgspec msgpack array-like", bench_msgspec_msgpack_array_like),
     ("msgspec json", bench_msgspec_json),
-    ("msgspec json array-like", bench_msgspec_json_array_like),
+    # ("msgspec json array-like", bench_msgspec_json_array_like),
 ]
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -786,6 +786,13 @@ class TestStrings:
         with pytest.raises(msgspec.DecodeError, match="invalid character"):
             msgspec.json.decode(buf2)
 
+        # Test str skipping
+        class Test(msgspec.Struct):
+            x: int
+
+        buf3 = msgspec.json.encode({"y": sol, "x": 1})
+        msgspec.json.decode(buf3, type=Test)
+
 
 class TestBinary:
     @pytest.mark.parametrize(


### PR DESCRIPTION
This significantly speeds up JSON string decoding. Using some ideas borrowed from yyjson, as well as some general performance tricks, we:

- Use a new lookup table for determining interesting char values that require special handling.
- Have separate processing loops for ascii and unicode
- Split off the (less common) escape handling routine into a separate function.
- Manually unroll the string processing loops
- Apply an inline asm hack to get GCC to generate better code

Besides a faster string parsing inner loop, this also lets us determine if a string is all ascii characters for free. In this case, we skip calling `PyUnicode_DecodeUTF8` and instead manually create the new string object, further accelerating decoding.

In general, this results in:

- 2x speedup for decoding ascii-only strings
- 2x speedup for decoding ascii strings with escape characters (e.g. `\\n` -> `\n`)
- ~20% speedup for decoding strings containing non-ascii unicode characters