### PR TITLE
Add support for encoding/decoding `datetime.date` objects

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -113,6 +113,7 @@ Most combinations of the following types are supported (see
 - `set` / `typing.Set`
 - `frozenset` / `typing.FrozenSet`
 - `datetime.datetime`
+- `datetime.date`
 - `typing.Any`
 - `typing.Optional`
 - `typing.Union`
@@ -350,6 +351,30 @@ timezones are normalized to UTC.
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Invalid RFC3339 encoded datetime
+
+``date``
+~~~~~~~~~~~~
+
+`datetime.date` values are serialized as RFC3339_ encoded strings.
+
+.. code-block:: python
+
+    >>> import datetime
+
+    >>> date = datetime.date(2021, 4, 2)
+
+    >>> msg = msgspec.json.encode(date)
+
+    >>> msg
+    b'"2021-04-02"'
+
+    >>> msgspec.json.decode(msg, type=datetime.date)
+    datetime.date(2021, 4, 2)
+
+    >>> msgspec.json.decode(b'"oops not a date"', type=datetime.datetime)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Invalid RFC3339 encoded date
 
 ``list`` / ``tuple`` / ``set`` / ``frozenset``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -431,6 +431,9 @@ class SchemaBuilder:
         elif t is datetime.datetime:
             schema["type"] = "string"
             schema["format"] = "date-time"
+        elif t is datetime.date:
+            schema["type"] = "string"
+            schema["format"] = "date"
         elif t in (list, set, frozenset):
             schema["type"] = "array"
             if args:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -70,7 +70,15 @@ class Custom:
 class TestInvalidJSONTypes:
     def test_invalid_type_union(self):
         literal = Literal["a", "b"]
-        types = [FruitStr, literal, str, datetime.datetime, bytes, bytearray]
+        types = [
+            FruitStr,
+            literal,
+            str,
+            datetime.datetime,
+            datetime.date,
+            bytes,
+            bytearray,
+        ]
         for length in [2, 3, 4]:
             for types in itertools.combinations(types, length):
                 if set(types) in ({bytes, bytearray}, {str, literal}):
@@ -1036,9 +1044,9 @@ class TestDatetime:
             b'"0001-00-03T04:05:06.000007Z"',
             b'"0001-13-03T04:05:06.000007Z"',
             # Day out of range for month
-            b'"0001-02-00:05:06.000007Z"',
-            b'"0001-02-29:05:06.000007Z"',
-            b'"2000-02-30:05:06.000007Z"',
+            b'"0001-02-00T01:05:06.000007Z"',
+            b'"0001-02-29T01:05:06.000007Z"',
+            b'"2000-02-30T01:05:06.000007Z"',
             # Hour out of range
             b'"0001-02-03T24:05:06.000007Z"',
             # Minute out of range

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -126,6 +126,13 @@ def test_datetime():
     }
 
 
+def test_date():
+    assert msgspec.json.schema(datetime.date) == {
+        "type": "string",
+        "format": "date",
+    }
+
+
 @pytest.mark.parametrize(
     "typ", [list, tuple, set, frozenset, List, Tuple, Set, FrozenSet]
 )


### PR DESCRIPTION
These are encoded as RFC3339 formatted strings.

Part of #220.