### PR TITLE
Disable codecov patch status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,4 @@ coverage:
       default:
         target: auto
         threshold: 1%
-    patch:
-      default:
-        target: auto
-        threshold: 1%
+    patch: off


### PR DESCRIPTION
This has been a false failure more often than it has been useful (not
sure why). Since I mostly want coverage for introspection not for actual
CI checks, I'm disabling this for now.