### PR TITLE
Support integer Struct tags

### DIFF
--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -334,11 +334,12 @@ A struct's tagging configuration is determined as follows.
   a union.
 
 - If a struct is tagged, ``tag`` defaults to the class name (e.g. ``"Get"``) if
-  not provided or inherited. This can be overridden by passing a tag value
-  explicitly (e.g. ``tag="get"``). or a callable from class name to ``str``
-  (e.g.  ``tag=lambda name: name.lower()`` to lowercase the class name
-  automatically). Note that the tag value must be unique for all struct types
-  in a union.
+  not provided or inherited. This can be overridden by passing a string (or
+  less commonly an integer) value explicitly (e.g. ``tag="get"``).  ``tag`` can
+  also be passed a callable that takes the class name and returns a valid tag
+  value (e.g. ``tag=str.lower``). Note that tag values must be unique for all
+  struct types in a union, and ``str`` and ``int`` tag types cannot both be
+  used within the same union.
 
 If you like subclassing, both ``tag_field`` and ``tag`` are inheritable by
 subclasses, allowing configuration to be set once on a base class and reused
@@ -353,7 +354,7 @@ for all struct types you wish to tag.
     >>> # Create a base class for tagged structs, where:
     ... # - the tag field is "op"
     ... # - the tag is the class name lowercased
-    ... class TaggedBase(msgspec.Struct, tag_field="op", tag=lambda name: name.lower()):
+    ... class TaggedBase(msgspec.Struct, tag_field="op", tag=str.lower):
     ...     pass
 
     >>> # Use the base class to pass on the configuration

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -338,7 +338,7 @@ or doesn't match any valid `enum.IntEnum` member.
     >>> msgspec.json.decode(b'4', type=JobState)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    msgspec.DecodeError: Invalid enum value `4`
+    msgspec.DecodeError: Invalid enum value 4
 
 ``Enum``
 ~~~~~~~~
@@ -565,7 +565,7 @@ values, or doesn't match any of their component types.
     >>> msgspec.json.decode(b'4', type=Literal[1, 2, 3])
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    msgspec.DecodeError: Invalid enum value `4`
+    msgspec.DecodeError: Invalid enum value 4
 
     >>> msgspec.json.decode(b'"bad"', type=Literal[1, 2, 3])
     Traceback (most recent call last):

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -38,7 +38,7 @@ class Struct(metaclass=__StructMeta):
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     def __init_subclass__(
         cls,
-        tag: Union[None, bool, str, Callable[[str], str]] = None,
+        tag: Union[None, bool, str, int, Callable[[str], Union[str, int]]] = None,
         tag_field: Union[None, str] = None,
         rename: Union[
             None, Literal["lower", "upper", "camel", "pascal"], Callable[[str], str]
@@ -59,7 +59,7 @@ def defstruct(
     bases: Tuple[Type[Struct], ...] = (),
     module: Optional[str] = None,
     namespace: Optional[Dict[str, Any]] = None,
-    tag: Union[None, bool, str, Callable[[str], str]] = None,
+    tag: Union[None, bool, str, int, Callable[[str], Union[str, int]]] = None,
     tag_field: Union[None, str] = None,
     rename: Union[
         None, Literal["lower", "upper", "camel", "pascal"], Callable[[str], str]

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -154,13 +154,19 @@ def check_struct_tag_tag_field() -> None:
     class Test4(msgspec.Struct, tag="mytag"):
         pass
 
-    class Test5(msgspec.Struct, tag=lambda n: n.lower()):
+    class Test5(msgspec.Struct, tag=123):
         pass
 
-    class Test6(msgspec.Struct, tag_field=None):
+    class Test6(msgspec.Struct, tag=str.lower):
         pass
 
-    class Test7(msgspec.Struct, tag_field="type"):
+    class Test7(msgspec.Struct, tag=lambda n: len(n)):
+        pass
+
+    class Test8(msgspec.Struct, tag_field=None):
+        pass
+
+    class Test9(msgspec.Struct, tag_field="type"):
         pass
 
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1040,6 +1040,9 @@ class TestTagAndTagField:
             # tag str
             ({"tag": "test"}, "type", "test"),
             (dict(tag="test", tag_field="kind"), "kind", "test"),
+            # tag int
+            ({"tag": 1}, "type", 1),
+            (dict(tag=1, tag_field="kind"), "kind", 1),
             # tag callable
             (dict(tag=lambda n: n.lower()), "type", "test"),
             (dict(tag=lambda n: n.lower(), tag_field="kind"), "kind", "test"),
@@ -1068,6 +1071,11 @@ class TestTagAndTagField:
             ({"tag": "test"}, {"tag": "test2"}, "type", "test2"),
             ({"tag": "test"}, {"tag": None}, "type", "test"),
             ({"tag": "test"}, {"tag_field": "foo"}, "foo", "test"),
+            # tag int
+            ({"tag": 1}, {}, "type", 1),
+            ({"tag": 1}, {"tag": "test2"}, "type", "test2"),
+            ({"tag": 1}, {"tag": None}, "type", 1),
+            ({"tag": 1}, {"tag_field": "foo"}, "foo", 1),
             # tag callable
             ({"tag": lambda n: n.lower()}, {}, "type", "s2"),
             ({"tag": lambda n: n.lower()}, {"tag": False}, None, None),
@@ -1087,7 +1095,14 @@ class TestTagAndTagField:
 
     @pytest.mark.parametrize("tag", [b"bad", lambda n: b"bad"])
     def test_tag_wrong_type(self, tag):
-        with pytest.raises(TypeError, match="`tag` must be a `str`"):
+        with pytest.raises(TypeError, match="`tag` must be a `str` or an `int`"):
+
+            class Test(Struct, tag=tag):
+                pass
+
+    @pytest.mark.parametrize("tag", [-(2**63) - 1, 2**63])
+    def test_tag_integer_out_of_range(self, tag):
+        with pytest.raises(ValueError, match="Integer `tag` values must be"):
 
             class Test(Struct, tag=tag):
                 pass


### PR DESCRIPTION
Previously tagged unions only supported `str` tag values. We now also
support `int` tag values, with a few caveats:

- A single `Union` of `Struct` types cannot mix both `int` and `str` tag
types.
- Integer `tag` values currently only support values that fit in an
int64 (``-2**63 <= tag <= 2**63 - 1``). This restriction has also been added
to `IntEnum` and integer `Literal` types (previously these supported up
to a `uint64`). This restriction makes the implementation easier, but
can be removed if needed in the future. For now a `NotImplementedError`
is raised if the user attempts to use out-of-range integer values,
pointing them to raise an issue on GitHub if they need the feature.

Fixes #134.