### PR TITLE
breaking: Encode/decode all enums by value.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -319,60 +319,6 @@ type in MessagePack.
     >>> msgspec.json.decode(msg, type=bytearray)
     bytearray(b'\xf0\x9d\x84\x9e')
 
-``IntEnum``
-~~~~~~~~~~~
-
-`enum.IntEnum` types encode as their integer *values* in both JSON and
-MessagePack. An error is raised during decoding if the value isn't an integer,
-or doesn't match any valid `enum.IntEnum` member.
-
-.. code-block:: python
-
-    >>> import enum
-
-    >>> class JobState(enum.IntEnum):
-    ...     CREATED = 0
-    ...     RUNNING = 1
-    ...     SUCCEEDED = 2
-    ...     FAILED = 3
-
-    >>> msgspec.json.encode(JobState.RUNNING)
-    b'1'
-
-    >>> msgspec.json.decode(b'2', type=JobState)
-    <JobState.SUCCEEDED: 2>
-
-    >>> msgspec.json.decode(b'4', type=JobState)
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    msgspec.ValidationError: Invalid enum value 4
-
-``Enum``
-~~~~~~~~
-
-`enum.Enum` types encode as strings of the member *names* (not their values) in
-both JSON and MessagePack. An error is raised during decoding if the value
-isn't a string or doesn't match any valid `enum.Enum` member.
-
-.. code-block:: python
-
-    >>> import enum
-
-    >>> class Fruit(enum.Enum):
-    ...     APPLE = "apple value"
-    ...     BANANA = "banana value"
-
-    >>> msgspec.json.encode(Fruit.APPLE)
-    b'"APPLE"'
-
-    >>> msgspec.json.decode(b'"APPLE"', type=Fruit)
-    <Fruit.APPLE: 'apple value'>
-
-    >>> msgspec.json.decode(b'"GRAPE"', type=Fruit)
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    msgspec.ValidationError: Invalid enum value 'GRAPE'
-
 ``datetime``
 ~~~~~~~~~~~~
 
@@ -633,6 +579,50 @@ fields have their defaults applied. Type checking also still applies.
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `str`, got `int` - at `$[1][1]`
+
+``Enum`` / ``IntEnum``
+~~~~~~~~~~~~~~~~~~~~~~
+
+`enum.Enum` and `enum.IntEnum` types encode as their member *values* in both
+JSON and MessagePack. Only enums composed of all string or all integer values
+are supported. An error is raised during decoding if the value isn't the proper
+type, or doesn't match any valid member.
+
+.. code-block:: python
+
+    >>> import enum
+
+    >>> class Fruit(enum.Enum):
+    ...     APPLE = "apple"
+    ...     BANANA = "banana"
+
+    >>> msgspec.json.encode(Fruit.APPLE)
+    b'"apple"'
+
+    >>> msgspec.json.decode(b'"apple"', type=Fruit)
+    <Fruit.APPLE: 'apple'>
+
+    >>> msgspec.json.decode(b'"grape"', type=Fruit)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Invalid enum value 'grape'
+
+    >>> class JobState(enum.IntEnum):
+    ...     CREATED = 0
+    ...     RUNNING = 1
+    ...     SUCCEEDED = 2
+    ...     FAILED = 3
+
+    >>> msgspec.json.encode(JobState.RUNNING)
+    b'1'
+
+    >>> msgspec.json.decode(b'2', type=JobState)
+    <JobState.SUCCEEDED: 2>
+
+    >>> msgspec.json.decode(b'4', type=JobState)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Invalid enum value 4
 
 ``Literal``
 ~~~~~~~~~~~

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -447,10 +447,7 @@ class SchemaBuilder:
             schema.setdefault("title", t.__name__)
             if has_nondefault_docstring(t):
                 schema.setdefault("description", t.__doc__)
-            if issubclass(t, enum.IntEnum):
-                schema["enum"] = sorted(int(e) for e in t)
-            else:
-                schema["enum"] = sorted(e.name for e in t)
+            schema["enum"] = sorted(e.value for e in t)
         elif is_struct(t):
             schema.setdefault("title", t.__name__)
             if has_nondefault_docstring(t):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -36,24 +36,9 @@ from utils import temp_module
 UTC = datetime.timezone.utc
 
 
-class FruitInt(enum.IntEnum):
-    APPLE = 1
-    BANANA = 2
-
-
 class FruitStr(enum.Enum):
     APPLE = "apple"
     BANANA = "banana"
-
-
-class VeggieInt(enum.IntEnum):
-    CARROT = 1
-    LETTUCE = 2
-
-
-class VeggieStr(enum.Enum):
-    CARROT = "carrot"
-    LETTUCE = "banana"
 
 
 class Person(msgspec.Struct):
