### PR TITLE
Fix bug in JSON base64 encoding

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -8527,7 +8527,8 @@ static const char base64_encode_table[] =
 static int
 json_encode_bin(EncoderState *self, const char* buf, Py_ssize_t len) {
     char *out;
-    int nbits = 0, charbuf = 0;
+    int nbits = 0;
+    unsigned int charbuf = 0;
     Py_ssize_t encoded_len;
 
     if (len >= (1LL << 32)) {
@@ -8546,8 +8547,9 @@ json_encode_bin(EncoderState *self, const char* buf, Py_ssize_t len) {
     out = self->output_buffer_raw + self->output_len;
 
     *out++ = '"';
+
     for (; len > 0; len--, buf++) {
-        charbuf = (charbuf << 8) | *buf;
+        charbuf = (charbuf << 8) | (unsigned char)(*buf);
         nbits += 8;
         while (nbits >= 6) {
             unsigned char ind = (charbuf >> (nbits - 6)) & 0x3f;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+import math
+import random
+import string
+import struct
+
+import pytest
+
+
+class Rand:
+    """Random source, pulled out into fixture with repr so the seed is
+    displayed on failing tests"""
+
+    def __init__(self, seed=0):
+        self.seed = seed or random.randint(0, 2**32 - 1)
+        self.rand = random.Random(self.seed)
+
+    def __repr__(self):
+        return f"Rand({self.seed})"
+
+    def str(self, n, m=0):
+        """
+        str(n) -> random string of length `n`.
+        str(n, m) -> random string between lengths `n` & `m`
+        """
+        if m:
+            n = self.rand.randint(n, m)
+        return "".join(self.rand.choices(string.ascii_letters, k=n))
+
+    def bytes(self, n):
+        """random bytes of length `n`"""
+        return self.rand.getrandbits(8 * n).to_bytes(n, "little")
+
+    def float(self):
+        """random finite float"""
+        while True:
+            dbytes = self.rand.getrandbits(64).to_bytes(8, "big")
+            x = struct.unpack("!d", dbytes)[0]
+            if math.isfinite(x):
+                return x
+
+
+@pytest.fixture
+def rand():
+    yield Rand()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import enum
 import gc
 import sys
-import random
-import string
 import weakref
 from collections import namedtuple
 from typing import (
@@ -93,32 +91,6 @@ class Custom:
 
     def __eq__(self, other):
         return self.x == other.x and self.y == other.y
-
-
-class Rand:
-    """Random source, pulled out into fixture with repr so the seed is
-    displayed on failing tests"""
-
-    def __init__(self, seed=0):
-        self.seed = seed or random.randint(0, 2**32 - 1)
-        self.rand = random.Random(self.seed)
-
-    def __repr__(self):
-        return f"Rand({self.seed})"
-
-    def str(self, n, m=0):
-        """
-        randstr(N) -> random string of length N.
-        randstr(N,M) -> random string between lengths N & M
-        """
-        if m:
-            n = self.rand.randint(n, m)
-        return "".join(self.rand.choices(string.ascii_letters, k=n))
-
-
-@pytest.fixture
-def rand():
-    yield Rand()
 
 
 class TestEncodeSubclasses:


### PR DESCRIPTION
Previously there was a bug in the base64 encoding implementation used by `msgspec.json` for encoding `bytes`/`bytearray`/`memoryview` objects. This bug only appeared for bytes with values outside the range 0 <= x <= 127, which weren't caught by the existing tests.

To remedy this we:
- fix the bug
- augment the existing test suite to cover this situation
- add some fuzz testing for the base64 encoding code

Fixes #215.