### PR TITLE
enable 3.11 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     env:
       CIBW_TEST_REQUIRES: "pytest msgpack"
       CIBW_TEST_COMMAND: "pytest {project}/tests"
-      CIBW_BUILD: "cp38-* cp39-* cp310-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
       CIBW_SKIP: "*-win32 *_i686 *_s390x *_ppc64le"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "x86_64 aarch64"
@@ -96,14 +96,8 @@ jobs:
         run: |
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64" >> $GITHUB_ENV
 
-      - name: Enable CPython 3.11 prerelease builds for Linux testing
-        if: github.event_name != 'release' && runner.os == 'Linux'
-        run: |
-            echo "CIBW_PRERELEASE_PYTHONS=True" >> $GITHUB_ENV
-            echo "CIBW_BUILD=cp38-* cp39-* cp310-* cp311-*" >> $GITHUB_ENV
-
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.8.0
+        uses: pypa/cibuildwheel@v2.11.2
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     license="BSD",
     packages=["msgspec"],


### PR DESCRIPTION
Updates CI and build script to build 3.11 release builds rather than using the 3.11 pre-releases.