### PR TITLE
Add missing type hint for __match_args__

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -37,6 +37,7 @@ class __StructMeta(type):
 
 class Struct(metaclass=__StructMeta):
     __struct_fields__: ClassVar[Tuple[str, ...]]
+    __match_args__: ClassVar[Tuple[str, ...]]
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     def __init_subclass__(
         cls,

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -205,6 +205,9 @@ def check_struct_attributes() -> None:
     for field in Point.__struct_fields__:
         reveal_type(field)  # assert "str" in typ
 
+    for field in Point.__match_args__:
+        reveal_type(field)  # assert "any" not in typ.lower()
+
     p = Point(1, 2)
 
     for field in p.__struct_fields__:


### PR DESCRIPTION
`__match_args__` has long been supported for struct types, but the type hint in the corresponding `.pyi` file was missing, causing mypy/pyright to complain when using match-case statements on struct types.