### PR TITLE
Rename `nogc` to `gc`

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -12,16 +12,13 @@ import pydantic
 import ujson
 
 
-NOGC = True
-
-
-class Address(msgspec.Struct, nogc=NOGC):
+class Address(msgspec.Struct, gc=False):
     street: str
     state: str
     zip: int
 
 
-class Person(msgspec.Struct, nogc=NOGC):
+class Person(msgspec.Struct, gc=False):
     first: str
     last: str
     age: int
@@ -30,13 +27,13 @@ class Person(msgspec.Struct, nogc=NOGC):
     email: Optional[str] = None
 
 
-class Address2(msgspec.Struct, array_like=True, nogc=NOGC):
+class Address2(msgspec.Struct, array_like=True, gc=False):
     street: str
     state: str
     zip: int
 
 
-class Person2(msgspec.Struct, array_like=True, nogc=NOGC):
+class Person2(msgspec.Struct, array_like=True, gc=False):
     first: str
     last: str
     age: int

--- a/benchmarks/bench_gc.py
+++ b/benchmarks/bench_gc.py
@@ -48,7 +48,7 @@ class Point(msgspec.Struct):
     z: int
 
 
-class PointNoGC(msgspec.Struct, nogc=True):
+class PointGCFalse(msgspec.Struct, gc=False):
     x: int
     y: int
     z: int
@@ -108,7 +108,7 @@ def main():
         ("standard class", PointClass),
         ("standard class with __slots__", PointClassSlots),
         ("msgspec struct", Point),
-        ("msgspec struct with nogc=True", PointNoGC),
+        ("msgspec struct with gc=False", PointGCFalse),
     ]:
         print(f"Benchmarking {name}...")
         gc_time, mibytes = bench_gc(cls)

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -208,7 +208,7 @@ Benchmark - Garbage Collection
 
 `msgspec.Struct` instances implement several optimizations for reducing garbage
 collection (GC) pressure and decreasing memory usage. Here we benchmark structs
-(with and without :ref:`nogc=True <struct-nogc>`) against standard Python
+(with and without :ref:`gc=False <struct-gc>`) against standard Python
 classes (with and without `__slots__
 <https://docs.python.org/3/reference/datamodel.html#slots>`__).
 
@@ -232,7 +232,7 @@ The `full benchmark source can be found here
 +-----------------------------------+--------------+-------------------+
 | **msgspec struct**                | 13.96        | 120.11            |
 +-----------------------------------+--------------+-------------------+
-| **msgspec struct with nogc=True** | 1.07         | 104.85            |
+| **msgspec struct with gc=False**  | 1.07         | 104.85            |
 +-----------------------------------+--------------+-------------------+
 
 - Standard Python classes are the most memory hungry (since all data is stored
@@ -247,7 +247,7 @@ The `full benchmark source can be found here
   ``__slots__`` (and thus have the same memory usage), but due to deferred GC
   tracking a full GC pass completes in a fraction of the time.
 
-- `msgspec.Struct` instances with ``nogc=True`` have the lowest memory usage
+- `msgspec.Struct` instances with ``gc=False`` have the lowest memory usage
   (lack of GC reduces memory by 16 bytes per instance). They also have the
   lowest GC pause (75x faster than standard classes!) since the entire
   composing dict can be skipped during GC traversal.

--- a/docs/source/perf-tips.rst
+++ b/docs/source/perf-tips.rst
@@ -240,7 +240,7 @@ benefit from using it instead of JSON. And since ``msgspec`` supports both
 protocols with a consistent interface, switching from ``msgspec.json`` to
 ``msgspec.msgpack`` should be fairly painless.
 
-Use ``nogc=True``
+Use ``gc=False``
 -----------------
 
 Python processes with a large number of long-lived objects, or operations that
@@ -249,9 +249,9 @@ to Python's garbage collector (GC). By default, `msgspec.Struct` types
 implement a few optimizations to reduce the load on the GC (and thus reduce the
 frequency and duration of a GC pause). If you find that GC is still a problem,
 and **are certain** that your Struct types may never participate in a reference
-cycle, then you **may** benefit from setting ``nogc=True`` on your Struct
+cycle, then you **may** benefit from setting ``gc=False`` on your Struct
 types.  Depending on workload, this can result in a measurable decrease in
-pause time and frequency due to GC passes. See :ref:`struct-nogc` for more
+pause time and frequency due to GC passes. See :ref:`struct-gc` for more
 details.
 
 Use ``array_like=True``

--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -606,7 +606,7 @@ has a signature similar to `dataclasses.make_dataclass`. See
     Point(x=1.0, y=2.0)
 
 
