### PR TITLE
Don't accidentally include C source in built whl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     license="BSD",
     packages=["msgspec"],
     package_data={"msgspec": ["py.typed", "*.pyi"]},
-    include_package_data=True,
     ext_modules=ext_modules,
     long_description=(
         open("README.rst", encoding="utf-8").read()


### PR DESCRIPTION
The `include_package_data=True` flag was set (I think this was a
copy-paste from an example for distributing `.pyi` files in the
package). This option automatically includes all files in the source
tree in the built wheel as package data (including the original C
source). Since we alreay manually set `package_data`, the boolean flag
is unnecessary, and the C source adds a (comparatively) non-negligible
amount of data to the the built `whl`. No need to set this flag, and
removing it decreases the package size.