@@ -1069,32 +1054,6 @@ class TestDatetime:
             msgspec.json.decode(s, type=datetime.datetime)
 
 
-class TestEnum:
-    def test_encode_enum(self):
-        s = msgspec.json.encode(FruitStr.APPLE)
-        assert s == b'"APPLE"'
-
-    def test_decode_enum(self):
-        x = msgspec.json.decode(b'"APPLE"', type=FruitStr)
-        assert x == FruitStr.APPLE
-
-    def test_decode_enum_invalid_value(self):
-        with pytest.raises(
-            msgspec.ValidationError, match="Invalid enum value 'MISSING'"
-        ):
-            msgspec.json.decode(b'"MISSING"', type=FruitStr)
-
-    def test_decode_enum_invalid_value_nested(self):
-        class Test(msgspec.Struct):
-            fruit: FruitStr
-
-        with pytest.raises(
-            msgspec.ValidationError,
-            match=r"Invalid enum value 'MISSING' - at `\$.fruit`",
-        ):
-            msgspec.json.decode(b'{"fruit": "MISSING"}', type=Test)
-
-
 class TestIntegers:
     @pytest.mark.parametrize("ndigits", range(21))
     def test_encode_int(self, ndigits):
@@ -1182,29 +1141,6 @@ class TestIntegers:
     def test_decode_int_type_error(self):
         with pytest.raises(msgspec.ValidationError, match="Expected `str`, got `int`"):
             msgspec.json.decode(b"123", type=str)
-
-
-class TestIntEnum:
-    def test_encode_intenum(self):
-        s = msgspec.json.encode(FruitInt.APPLE)
-        assert s == b"1"
-
-    def test_decode_intenum(self):
-        x = msgspec.json.decode(b"1", type=FruitInt)
-        assert x == FruitInt.APPLE
-
-    def test_decode_intenum_invalid_value(self):
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 3"):
-            msgspec.json.decode(b"3", type=FruitInt)
-
-    def test_decode_intenum_invalid_value_nested(self):
-        class Test(msgspec.Struct):
-            fruit: FruitInt
-
-        with pytest.raises(
-            msgspec.ValidationError, match=r"Invalid enum value 3 - at `\$.fruit`"
-        ):
-            msgspec.json.decode(b'{"fruit": 3}', type=Test)
 
 
 class TestLiteral:

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -38,16 +38,6 @@ class FruitStr(enum.Enum):
     BANANA = "banana"
 
 
-class VeggieInt(enum.IntEnum):
-    CARROT = 1
-    LETTUCE = 2
-
-
-class VeggieStr(enum.Enum):
-    CARROT = "carrot"
-    LETTUCE = "banana"
-
-
 class Person(msgspec.Struct):
     first: str
     last: str
@@ -1043,7 +1033,7 @@ class TestTypedDecoder:
         dec = msgspec.msgpack.Decoder(FruitStr)
 
         a = enc.encode(FruitStr.APPLE)
-        assert enc.encode("APPLE") == a
+        assert enc.encode("apple") == a
         assert dec.decode(a) == FruitStr.APPLE
 
         with pytest.raises(msgspec.DecodeError, match="truncated"):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -207,7 +207,7 @@ def test_enum():
             "Example": {
                 "title": "Example",
                 "description": "A docstring",
-                "enum": ["A", "B", "C"],
+                "enum": ["x", "y", "z"],
             }
         },
     }
@@ -767,7 +767,7 @@ def test_schema_components_collects_subtypes():
 
     assert s == {"type": "object", "additionalProperties": r4}
     assert components == {
-        "ExEnum": {"enum": ["A"], "title": "ExEnum"},
+        "ExEnum": {"enum": [1], "title": "ExEnum"},
         "ExStruct": {
             "type": "object",
             "title": "ExStruct",


### PR DESCRIPTION
Previously integer enums encoded/decoded by their integer *values*,
while all other enums encoded/decoded by their string *names*. This PR
changes things so that all enums encode/decode by their values (string
and integer values only supported for now).

**This is a breaking change**

Before this PR:

```python
import enum
import msgspec

class Example(enum.Enum):
    A = "x"

msgspec.json.encode(Example.A)
# > b'"A"'
```

After this PR:

```python
import enum
import msgspec

class Example(enum.Enum):
    A = "x"

msgspec.json.encode(Example.A)
# > b'"x"'
```

Many other tools in the python ecosystem support encoding enums as their
values by default (`orjson`, `pydantic`, `cattrs`, `json`), but no tool
AFAICT supports encoding as their names by default. The purpose of this
change is to better match the rest of the Python ecosystem.

Fixes #209.