-.. _struct-nogc:
+.. _struct-gc:
 
 Disabling Garbage Collection (Advanced)
 ---------------------------------------
@@ -654,23 +654,23 @@ structs referencing containers (lists, dicts, structs, ...) will.
 
 If you *are certain* that your struct types can *never* participate in a
 reference cycle, you *may* find a :ref:`performance boost
-<struct-gc-benchmark>` from setting ``nogc=True`` on a struct definition. This
+<struct-gc-benchmark>` from setting ``gc=False`` on a struct definition. This
 boost is tricky to measure in isolation, since it should only result in the
 garbage collector not running as frequently - an integration benchmark is
 recommended to determine if this is worthwhile for your workload. A workload is
 likely to benefit from this optimization in the following situations:
 
 - You're allocating a lot of struct objects at once (for example, decoding a
-  large object). Setting ``nogc=True`` on these types will reduce the
+  large object). Setting ``gc=False`` on these types will reduce the
   likelihood of a GC pass occurring while decoding, improving application
   latency.
-- You have a large number of long-lived struct objects. Setting ``nogc=True``
+- You have a large number of long-lived struct objects. Setting ``gc=False``
   on these types will reduce the load on the GC during collection cycles of
   later generations.
 
-Struct types with ``nogc=True`` will never be tracked, even if they reference
+Struct types with ``gc=False`` will never be tracked, even if they reference
 container types. It is your responsibility to ensure cycles with these objects
-don't occur, as a cycle containing only ``nogc=True`` structs will *never* be
+don't occur, as a cycle containing only ``gc=False`` structs will *never* be
 collected (leading to a memory leak).
 
 .. _type annotations: https://docs.python.org/3/library/typing.html

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -48,7 +48,7 @@ class Struct(metaclass=__StructMeta):
         eq: bool = True,
         order: bool = False,
         array_like: bool = False,
-        nogc: bool = False,
+        gc: bool = True,
     ) -> None: ...
 
 def defstruct(
@@ -68,7 +68,7 @@ def defstruct(
     eq: bool = True,
     order: bool = False,
     array_like: bool = False,
-    nogc: bool = False,
+    gc: bool = True,
 ) -> Type[Struct]: ...
 
 # Lie and say `Raw` is a subclass of `bytes`, so mypy will accept it in most

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -119,8 +119,8 @@ def check_struct_order() -> None:
     reveal_type(t.y)  # assert "str" in typ
 
 
-def check_struct_nogc() -> None:
-    class Test(msgspec.Struct, nogc=True):
+def check_struct_gc() -> None:
+    class Test(msgspec.Struct, gc=False):
         x: int
         y: str
 
@@ -224,7 +224,7 @@ def check_defstruct_config_options() -> None:
         order=True,
         eq=True,
         array_like=True,
-        nogc=True,
+        gc=False,
         tag="mytag",
         tag_field="mytagfield",
         rename="lower"

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1932,8 +1932,8 @@ class TestStruct:
         assert not gc.is_tracked(e)
 
     @pytest.mark.parametrize("array_like", [False, True])
-    def test_struct_nogc_always_untracked_on_decode(self, array_like):
-        class Test(msgspec.Struct, array_like=array_like, nogc=True):
+    def test_struct_gc_false_always_untracked_on_decode(self, array_like):
+        class Test(msgspec.Struct, array_like=array_like, gc=False):
             x: Any
             y: Any
 

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -1584,8 +1584,8 @@ class TestStruct:
         assert not gc.is_tracked(e)
 
     @pytest.mark.parametrize("array_like", [False, True])
-    def test_struct_nogc_always_untracked_on_decode(self, array_like):
-        class Test(msgspec.Struct, array_like=array_like, nogc=True):
+    def test_struct_gc_false_always_untracked_on_decode(self, array_like):
+        class Test(msgspec.Struct, array_like=array_like, gc=False):
             x: Any
             y: Any
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -563,26 +563,24 @@ def test_struct_gc_not_added_if_not_needed():
     assert not gc.is_tracked(t)
 
 
-class TestNoGC:
-    """nogc structs are never tracked, even if they reference a container type"""
-
+class TestStructGC:
     def test_memory_layout(self):
         sizes = {}
-        for nogc in [False, True]:
+        for has_gc in [False, True]:
 
-            class Test(Struct, nogc=nogc):
+            class Test(Struct, gc=has_gc):
                 x: object
                 y: object
 
-            sizes[nogc] = sys.getsizeof(Test(1, 2))
+            sizes[has_gc] = sys.getsizeof(Test(1, 2))
 
-        # Currently nogc structs are 16 bytes smaller than gc structs, but
-        # that's a cpython implementation detail. This test is mainly to check
-        # that the smaller layout is being actually used.
-        assert sizes[True] < sizes[False]
+        # Currently gc=False structs are 16 bytes smaller than gc=True structs,
+        # but that's a cpython implementation detail. This test is mainly to
+        # check that the smaller layout is being actually used.
+        assert sizes[False] < sizes[True]
 
     def test_init(self):
-        class Test(Struct, nogc=True):
+        class Test(Struct, gc=False):
             x: object
             y: object
 
@@ -591,7 +589,7 @@ class TestNoGC:
         assert not gc.is_tracked(Test(1, [1, 2, 3]))
 
     def test_setattr(self):
-        class Test(Struct, nogc=True):
+        class Test(Struct, gc=False):
             x: object
             y: object
 
@@ -601,11 +599,11 @@ class TestNoGC:
         t.x = []
         assert not gc.is_tracked(t)
 
-    def test_nogc_inherit_from_gc(self):
+    def test_gc_false_inherit_from_gc_true(self):
         class HasGC(Struct):
             x: object
 
-        class NoGC(HasGC, nogc=True):
+        class NoGC(HasGC, gc=False):
             y: object
 
         assert gc.is_tracked(HasGC([]))
@@ -616,11 +614,11 @@ class TestNoGC:
         x.y = []
         assert not gc.is_tracked(x)
 
-    def test_gc_inherit_from_nogc(self):
-        class NoGC(Struct, nogc=True):
+    def test_gc_true_inherit_from_gc_false(self):
+        class NoGC(Struct, gc=False):
             y: object
 
-        class HasGC(NoGC, nogc=False):
+        class HasGC(NoGC, gc=True):
             x: object
 
         assert gc.is_tracked(HasGC(1, []))
@@ -630,38 +628,36 @@ class TestNoGC:
         x.x = []
         assert gc.is_tracked(x)
 
+    @pytest.mark.parametrize("has_gc", [False, True])
+    def test_struct_gc_set_on_copy(self, has_gc):
+        """Copying doesn't go through the struct constructor"""
 
-@pytest.mark.parametrize("nogc", [False, True])
-def test_struct_gc_set_on_copy(nogc):
-    """Copying doesn't go through the struct constructor"""
+        class Test(Struct, gc=has_gc):
+            x: object
+            y: object
 
-    class Test(Struct, nogc=nogc):
-        x: object
-        y: object
+        assert not gc.is_tracked(copy.copy(Test(1, 2)))
+        assert not gc.is_tracked(copy.copy(Test(1, ())))
+        assert gc.is_tracked(copy.copy(Test(1, []))) == has_gc
 
-    assert not gc.is_tracked(copy.copy(Test(1, 2)))
-    assert not gc.is_tracked(copy.copy(Test(1, ())))
-    assert gc.is_tracked(copy.copy(Test(1, []))) == (not nogc)
+    @pytest.mark.parametrize("has_gc", [False, True])
+    def test_struct_finalizer_called(self, has_gc):
+        """Check that structs dealloc properly calls __del__"""
 
+        called = False
 
-@pytest.mark.parametrize("nogc", [False, True])
-def test_struct_finalizer_called(nogc):
-    """Check that structs dealloc properly calls __del__"""
+        class Test(Struct, gc=has_gc):
+            x: int
+            y: int
 
-    called = False
+            def __del__(self):
+                nonlocal called
+                called = True
 
-    class Test(Struct, nogc=nogc):
-        x: int
-        y: int
+        t = Test(1, 2)
+        del t
 
-        def __del__(self):
-            nonlocal called
-            called = True
-
-    t = Test(1, 2)
-    del t
-
-    assert called
+        assert called
 
 
 class MyStruct(Struct):
@@ -709,7 +705,7 @@ def test_struct_handles_missing_attributes():
         ("order", False),
         ("eq", True),
         ("array_like", False),
-        ("nogc", False),
+        ("gc", True),
         ("omit_defaults", False),
     ],
 )
@@ -1195,7 +1191,7 @@ class TestDefStruct:
             ("order", False),
             ("eq", True),
             ("array_like", False),
-            ("nogc", False),
+            ("gc", True),
         ],
     )
     def test_defstruct_bool_options(self, option, default):


### PR DESCRIPTION
All other option names are `_` separated, so this should really be
`no_gc`. The double-negative feels unnecessary, it's cleaner just to
name this `gc`, defaulting to `gc=True`.

This is a breaking change, but afaik no one is really using this option
right now so a breaking change feels fine.