### PR TITLE
Add support for encoding/decoding UUIDs

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -114,6 +114,7 @@ Most combinations of the following types are supported (see
 - `frozenset` / `typing.FrozenSet`
 - `datetime.datetime`
 - `datetime.date`
+- `uuid.UUID`
 - `typing.Any`
 - `typing.Optional`
 - `typing.Union`
@@ -371,10 +372,35 @@ timezones are normalized to UTC.
     >>> msgspec.json.decode(msg, type=datetime.date)
     datetime.date(2021, 4, 2)
 
-    >>> msgspec.json.decode(b'"oops not a date"', type=datetime.datetime)
+    >>> msgspec.json.decode(b'"oops not a date"', type=datetime.date)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Invalid RFC3339 encoded date
+
+``uuid``
+~~~~~~~~
+
+`uuid.UUID` values are serialized as RFC4122_ encoded strings.
+
+.. code-block:: python
+
+    >>> import uuid
+
+    >>> u = uuid.UUID("c4524ac0-e81e-4aa8-a595-0aec605a659a")
+
+    >>> msg = msgspec.json.encode(u)
+
+    >>> msg
+    b'"c4524ac0-e81e-4aa8-a595-0aec605a659a"'
+
+    >>> msgspec.json.decode(msg, type=uuid.UUID)
+    UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
+
+    >>> msgspec.json.decode(b'"oops not a uuid"', type=uuid.UUID)
+    Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Invalid UUID
+
 
 ``list`` / ``tuple`` / ``set`` / ``frozenset``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -993,6 +1019,7 @@ efficiently skipped without decoding.
 .. _pydantic: https://pydantic-docs.helpmanual.io/
 .. _RFC8259: https://datatracker.ietf.org/doc/html/rfc8259
 .. _RFC3339: https://datatracker.ietf.org/doc/html/rfc3339
+.. _RFC4122: https://datatracker.ietf.org/doc/html/rfc4122
 .. _timestamp extension: https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type
 .. _dataclasses: https://docs.python.org/3/library/dataclasses.html
 .. _attrs: https://www.attrs.org/en/stable/index.html

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -8149,7 +8149,7 @@ error:
     return NULL;
 
 invalid:
-    return ms_error_with_path("Invalid uuid%U", path);
+    return ms_error_with_path("Invalid UUID%U", path);
 }
 
 /*************************************************************************

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -2,6 +2,7 @@ import datetime
 import enum
 import re
 import sys
+import uuid
 from typing import Any, Union, Literal, List, Tuple, Dict, Set, FrozenSet
 
 if sys.version_info >= (3, 9):
@@ -434,6 +435,9 @@ class SchemaBuilder:
         elif t is datetime.date:
             schema["type"] = "string"
             schema["format"] = "date"
+        elif t is uuid.UUID:
+            schema["type"] = "string"
+            schema["format"] = "uuid"
         elif t in (list, set, frozenset):
             schema["type"] = "array"
             if args:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2049,5 +2049,5 @@ class TestUUID:
     )
     def test_decode_uuid_malformed(self, proto, uuid_str):
         msg = proto.encode(uuid_str)
-        with pytest.raises(msgspec.ValidationError, match="Invalid uuid"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid UUID"):
             proto.decode(msg, type=uuid.UUID)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,6 @@
 import enum
 import datetime
+import decimal
 import uuid
 from base64 import b64encode
 from copy import deepcopy
@@ -79,13 +80,13 @@ def test_msgpack_ext():
 
 def test_custom():
     with pytest.raises(TypeError, match="Custom types"):
-        assert msgspec.json.schema(uuid.UUID)
+        assert msgspec.json.schema(decimal.Decimal)
 
-    schema = {"type": "string", "pattern": "uuid4"}
+    schema = {"type": "string", "format": "decimal"}
 
     assert (
         msgspec.json.schema(
-            Annotated[uuid.UUID, msgspec.Meta(extra_json_schema=schema)]
+            Annotated[decimal.Decimal, msgspec.Meta(extra_json_schema=schema)]
         )
         == schema
     )
@@ -130,6 +131,13 @@ def test_date():
     assert msgspec.json.schema(datetime.date) == {
         "type": "string",
         "format": "date",
+    }
+
+
+def test_uuid():
+    assert msgspec.json.schema(uuid.UUID) == {
+        "type": "string",
+        "format": "uuid",
     }
 
 


### PR DESCRIPTION
This adds support for encoding/decoding UUIDs as strings in the format described by RFC4122.

The encoding and decoding are done as efficiently as possible - on my machine UUIDs

- encode ~2x faster than orjson
- encode ~70x faster than pydantic
- decode ~10x faster than pydantic

Benchmark:

```python
In [1]: import msgspec, orjson, pydantic, uuid

In [2]: class Struct(msgspec.Struct):
   ...:     data: list[uuid.UUID]
   ...: 

In [3]: class Model(pydantic.BaseModel):
   ...:     data: list[uuid.UUID]
   ...: 

In [4]: data = [uuid.uuid4() for _ in range(5000)]

In [5]: struct = Struct(data=data)

In [6]: model = Model(data=data)

In [7]: enc = msgspec.json.Encoder()

In [8]: dec = msgspec.json.Decoder(Struct)

In [9]: msg = enc.encode(struct)

In [10]: %timeit enc.encode(struct)  # msgspec encode time
252 µs ± 4.32 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [11]: %timeit orjson.dumps(data)  # orjson encode time
537 µs ± 1.99 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [12]: %timeit model.json()  # pydantic encode time
18 ms ± 37.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [13]: %timeit dec.decode(msg)  # msgspec decode time
1.07 ms ± 4.45 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [14]: %timeit Model.parse_raw(msg)  # pydantic decode time
11.3 ms ± 115 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```