### PR TITLE
Fixup TypedDict/NamedTuple error handling branch

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -4935,11 +4935,11 @@ TypedDictInfo_Convert(PyObject *obj, bool err_not_json, bool *json_compatible) {
 error:
     if (cache_set) {
         /* An error occurred after the cache was created and set on the
-         * TypedDict. We need to delete the attribute */
-        if (PyObject_DelAttr(obj, mod->str___msgspec_cache__) < 0) {
-            /* Ignore errors if deletion fails */
-            PyErr_Clear();
-        }
+         * TypedDict. We need to delete the attribute.
+         *
+         * No need for error checking, if deletion fails, we raise that error
+         * instead. */
+        PyObject_DelAttr(obj, mod->str___msgspec_cache__);
     }
     Py_XDECREF((PyObject *)info);
     Py_XDECREF(annotations);
@@ -5168,11 +5168,11 @@ cleanup:
         Py_CLEAR(info);
         if (cache_set) {
             /* An error occurred after the cache was created and set on the
-            * NamedTuple. We need to delete the attribute */
-            if (PyObject_DelAttr(obj, mod->str___msgspec_cache__) < 0) {
-                /* Ignore errors if deletion fails */
-                PyErr_Clear();
-            }
+            * NamedTuple. We need to delete the attribute 
+            *
+            * No need for error checking, if deletion fails, we raise that
+            * error instead. */
+            PyObject_DelAttr(obj, mod->str___msgspec_cache__);
         }
     }
     Py_XDECREF(annotations);


### PR DESCRIPTION
This fixes a small bug in the error handling for `TypeNode` creation for
`TypedDict`/`NamedTuple` types. The logic for creating these types goes:

- Create a new node
- Cache it on the object (the typeddict/namedtuple object itself)
- Populate the node

In the case of an error during the last step, an attempt is made to
delete the node from the object (since the type is invalid). Previously,
if an error occurred during `PyObject_DelAttr`, we'd clear the error and
continue. This would accidentally lead to no error being returned,
causing a `SystemError` later on.

This was definitely a bug, but I'm not sure why that delattr call would
fail here. I'm seeing a few rare flaky test failures that could have
been caused by this faulty logic, but I'm unable to reproduce the
failures locally. Pushing up this change now should result in a better
error message the next time it happens.