### PR TITLE
dataclass support

### DIFF
--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -68,7 +68,7 @@ def get_dataclass_info(cls):
     for field in cls.__dataclass_fields__.values():
         if field._field_type is not _FIELD:
             if field._field_type is _FIELD_INITVAR:
-                raise TypeError("dataclasses with `InitVar` fields is not supported")
+                raise TypeError("dataclasses with `InitVar` fields are not supported")
             continue
         name = field.name
         typ = field.type

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,14 +13,10 @@ def temp_module(code):
     exec whatever is needed for that test"""
     code = textwrap.dedent(code)
     name = f"temp_{uuid.uuid4().hex}"
-    ns = {"__name__": name}
-    exec(code, ns)
     mod = types.ModuleType(name)
-    for k, v in ns.items():
-        setattr(mod, k, v)
-
+    sys.modules[name] = mod
     try:
-        sys.modules[name] = mod
+        exec(code, mod.__dict__)
         yield mod
     finally:
         sys.modules.pop(name, None)


### PR DESCRIPTION
This PR adds encoding/decoding support for dataclasses, mirroring our support for `typing.NamedTuple`/`collections.namedtuple`/`typing.TypedDict`. Dataclasses are encoded to/decoded from mappings containing all attributes assigned to the object (union of `__dict__` and `__slots__`).

I do not intend to add support for additional configuration (e.g. renaming fields using `camelCase`) - if the user wants more customization they should switch to using structs. Structs support all the common features of dataclasses, but are more performant to create/use/encode/decode, and are more customizable. The intent of adding dataclass support is:

- Compatibility with what `orjson` is capable of encoding efficiently. Initial benchmarks show the implementation here encodes measurably faster than the one in `orjson`, especially if `slots=True` is used, see below.
- More general support for common python object types.

Todo:

- [x] JSON encoding support
- [x] MessagePack encoding support
- [x] JSON decoding support
- [x] MessagePack decoding support
- [x] Docs

Fixes #57. 