### PR TITLE
Support mappings for `rename`

### DIFF
--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -468,8 +468,11 @@ To handle this, ``msgspec`` supports a ``rename`` configuration option in
 - ``"upper"``: uppercase all fields (``EXAMPLE_FIELD``)
 - ``"camel"``: camelCase all fields (``exampleField``)
 - ``"pascal"``: PascalCase all fields (``ExampleField``)
-- A callable (signature ``rename(name: str) -> str``) to use to rename all
-  field names
+- A mapping from field names to the renamed names. Field names missing from the
+  mapping will not be renamed.
+- A callable (signature ``rename(name: str) -> Optional[str]``) to use to
+  rename all field names. Note that ``None`` for a return value indicates the
+  original field name should be used.
 
 The renamed field names are used for encoding and decoding only, any python
 code will still refer to them using their original names.
@@ -519,8 +522,8 @@ generating `Struct` types to match an existing API.
         ...
     }
 
-    # Pass `.get` method to `rename` to explicitly rename all fields
-    class V1PodSpec(msgspec.Struct, rename=v1podspec_names.get):
+    # Pass the mapping to `rename` to explicitly rename all fields
+    class V1PodSpec(msgspec.Struct, rename=v1podspec_names):
         ...
         service_account_name: str = ""
         set_hostname_as_fqdn: bool = False

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -1,17 +1,18 @@
 from typing import (
-    Type,
-    Callable,
-    Dict,
-    Tuple,
-    Iterable,
-    Optional,
     Any,
-    Union,
-    TypeVar,
+    Callable,
     ClassVar,
-    Literal,
-    overload,
+    Dict,
     Final,
+    Iterable,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
 )
 
 # Use `__dataclass_transform__` to catch more errors under pyright. Since we don't expose
@@ -44,7 +45,8 @@ class Struct(metaclass=__StructMeta):
         rename: Union[
             None,
             Literal["lower", "upper", "camel", "pascal", "kebab"],
-            Callable[[str], str],
+            Callable[[str], Optional[str]],
+            Mapping[str, str],
         ] = None,
         omit_defaults: bool = False,
         frozen: bool = False,
@@ -68,7 +70,8 @@ def defstruct(
     rename: Union[
         None,
         Literal["lower", "upper", "camel", "pascal", "kebab"],
-        Callable[[str], str],
+        Callable[[str], Optional[str]],
+        Mapping[str, str],
     ] = None,
     omit_defaults: bool = False,
     frozen: bool = False,

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -59,6 +59,12 @@ def check_struct_rename() -> None:
     class TestCallable(msgspec.Struct, rename=lambda x: x.title()):
         x: int
 
+    class TestCallableNone(msgspec.Struct, rename=lambda x: None):
+        x: int
+
+    class TestMapping(msgspec.Struct, rename={"x": "X"}):
+        x: int
+
     class TestNone(msgspec.Struct, rename=None):
         x: int
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1319,15 +1319,30 @@ class TestRename:
 
         assert Test.__struct_encode_fields__ == ("Field_One", "Field_Two")
 
+    def test_rename_callable_returns_none(self):
+        class Test(Struct, rename={"from_": "from"}.get):
+            from_: str
+            to: str
+
+        assert Test.__struct_encode_fields__ == ("from", "to")
+
     def test_rename_callable_returns_non_string(self):
         with pytest.raises(
-            TypeError, match="Expected calling `rename` to return a `str`, got `int`"
+            TypeError,
+            match="Expected calling `rename` to return a `str` or `None`, got `int`",
         ):
 
             class Test(Struct, rename=lambda x: 1):
                 aa1: int
                 aa2: int
                 ab1: int
+
+    def test_rename_mapping(self):
+        class Test(Struct, rename={"from_": "from"}):
+            from_: str
+            to: str
+
+        assert Test.__struct_encode_fields__ == ("from", "to")
 
     def test_rename_bad_value(self):
         with pytest.raises(ValueError, match="rename='invalid' is unsupported"):
@@ -1336,7 +1351,7 @@ class TestRename:
                 x: int
 
     def test_rename_bad_type(self):
-        with pytest.raises(TypeError, match="str or a callable"):
+        with pytest.raises(TypeError, match="str, callable, or mapping"):
 
             class Test(Struct, rename=1):
                 x: int


### PR DESCRIPTION
This adds support for passing either a `Mapping[str, str]` or a callable of signature `Callable[[str], Optional[str]]` (the `Optional` is the new bit) to `rename`. This makes it easier to only rename a few fields in a struct, as the rename function doesn't need to handle every field.

Simplifies the use case described in #182.