### PR TITLE
[UNTESTED] Add support for renaming to kebap-case

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -41,7 +41,9 @@ class Struct(metaclass=__StructMeta):
         tag: Union[None, bool, str, int, Callable[[str], Union[str, int]]] = None,
         tag_field: Union[None, str] = None,
         rename: Union[
-            None, Literal["lower", "upper", "kebap", "camel", "pascal"], Callable[[str], str]
+            None,
+            Literal["lower", "upper", "camel", "pascal", "kebab"],
+            Callable[[str], str],
         ] = None,
         omit_defaults: bool = False,
         frozen: bool = False,
@@ -62,7 +64,9 @@ def defstruct(
     tag: Union[None, bool, str, int, Callable[[str], Union[str, int]]] = None,
     tag_field: Union[None, str] = None,
     rename: Union[
-        None, Literal["lower", "upper", "kebap", "camel", "pascal"], Callable[[str], str]
+        None,
+        Literal["lower", "upper", "camel", "pascal", "kebab"],
+        Callable[[str], str],
     ] = None,
     omit_defaults: bool = False,
     frozen: bool = False,

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -41,7 +41,7 @@ class Struct(metaclass=__StructMeta):
         tag: Union[None, bool, str, int, Callable[[str], Union[str, int]]] = None,
         tag_field: Union[None, str] = None,
         rename: Union[
-            None, Literal["lower", "upper", "camel", "pascal"], Callable[[str], str]
+            None, Literal["lower", "upper", "kebap", "camel", "pascal"], Callable[[str], str]
         ] = None,
         omit_defaults: bool = False,
         frozen: bool = False,
@@ -62,7 +62,7 @@ def defstruct(
     tag: Union[None, bool, str, int, Callable[[str], Union[str, int]]] = None,
     tag_field: Union[None, str] = None,
     rename: Union[
-        None, Literal["lower", "upper", "camel", "pascal"], Callable[[str], str]
+        None, Literal["lower", "upper", "kebap", "camel", "pascal"], Callable[[str], str]
     ] = None,
     omit_defaults: bool = False,
     frozen: bool = False,

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -3208,6 +3208,11 @@ rename_upper(PyObject *field) {
 }
 
 static PyObject*
+rename_kebap(PyObject *field) {
+    return PyObject_CallMethod(field, "replace", "ss", "_", "-");
+}
+
+static PyObject*
 rename_camel_inner(PyObject *field, bool cap_first) {
     PyObject *parts = NULL, *out = NULL, *empty = NULL;
     PyObject *underscore = PyUnicode_FromStringAndSize("_", 1);
@@ -3276,6 +3281,9 @@ StructMeta_rename_fields(PyObject *fields, PyObject *rename)
         }
         else if (PyUnicode_CompareWithASCIIString(rename, "upper") == 0) {
             method = &rename_upper;
+        }
+        else if (PyUnicode_CompareWithASCIIString(rename, "kebap") == 0) {
+            method = &rename_kebap;
         }
         else if (PyUnicode_CompareWithASCIIString(rename, "camel") == 0) {
             method = &rename_camel;
@@ -4792,8 +4800,9 @@ PyDoc_STRVAR(Struct__doc__,
 "   information.\n"
 "rename: str, callable, or None, default None\n"
 "   Controls renaming the field names used when encoding/decoding the struct.\n"
-"   May be one of ``\"lower\"``, ``\"upper\"``, ``\"camel\"``, or ``\"pascal\"``\n"
-"   to rename in lowercase, UPPERCASE, camelCase, or PascalCase respectively\n"
+"   May be one of ``\"lower\"``, ``\"upper\"``, ``\"kebap\"``, ``\"camel\"``, or\n"
+"   ``\"pascal\"`` to rename in lowercase, UPPERCASE, kebap-case, camelCase, or\n"
+"   PascalCase respectively\n"
 "   Alternatively, may be a callable that takes a string (the field name) and\n"
 "   returns a new string. Default is ``None`` for no field renaming.\n"
 "array_like: bool, default False\n"

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -3208,8 +3208,20 @@ rename_upper(PyObject *field) {
 }
 
 static PyObject*
-rename_kebap(PyObject *field) {
-    return PyObject_CallMethod(field, "replace", "ss", "_", "-");
+rename_kebab(PyObject *field) {
+    PyObject *underscore = NULL, *dash = NULL, *temp = NULL, *out = NULL;
+    underscore = PyUnicode_FromStringAndSize("_", 1);
+    if (underscore == NULL) goto error;
+    dash = PyUnicode_FromStringAndSize("-", 1);
+    if (dash == NULL) goto error;
+    temp = PyObject_CallMethod(field, "strip", "s", "_");
+    if (temp == NULL) goto error;
+    out = PyUnicode_Replace(temp, underscore, dash, -1);
+error:
+    Py_XDECREF(underscore);
+    Py_XDECREF(dash);
+    Py_XDECREF(temp);
+    return out;
 }
 
 static PyObject*
@@ -3282,14 +3294,14 @@ StructMeta_rename_fields(PyObject *fields, PyObject *rename)
         else if (PyUnicode_CompareWithASCIIString(rename, "upper") == 0) {
             method = &rename_upper;
         }
-        else if (PyUnicode_CompareWithASCIIString(rename, "kebap") == 0) {
-            method = &rename_kebap;
-        }
         else if (PyUnicode_CompareWithASCIIString(rename, "camel") == 0) {
             method = &rename_camel;
         }
         else if (PyUnicode_CompareWithASCIIString(rename, "pascal") == 0) {
             method = &rename_pascal;
+        }
+        else if (PyUnicode_CompareWithASCIIString(rename, "kebab") == 0) {
+            method = &rename_kebab;
         }
         else {
             PyErr_Format(PyExc_ValueError, "rename='%U' is unsupported", rename);
@@ -4800,11 +4812,11 @@ PyDoc_STRVAR(Struct__doc__,
 "   information.\n"
 "rename: str, callable, or None, default None\n"
 "   Controls renaming the field names used when encoding/decoding the struct.\n"
-"   May be one of ``\"lower\"``, ``\"upper\"``, ``\"kebap\"``, ``\"camel\"``, or\n"
-"   ``\"pascal\"`` to rename in lowercase, UPPERCASE, kebap-case, camelCase, or\n"
-"   PascalCase respectively\n"
-"   Alternatively, may be a callable that takes a string (the field name) and\n"
-"   returns a new string. Default is ``None`` for no field renaming.\n"
+"   May be one of ``\"lower\"``, ``\"upper\"``, ``\"camel\"``, ``\"pascal\"``, or\n"
+"   ``\"kebab\"`` to rename in lowercase, UPPERCASE, camelCase, PascalCase,\n"
+"   or kebab-case respectively. Alternatively, may be a callable that takes a\n"
+"   string (the field name) and returns a new string. Default is ``None`` for\n"
+"   no field renaming.\n"
 "array_like: bool, default False\n"
 "   If True, this struct type will be treated as an array-like type during\n"
 "   encoding/decoding, rather than a dict-like type (the default). This may\n"

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -53,6 +53,9 @@ def check_struct_rename() -> None:
     class TestPascal(msgspec.Struct, rename="pascal"):
         x: int
 
+    class TestKebab(msgspec.Struct, rename="kebab"):
+        x: int
+
     class TestCallable(msgspec.Struct, rename=lambda x: x.title()):
         x: int
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1254,23 +1254,30 @@ class TestRename:
 
         assert Test.__struct_encode_fields__ == ("FIELD_ONE", "FIELD_TWO")
 
-    def test_rename_kebap(self):
-        class Test(Struct, rename="kebap"):
+    def test_rename_kebab(self):
+        class Test(Struct, rename="kebab"):
             field_one: int
-            field_two: str
+            field_two_with_suffix: str
+            __field_three__: bool
+            field4: float
 
-        assert Test.__struct_encode_fields__ == ("field_one", "field-one")
+        assert Test.__struct_encode_fields__ == (
+            "field-one",
+            "field-two-with-suffix",
+            "field-three",
+            "field4",
+        )
 
     def test_rename_camel(self):
         class Test(Struct, rename="camel"):
             field_one: int
-            field_two: str
+            field_two_with_suffix: str
             __field__three__: bool
             field4: float
 
         assert Test.__struct_encode_fields__ == (
             "fieldOne",
-            "fieldTwo",
+            "fieldTwoWithSuffix",
             "fieldThree",
             "field4",
         )
@@ -1278,13 +1285,13 @@ class TestRename:
     def test_rename_pascal(self):
         class Test(Struct, rename="pascal"):
             field_one: int
-            field_two: str
+            field_two_with_suffix: str
             __field__three__: bool
             field4: float
 
         assert Test.__struct_encode_fields__ == (
             "FieldOne",
-            "FieldTwo",
+            "FieldTwoWithSuffix",
             "FieldThree",
             "Field4",
         )

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1254,6 +1254,13 @@ class TestRename:
 
         assert Test.__struct_encode_fields__ == ("FIELD_ONE", "FIELD_TWO")
 
+    def test_rename_kebap(self):
+        class Test(Struct, rename="kebap"):
+            field_one: int
+            field_two: str
+
+        assert Test.__struct_encode_fields__ == ("field_one", "field-one")
+
     def test_rename_camel(self):
         class Test(Struct, rename="camel"):
             field_one: int


### PR DESCRIPTION
Hi,

this should implement builtin renaming to kebap-case.  I didn't test the code due to me virtually never working with Python and less with its C API, so it'd be good if someone else tested it.  Also, I only added one test case where I saw fit/understood the testing harness, more could be added but I wouldn't know how.

