### PR TITLE
Work around mypy limitations

### DIFF
--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -33,6 +33,7 @@ class Encoder:
 class Decoder(Generic[T]):
     type: Type[T]
     dec_hook: dec_hook_sig
+
     @overload
     def __init__(
         self: Decoder[Any],
@@ -43,6 +44,13 @@ class Decoder(Generic[T]):
     def __init__(
         self: Decoder[T],
         type: Type[T] = ...,
+        *,
+        dec_hook: dec_hook_sig = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: Decoder[Any],
+        type: Any = ...,
         *,
         dec_hook: dec_hook_sig = None,
     ) -> None: ...
@@ -61,6 +69,13 @@ def decode(
     type: Type[T] = ...,
     dec_hook: dec_hook_sig = None,
 ) -> T: ...
+@overload
+def decode(
+    buf: bytes,
+    *,
+    type: Any = ...,
+    dec_hook: dec_hook_sig = None,
+) -> Any: ...
 def encode(obj: Any, *, enc_hook: enc_hook_sig = None) -> bytes: ...
 def schema(type: Any) -> Dict[str, Any]: ...
 def schema_components(

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -32,6 +32,14 @@ class Decoder(Generic[T]):
         dec_hook: dec_hook_sig = None,
         ext_hook: ext_hook_sig = None,
     ) -> None: ...
+    @overload
+    def __init__(
+        self: Decoder[Any],
+        type: Any = ...,
+        *,
+        dec_hook: dec_hook_sig = None,
+        ext_hook: ext_hook_sig = None,
+    ) -> None: ...
     def decode(self, data: bytes) -> T: ...
 
 class Encoder:
@@ -63,4 +71,12 @@ def decode(
     dec_hook: dec_hook_sig = None,
     ext_hook: ext_hook_sig = None,
 ) -> T: ...
+@overload
+def decode(
+    buf: bytes,
+    *,
+    type: Any = ...,
+    dec_hook: dec_hook_sig = None,
+    ext_hook: ext_hook_sig = None,
+) -> Any: ...
 def encode(obj: Any, *, enc_hook: enc_hook_sig = None) -> bytes: ...

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -1,7 +1,9 @@
 # fmt: off
+from __future__ import annotations
+
 import datetime
 import pickle
-from typing import List, Any, Type
+from typing import List, Any, Type, Union
 import msgspec
 
 def check___version__() -> None:
@@ -391,6 +393,14 @@ def check_msgpack_Decoder_decode_typed() -> None:
     reveal_type(o)  # assert ("List" in typ or "list" in typ) and "int" in typ
 
 
+def check_msgpack_Decoder_decode_union() -> None:
+    # Pyright doesn't require the annotation, but mypy does until TypeForm
+    # is supported. This is mostly checking that no error happens here.
+    dec: msgspec.msgpack.Decoder[Union[int, str]] = msgspec.msgpack.Decoder(Union[int, str])
+    o = dec.decode(b'')
+    reveal_type(o)  # assert ("int" in typ and "str" in typ)
+
+
 def check_msgpack_Decoder_decode_type_comment() -> None:
     dec = msgspec.msgpack.Decoder()  # type: msgspec.msgpack.Decoder[List[int]]
     b = msgspec.msgpack.encode([1, 2, 3])
@@ -412,6 +422,11 @@ def check_msgpack_decode_typed() -> None:
     o = msgspec.msgpack.decode(b, type=List[int])
 
     reveal_type(o)  # assert ("List" in typ or "list" in typ) and "int" in typ
+
+
+def check_msgpack_decode_typed_union() -> None:
+    o: Union[int, str] = msgspec.msgpack.decode(b"", type=Union[int, str])
+    reveal_type(o)  # assert "int" in typ and "str" in typ
 
 
 def check_msgpack_encode_enc_hook() -> None:
@@ -495,6 +510,12 @@ def check_json_Decoder_decode_type_comment() -> None:
     reveal_type(o)  # assert ("List" in typ or "list" in typ) and "int" in typ
 
 
+def check_json_Decoder_decode_union() -> None:
+    dec: msgspec.json.Decoder[Union[int, str]] = msgspec.json.Decoder(Union[int, str])
+    o = dec.decode(b'')
+    reveal_type(o)  # assert ("int" in typ and "str" in typ)
+
+
 def check_json_decode_any() -> None:
     b = msgspec.json.encode([1, 2, 3])
     o = msgspec.json.decode(b)
@@ -507,6 +528,11 @@ def check_json_decode_typed() -> None:
     o = msgspec.json.decode(b, type=List[int])
 
     reveal_type(o)  # assert ("List" in typ or "list" in typ) and "int" in typ
+
+
+def check_json_decode_typed_union() -> None:
+    o: Union[int, str] = msgspec.json.decode(b"", type=Union[int, str])
+    reveal_type(o)  # assert "int" in typ and "str" in typ
 
 
 def check_json_encode_enc_hook() -> None:


### PR DESCRIPTION
Currently mypy doesn't interpret things other than classes as being compatible with `Type[T]` (they literally have to be instances of `type`). This makes it hard to properly type the `decode` methods or `Decoder` constructors, as passing type-like-things (e.g. `Union[int, str]`) will error under mypy. `pyright` doesn't have this limitation.

For now we add a fallback `overload` to these methods that infers the decoder type as `Decoder[Any]`. This means that `mypy` will no longer error, but will require an explicit annotation to infer the type of the output of `decode`.

If/once the `TypeForm` PEP lands, this hack can be removed. Until then `pyright` support for these annotations will be much better than `mypy` support.

Fixes #173.