### PR TITLE
Add `weakref` support to Struct types

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -40,15 +40,16 @@ class Struct(metaclass=__StructMeta):
         cls,
         tag: Union[None, bool, str, Callable[[str], str]] = None,
         tag_field: Union[None, str] = None,
-        omit_defaults: bool = False,
         rename: Union[
             None, Literal["lower", "upper", "camel", "pascal"], Callable[[str], str]
         ] = None,
+        omit_defaults: bool = False,
         frozen: bool = False,
         eq: bool = True,
         order: bool = False,
         array_like: bool = False,
         gc: bool = True,
+        weakref: bool = False,
     ) -> None: ...
 
 def defstruct(
@@ -60,15 +61,16 @@ def defstruct(
     namespace: Optional[Dict[str, Any]] = None,
     tag: Union[None, bool, str, Callable[[str], str]] = None,
     tag_field: Union[None, str] = None,
-    omit_defaults: bool = False,
     rename: Union[
         None, Literal["lower", "upper", "camel", "pascal"], Callable[[str], str]
     ] = None,
+    omit_defaults: bool = False,
     frozen: bool = False,
     eq: bool = True,
     order: bool = False,
     array_like: bool = False,
     gc: bool = True,
+    weakref: bool = False,
 ) -> Type[Struct]: ...
 
 # Lie and say `Raw` is a subclass of `bytes`, so mypy will accept it in most

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -130,6 +130,17 @@ def check_struct_gc() -> None:
     reveal_type(t.y)  # assert "str" in typ
 
 
+def check_struct_weakref() -> None:
+    class Test(msgspec.Struct, weakref=True):
+        x: int
+        y: str
+
+    t = Test(1, "foo")
+    reveal_type(t)  # assert "Test" in typ
+    reveal_type(t.x)  # assert "int" in typ
+    reveal_type(t.y)  # assert "str" in typ
+
+
 def check_struct_tag_tag_field() -> None:
     class Test1(msgspec.Struct, tag=None):
         pass

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -680,7 +680,8 @@ class TestStructGC:
                     called = True
 
             t = Test(1, 2)
-            assert not gc.is_finalized(t)
+            if hasattr(gc, "is_finalized"):
+                assert not gc.is_finalized(t)
             del t
 
             assert called

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -6,7 +6,8 @@ import inspect
 import operator
 import pickle
 import sys
-from typing import Any
+import weakref
+from typing import Any, Optional
 
 import pytest
 
@@ -72,6 +73,15 @@ def test_struct_subclass_forbids_init_new_slots():
         class Test3(Struct):
             __slots__ = ("a",)
             a: int
+
+
+def test_struct_subclass_forbids_field_named_weakref():
+    with pytest.raises(
+        TypeError, match="Cannot have a struct field named '__weakref__'"
+    ):
+
+        class Test1(Struct):
+            __weakref__: int
 
 
 def test_struct_subclass_forbids_non_struct_bases():
@@ -640,24 +650,98 @@ class TestStructGC:
         assert not gc.is_tracked(copy.copy(Test(1, ())))
         assert gc.is_tracked(copy.copy(Test(1, []))) == has_gc
 
-    @pytest.mark.parametrize("has_gc", [False, True])
-    def test_struct_finalizer_called(self, has_gc):
-        """Check that structs dealloc properly calls __del__"""
-
-        called = False
-
-        class Test(Struct, gc=has_gc):
+    def test_struct_dealloc_decrefs_type(self):
+        class Test(Struct):
             x: int
             y: int
 
-            def __del__(self):
-                nonlocal called
-                called = True
-
+        orig = sys.getrefcount(Test)
         t = Test(1, 2)
+        temp = sys.getrefcount(Test)
+        assert temp == orig + 1
+        del t
+        new = sys.getrefcount(Test)
+        assert orig == new
+
+    @pytest.mark.parametrize("has_gc", [False, True])
+    def test_struct_dealloc_calls_finalizer(self, has_gc):
+        # We loop here (and in the resurrection test) to ensure that the
+        # `is_finalized` state isn't carried over through the freelist from a
+        # previously allocated struct.
+        for _ in range(3):
+            called = False
+
+            class Test(Struct, gc=has_gc):
+                x: int
+                y: int
+
+                def __del__(self):
+                    nonlocal called
+                    called = True
+
+            t = Test(1, 2)
+            assert not gc.is_finalized(t)
+            del t
+
+            assert called
+
+    @pytest.mark.parametrize("has_gc", [False, True])
+    def test_struct_dealloc_supports_finalizer_resurrection(self, has_gc):
+        for _ in range(3):
+            called = False
+            new_ref = None
+
+            class Test(Struct, gc=has_gc):
+                x: int
+                y: int
+
+                def __del__(self):
+                    # XXX: Python will only run `__del__` once, even if it's
+                    # resurrected FOR GC TYPES ONLY. If gc=False, cpython will
+                    # happily run `__del__` every time the refcount drops to 0
+                    nonlocal called
+                    nonlocal new_ref
+                    if not called:
+                        called = True
+                        new_ref = self
+
+            t = Test(1, 2)
+
+            del t
+            assert called
+            assert new_ref is not None
+            del new_ref
+
+    def test_struct_dealloc_trashcan(self):
+        call_count = 0
+
+        class Node(Struct):
+            child: "Optional[Node]" = None
+
+            def __del__(self):
+                nonlocal call_count
+                call_count += 1
+
+        node = None
+        for _ in range(100):
+            node = Node(node)
+
+        del node
+        assert call_count == 100
+
+    def test_struct_dealloc_weakref(self):
+        class Test(Struct, weakref=True):
+            x: int
+
+        t = Test(1)
+        # smoketest dealloc weakrefable struct doesn't crash
         del t
 
-        assert called
+        t = Test(1)
+        ref = weakref.ref(t)
+        assert ref() is not None
+        del t
+        assert ref() is None
 
 
 class MyStruct(Struct):
@@ -752,6 +836,43 @@ def test_struct_option_precedence(option, default):
         pass
 
     assert get(T) is False
+
+
+def test_weakref_option():
+    class Default(Struct):
+        pass
+
+    assert Default.__weakrefoffset__ == 0
+
+    class Enabled(Struct, weakref=True):
+        pass
+
+    assert Enabled.__weakrefoffset__ != 0
+
+    class Disabled(Struct, weakref=False):
+        pass
+
+    assert Disabled.__weakrefoffset__ == 0
+
+    class T(Enabled):
+        pass
+
+    assert T.__weakrefoffset__ != 0
+
+    class T(Enabled, Default):
+        pass
+
+    assert T.__weakrefoffset__ != 0
+
+    class T(Default, Disabled, Enabled):
+        pass
+
+    assert T.__weakrefoffset__ != 0
+
+    with pytest.raises(ValueError, match="Cannot set `weakref=False`"):
+
+        class T(Enabled, weakref=False):
+            pass
 
 
 def test_invalid_option_raises():
@@ -1203,6 +1324,16 @@ class TestDefStruct:
 
         Test = defstruct("Test", [])
         assert getattr(Test, option) is default
+
+    def test_defstruct_weakref(self):
+        Test = defstruct("Test", [])
+        assert Test.__weakrefoffset__ == 0
+
+        Test = defstruct("Test", [], weakref=False)
+        assert Test.__weakrefoffset__ == 0
+
+        Test = defstruct("Test", [], weakref=True)
+        assert Test.__weakrefoffset__ != 0
 
     def test_defstruct_tag_and_tag_field(self):
         Test = defstruct("Test", [], tag="mytag", tag_field="mytagfield")


### PR DESCRIPTION
This adds a new `weakref` config option for structs. If `True`, instances of the struct type will support weakrefs. Defaults to False.


This was requested by a user for quickle (https://github.com/jcrist/quickle/issues/63), which isn't actively maintained, but is the predecessor for `msgspec`. It was easy enough to add, and uncovered a few subtle bugs (fixed here):

- Fixes a bug when deallocating long chains of Struct instances, which requires trashcan support. Previously the freelist interactions were done outside of the TRASHCAN macros, which was incorrect.
- Fixes a bug where `Struct` types with a `__del__` method and GC support interacted poorly with the freelist, potentially causing reused instances to fail to run their `__del__` method.
