### PR TITLE
Forbid struct operations in `__init_subclass__`

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -3686,6 +3686,22 @@ StructMeta_prep_types(PyObject *py_self, bool err_not_json, bool *json_compatibl
         }
     }
 
+    if (MS_UNLIKELY(self->struct_fields == NULL)) {
+        /* The struct isn't fully initialized! This most commonly happens if
+         * the user tries to do anything inside a `__init_subclass__` method.
+         * Error nicely rather than segfaulting. */
+        PyErr_Format(
+            PyExc_ValueError,
+            "Type `%R` isn't fully defined, and can't be used in any "
+            "`Decoder`/`decode` operations. This commonly happens when "
+            "trying to use the struct type within an `__init_subclass__` "
+            "method. If you believe what you're trying to do should work, "
+            "please raise an issue on GitHub.",
+            py_self
+        );
+        return -1;
+    }
+
     /* Prevent recursion, clear on return */
     self->traversing = true;
 


### PR DESCRIPTION
`__init_subclass__` runs halfway through a type being defined.
Previously this meant that if a user defines a `Struct` subclass with an
`__init_subclass__` hook, that hook gets called before the `Struct` type
is fully defined, meaning that if the user trys to do any struct
operations with that class inside `__init_subclass__` a segfault could
occur.

Rather than splitting our struct definition routine into two parts
(with the second part running in a base `__init_subclass__` that any
users overriding `__init_subclass__` would need to remember to call), we
instead forbid struct operations on half-defined types. This shouldn't
cause any real issues for users, but prevents a possible segfault during
naive usage.

Fixes #73.