### PR TITLE
Support timezone-naive datetimes with enc_hook

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -375,10 +375,11 @@ isn't a string or doesn't match any valid `enum.Enum` member.
 ~~~~~~~~~~~~
 
 `datetime.datetime` values are serialized as RFC3339_ encoded strings in JSON,
-and the `timestamp extension`_ in MessagePack. Only `timezone aware
+and the `timestamp extension`_ in MessagePack. Only `timezone-aware
 <https://docs.python.org/3/library/datetime.html#aware-and-naive-objects>`__
-datetime objects are supported. During decoding, all timezones are normalized
-to UTC.
+datetime objects are supported by default (timezone-naive datetimes can be
+supported using an ``enc_hook``, see :doc:`extending`). During decoding, all
+timezones are normalized to UTC.
 
 .. code-block:: python
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -881,6 +881,25 @@ class TestDatetime:
         s = msgspec.json.encode(x)
         assert s == expected
 
+    def test_encode_datetime_no_tzinfo_errors_by_default(self):
+        x = datetime.datetime.now()
+        with pytest.raises(
+            TypeError, match="Encoding timezone-naive datetime objects is unsupported"
+        ):
+            msgspec.json.encode(x)
+
+    def test_encode_datetime_no_tzinfo_hits_enc_hook(self):
+        x = datetime.datetime.now()
+        res = msgspec.json.encode(x.replace(tzinfo=datetime.timezone.utc))
+
+        def enc_hook(obj):
+            if isinstance(obj, datetime.datetime):
+                return obj.replace(tzinfo=datetime.timezone.utc)
+            raise TypeError(str(type(obj)))
+
+        sol = msgspec.json.encode(x, enc_hook=enc_hook)
+        assert res == sol
+
     @pytest.mark.parametrize(
         "dt",
         [


### PR DESCRIPTION
Previously timezone-naive datetime objects would always error during
encoding. We now support encoding these through a custom ``enc_hook``
(the default is still to error). I _think_ this makes sense, but it's a
little weird since at the type level this means that only some
`datetime` objects will hit the `enc_hook`. If only python had two
different classes for representing timezone-aware and timezone-naive
datetimes.

Fixes #152.