### PR TITLE
Fix flaky NamedTuple/TypedDict tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
     env:
       CIBW_TEST_REQUIRES: "pytest msgpack"

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -6318,11 +6318,13 @@ TypedDictInfo_Convert(PyObject *obj, bool err_not_json, bool *json_compatible) {
 error:
     if (cache_set) {
         /* An error occurred after the cache was created and set on the
-         * TypedDict. We need to delete the attribute.
-         *
-         * No need for error checking, if deletion fails, we raise that error
-         * instead. */
+         * TypedDict. We need to delete the attribute. Fetch and restore the
+         * original exception to avoid DelAttr silently clearing it on rare
+         * occasions. */
+        PyObject *err_type, *err_value, *err_tb;
+        PyErr_Fetch(&err_type, &err_value, &err_tb);
         PyObject_DelAttr(obj, mod->str___msgspec_cache__);
+        PyErr_Restore(err_type, err_value, err_tb);
     }
     Py_XDECREF((PyObject *)info);
     Py_XDECREF(annotations);
@@ -6551,11 +6553,13 @@ cleanup:
         Py_CLEAR(info);
         if (cache_set) {
             /* An error occurred after the cache was created and set on the
-            * NamedTuple. We need to delete the attribute.
-            *
-            * No need for error checking, if deletion fails, we raise that
-            * error instead. */
+            * NamedTuple. We need to delete the attribute. Fetch and restore
+            * the original exception to avoid DelAttr silently clearing it
+            * on rare occasions. */
+            PyObject *err_type, *err_value, *err_tb;
+            PyErr_Fetch(&err_type, &err_value, &err_tb);
             PyObject_DelAttr(obj, mod->str___msgspec_cache__);
+            PyErr_Restore(err_type, err_value, err_tb);
         }
     }
     Py_XDECREF(annotations);


### PR DESCRIPTION
The tests that a JSON incompatible `NamedTuple`/`TypedDict` would raise a nice error message previously would sometimes fail with a `SystemError` indicating a `NULL` return value without a valid exception. This was tricky to track down due to how rare the failure was (~1/500 runs).

The issue turns out to be that `PyObject_DelAttr` may sometimes clear an existing exception, even if no new exception is raised. Why this happens isn't clear to me; it may be a bug in CPython, or expected behavior.

To fix this, we now use `PyErr_Fetch`/`PyErr_Restore` to ensure the proper exception persists through the `PyObject_DelAttr` calls.