### PR TITLE
Support both timezone-aware and timezone-naive datetime objects

### DIFF
--- a/docs/source/constraints.rst
+++ b/docs/source/constraints.rst
@@ -132,6 +132,42 @@ These constraints are valid on `str` types:
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `str` matching regex '^[a-z0-9_]*$'
 
+.. _datetime-constraints:
+
+Datetime Constraints
+--------------------
+
+These constraints are valid on `datetime.datetime` and `datetime.time` types:
+
+- ``tz``: Whether the annotated type is required to be timezone-aware_. Set to
+  ``True`` to require timezone-aware values, or ``False`` to require
+  timezone-naive values. The default is ``None``, which accepts either
+  timezone-aware or timezone-naive values.
+
+.. code-block:: python
+
+    >>> import msgspec
+
+    >>> from datetime import datetime
+
+    >>> from typing import Annotated
+
+    >>> msgspec.json.decode(
+    ...     b'"2022-04-02T18:18:10"',
+    ...     type=Annotated[datetime, msgspec.Meta(tz=True)]  # require timezone aware
+    ... )
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Expected `datetime` with a timezone component
+
+    >>> msgspec.json.decode(
+    ...     b'"2022-04-02T18:18:10-06:00"',
+    ...     type=Annotated[datetime, msgspec.Meta(tz=False)]  # require timezone naive
+    ... )
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Expected `datetime` with no timezone component
+
 Bytes Constraints
 -----------------
 
@@ -197,3 +233,5 @@ These constraints are valid on `dict` types:
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `object` of length <= 3
+
+.. _timezone-aware: https://docs.python.org/3/library/datetime.html#aware-and-naive-objects

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -106,6 +106,7 @@ class Meta:
         pattern: Union[str, None] = None,
         min_length: Union[int, None] = None,
         max_length: Union[int, None] = None,
+        tz: Union[bool, None] = None,
         title: Union[str, None] = None,
         description: Union[str, None] = None,
         examples: Union[list, None] = None,
@@ -119,6 +120,7 @@ class Meta:
     pattern: Final[Union[str, None]]
     min_length: Final[Union[int, None]]
     max_length: Final[Union[int, None]]
+    tz: Final[Union[int, None]]
     title: Final[Union[str, None]]
     description: Final[Union[str, None]]
     examples: Final[Union[list, None]]

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -1746,47 +1746,48 @@ static PyTypeObject Meta_Type = {
 #define MS_TYPE_BYTEARRAY           (1ull << 7)
 #define MS_TYPE_DATETIME            (1ull << 8)
 #define MS_TYPE_DATE                (1ull << 9)
-#define MS_TYPE_UUID                (1ull << 10)
-#define MS_TYPE_EXT                 (1ull << 11)
-#define MS_TYPE_STRUCT              (1ull << 12)
-#define MS_TYPE_STRUCT_ARRAY        (1ull << 13)
-#define MS_TYPE_STRUCT_UNION        (1ull << 14)
-#define MS_TYPE_STRUCT_ARRAY_UNION  (1ull << 15)
-#define MS_TYPE_ENUM                (1ull << 16)
-#define MS_TYPE_INTENUM             (1ull << 17)
-#define MS_TYPE_CUSTOM              (1ull << 18)
-#define MS_TYPE_CUSTOM_GENERIC      (1ull << 19)
-#define MS_TYPE_DICT                ((1ull << 20) | (1ull << 21))
-#define MS_TYPE_LIST                (1ull << 22)
-#define MS_TYPE_SET                 (1ull << 23)
-#define MS_TYPE_FROZENSET           (1ull << 24)
-#define MS_TYPE_VARTUPLE            (1ull << 25)
-#define MS_TYPE_FIXTUPLE            (1ull << 26)
-#define MS_TYPE_INTLITERAL          (1ull << 27)
-#define MS_TYPE_STRLITERAL          (1ull << 28)
-#define MS_TYPE_TYPEDDICT           (1ull << 29)
-#define MS_TYPE_DATACLASS           (1ull << 30)
-#define MS_TYPE_NAMEDTUPLE          (1ull << 31)
+#define MS_TYPE_TIME                (1ull << 10)
+#define MS_TYPE_UUID                (1ull << 11)
+#define MS_TYPE_EXT                 (1ull << 12)
+#define MS_TYPE_STRUCT              (1ull << 13)
+#define MS_TYPE_STRUCT_ARRAY        (1ull << 14)
+#define MS_TYPE_STRUCT_UNION        (1ull << 15)
+#define MS_TYPE_STRUCT_ARRAY_UNION  (1ull << 16)
+#define MS_TYPE_ENUM                (1ull << 17)
+#define MS_TYPE_INTENUM             (1ull << 18)
+#define MS_TYPE_CUSTOM              (1ull << 19)
+#define MS_TYPE_CUSTOM_GENERIC      (1ull << 20)
+#define MS_TYPE_DICT                ((1ull << 21) | (1ull << 22))
+#define MS_TYPE_LIST                (1ull << 23)
+#define MS_TYPE_SET                 (1ull << 24)
+#define MS_TYPE_FROZENSET           (1ull << 25)
+#define MS_TYPE_VARTUPLE            (1ull << 26)
+#define MS_TYPE_FIXTUPLE            (1ull << 27)
+#define MS_TYPE_INTLITERAL          (1ull << 28)
+#define MS_TYPE_STRLITERAL          (1ull << 29)
+#define MS_TYPE_TYPEDDICT           (1ull << 30)
+#define MS_TYPE_DATACLASS           (1ull << 31)
+#define MS_TYPE_NAMEDTUPLE          (1ull << 32)
 /* Constraints */
-#define MS_CONSTR_INT_MIN           (1ull << 32)
-#define MS_CONSTR_INT_MAX           (1ull << 33)
-#define MS_CONSTR_INT_MULTIPLE_OF   (1ull << 34)
-#define MS_CONSTR_FLOAT_GT          (1ull << 35)
-#define MS_CONSTR_FLOAT_GE          (1ull << 36)
-#define MS_CONSTR_FLOAT_LT          (1ull << 37)
-#define MS_CONSTR_FLOAT_LE          (1ull << 38)
-#define MS_CONSTR_FLOAT_MULTIPLE_OF (1ull << 39)
-#define MS_CONSTR_STR_REGEX         (1ull << 40)
-#define MS_CONSTR_STR_MIN_LENGTH    (1ull << 41)
-#define MS_CONSTR_STR_MAX_LENGTH    (1ull << 42)
-#define MS_CONSTR_BYTES_MIN_LENGTH  (1ull << 43)
-#define MS_CONSTR_BYTES_MAX_LENGTH  (1ull << 44)
-#define MS_CONSTR_ARRAY_MIN_LENGTH  (1ull << 45)
-#define MS_CONSTR_ARRAY_MAX_LENGTH  (1ull << 46)
-#define MS_CONSTR_MAP_MIN_LENGTH    (1ull << 47)
-#define MS_CONSTR_MAP_MAX_LENGTH    (1ull << 48)
-#define MS_CONSTR_TZ_AWARE          (1ull << 49)
-#define MS_CONSTR_TZ_NAIVE          (1ull << 50)
+#define MS_CONSTR_INT_MIN           (1ull << 42)
+#define MS_CONSTR_INT_MAX           (1ull << 43)
+#define MS_CONSTR_INT_MULTIPLE_OF   (1ull << 44)
+#define MS_CONSTR_FLOAT_GT          (1ull << 45)
+#define MS_CONSTR_FLOAT_GE          (1ull << 46)
+#define MS_CONSTR_FLOAT_LT          (1ull << 47)
+#define MS_CONSTR_FLOAT_LE          (1ull << 48)
+#define MS_CONSTR_FLOAT_MULTIPLE_OF (1ull << 49)
+#define MS_CONSTR_STR_REGEX         (1ull << 50)
+#define MS_CONSTR_STR_MIN_LENGTH    (1ull << 51)
+#define MS_CONSTR_STR_MAX_LENGTH    (1ull << 52)
+#define MS_CONSTR_BYTES_MIN_LENGTH  (1ull << 53)
+#define MS_CONSTR_BYTES_MAX_LENGTH  (1ull << 54)
+#define MS_CONSTR_ARRAY_MIN_LENGTH  (1ull << 55)
+#define MS_CONSTR_ARRAY_MAX_LENGTH  (1ull << 56)
+#define MS_CONSTR_MAP_MIN_LENGTH    (1ull << 57)
+#define MS_CONSTR_MAP_MAX_LENGTH    (1ull << 58)
+#define MS_CONSTR_TZ_AWARE          (1ull << 59)
+#define MS_CONSTR_TZ_NAIVE          (1ull << 60)
 /* Extra flag bit, used by TypedDict/dataclass implementations */
 #define MS_EXTRA_FLAG               (1ull << 63)
 
@@ -7734,12 +7735,12 @@ ms_check_datetime_constraints(
     char *err, *type_str;
     if (tz == Py_None) {
         if (type->types & MS_CONSTR_TZ_AWARE) {
-            err = "Expected a %s with a timezone component%U";
+            err = "Expected `%s` with a timezone component%U";
             goto error;
         }
     }
     else if (type->types & MS_CONSTR_TZ_NAIVE) {
-        err = "Expected a %s with no timezone component%U";
+        err = "Expected `%s` with no timezone component%U";
         goto error;
     }
 
@@ -7749,11 +7750,11 @@ ms_check_datetime_constraints(
     );
 
 error:
-    if (type->types & MS_TYPE_DATETIME) {
-        type_str = "datetime";
+    if (type->types & MS_TYPE_TIME) {
+        type_str = "time";
     }
     else {
-        type_str = "time";
+        type_str = "datetime";
     }
 
     ms_raise_validation_error(path, err, type_str);
@@ -7896,7 +7897,9 @@ datetime_to_epoch(PyObject *obj, int64_t *seconds, int32_t *nanoseconds) {
  * copyright Rich Felker et. al, and is licensed under the standard MIT
  * license.  */
 static PyObject *
-datetime_from_epoch(int64_t epoch_secs, uint32_t epoch_nanos) {
+datetime_from_epoch(
+    int64_t epoch_secs, uint32_t epoch_nanos, TypeNode *type, PathNode *path
+) {
     int64_t days, secs, years;
     int months, remdays, remsecs, remyears;
     int qc_cycles, c_cycles, q_cycles;
@@ -7941,7 +7944,7 @@ datetime_from_epoch(int64_t epoch_secs, uint32_t epoch_nanos) {
         years++;
     }
 
-    return PyDateTimeAPI->DateTime_FromDateAndTime(
+    return ms_check_datetime_constraints(
         years + 2000,
         months + 3,
         remdays + 1,
@@ -7950,7 +7953,8 @@ datetime_from_epoch(int64_t epoch_secs, uint32_t epoch_nanos) {
         remsecs % 60,
         epoch_nanos / 1000,
         PyDateTime_TimeZone_UTC,
-        PyDateTimeAPI->DateTimeType
+        type,
+        path
     );
 }
 
@@ -10434,7 +10438,8 @@ mpack_decode_cint(DecoderState *self, int64_t *out, uint64_t *uout, PathNode *pa
 
 static PyObject *
 mpack_decode_datetime(
-    DecoderState *self, const char *data_buf, Py_ssize_t size, PathNode *path
+    DecoderState *self, const char *data_buf, Py_ssize_t size,
+    TypeNode *type, PathNode *path
 ) {
     uint64_t data64;
     uint32_t nanoseconds;
@@ -10470,7 +10475,7 @@ mpack_decode_datetime(
         err_msg = "Timestamp is out of range%U";
         goto invalid;
     }
-    return datetime_from_epoch(seconds, nanoseconds);
+    return datetime_from_epoch(seconds, nanoseconds, type, path);
 
 invalid:
     return ms_error_with_path(err_msg, path);
@@ -11484,7 +11489,7 @@ mpack_decode_ext(
     if (mpack_read(self, &data_buf, size) < 0) return NULL;
 
     if (type->types & MS_TYPE_DATETIME && code == -1) {
-        return mpack_decode_datetime(self, data_buf, size, path);
+        return mpack_decode_datetime(self, data_buf, size, type, path);
     }
     else if (type->types & MS_TYPE_EXT) {
         data = PyBytes_FromStringAndSize(data_buf, size);
@@ -11501,7 +11506,7 @@ mpack_decode_ext(
      * - otherwise return Ext object
      * */
     if (code == -1) {
-        return mpack_decode_datetime(self, data_buf, size, path);
+        return mpack_decode_datetime(self, data_buf, size, type, path);
     }
     else if (self->ext_hook == NULL) {
         data = PyBytes_FromStringAndSize(data_buf, size);

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -379,6 +379,9 @@ class SchemaBuilder:
                 schema["multipleOf"] = meta.multiple_of
             if meta.pattern is not None:
                 schema["pattern"] = meta.pattern
+            if meta.tz is True:
+                if t is datetime.datetime:
+                    schema["format"] = "date-time"
             if t is str:
                 if meta.max_length is not None:
                     schema["maxLength"] = meta.max_length
@@ -431,7 +434,6 @@ class SchemaBuilder:
             schema["contentEncoding"] = "base64"
         elif t is datetime.datetime:
             schema["type"] = "string"
-            schema["format"] = "date-time"
         elif t is datetime.date:
             schema["type"] = "string"
             schema["format"] = "date"

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -296,10 +296,12 @@ def check_meta_constructor() -> None:
     for val3 in [1, None]:
         msgspec.Meta(min_length=val3)
         msgspec.Meta(max_length=val3)
-    for val4 in [[1, 2, 3], None]:
-        msgspec.Meta(examples=val4)
-    for val5 in [{"foo": "bar"}, None]:
-        msgspec.Meta(extra_json_schema=val5)
+    for val4 in [True, False, None]:
+        msgspec.Meta(tz=val4)
+    for val5 in [[1, 2, 3], None]:
+        msgspec.Meta(examples=val5)
+    for val6 in [{"foo": "bar"}, None]:
+        msgspec.Meta(extra_json_schema=val6)
 
 
 def check_meta_attributes() -> None:
@@ -312,6 +314,7 @@ def check_meta_attributes() -> None:
     print(c.pattern)
     print(c.min_length)
     print(c.max_length)
+    print(c.tz)
     print(c.title)
     print(c.description)
     print(c.examples)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,3 +1,4 @@
+import datetime
 import math
 import re
 from typing import Dict, Union, List
@@ -533,6 +534,52 @@ class TestStrConstraints:
         for x in bad:
             with pytest.raises(msgspec.ValidationError):
                 dec.decode(proto.encode(Ex(x)))
+
+
+class TestDateTimeConstraints:
+    @staticmethod
+    def roundtrip(proto, cls, aware, as_str):
+        dt = datetime.datetime.now(datetime.timezone.utc if aware else None)
+
+        if as_str:
+            s = proto.encode(cls(dt.isoformat()))
+        else:
+            s = proto.encode(cls(dt))
+
+        res = proto.decode(s, type=cls)
+        assert res.x == dt
+
+    @pytest.mark.parametrize("as_str", [True, False])
+    def test_tz_none(self, proto, as_str):
+        class Ex(msgspec.Struct):
+            x: Annotated[datetime.datetime, Meta(tz=None)]
+
+        self.roundtrip(proto, Ex, True, as_str)
+        self.roundtrip(proto, Ex, False, as_str)
+
+    @pytest.mark.parametrize("as_str", [True, False])
+    def test_tz_false(self, proto, as_str):
+        class Ex(msgspec.Struct):
+            x: Annotated[datetime.datetime, Meta(tz=False)]
+
+        self.roundtrip(proto, Ex, False, as_str)
+
+        err_msg = r"Expected `datetime` with no timezone component - at `\$.x`"
+
+        with pytest.raises(msgspec.ValidationError, match=err_msg):
+            self.roundtrip(proto, Ex, True, as_str)
+
+    @pytest.mark.parametrize("as_str", [True, False])
+    def test_tz_true(self, proto, as_str):
+        class Ex(msgspec.Struct):
+            x: Annotated[datetime.datetime, Meta(tz=True)]
+
+        self.roundtrip(proto, Ex, True, as_str)
+
+        err_msg = r"Expected `datetime` with a timezone component - at `\$.x`"
+
+        with pytest.raises(msgspec.ValidationError, match=err_msg):
+            self.roundtrip(proto, Ex, False, as_str)
 
 
 class TestBytesConstraints:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -53,6 +53,7 @@ FIELDS = {
     "pattern": "^foo$",
     "min_length": 0,
     "max_length": 10,
+    "tz": True,
     "title": "example title",
     "description": "example description",
     "examples": ["example 1", "example 2"],
@@ -155,6 +156,8 @@ class TestMetaObject:
             val2 = {}
         elif isinstance(val, list):
             val2 = []
+        elif isinstance(val, bool):
+            val2 = not val
         elif isinstance(val, int):
             val2 = val + 25
         else:
@@ -201,6 +204,13 @@ class TestMetaObject:
         Meta(**{field: "good"})
         with pytest.raises(TypeError, match=f"`{field}` must be a str, got bytes"):
             Meta(**{field: b"bad"})
+
+    @pytest.mark.parametrize("field", ["tz"])
+    def test_bool_fields(self, field):
+        Meta(**{field: True})
+        Meta(**{field: False})
+        with pytest.raises(TypeError, match=f"`{field}` must be a bool, got float"):
+            Meta(**{field: 1.5})
 
     @pytest.mark.parametrize("field", ["examples"])
     def test_list_fields(self, field):
@@ -255,6 +265,13 @@ class TestInvalidConstraintAnnotations:
             match=f"Can only set `{name}` on a str, bytes, or collection type",
         ):
             msgspec.json.Decoder(Annotated[int, Meta(**{name: 1})])
+
+    def test_invalid_tz_constraint(self):
+        with pytest.raises(
+            TypeError,
+            match="Can only set `tz` on a datetime or time type",
+        ):
+            msgspec.json.Decoder(Annotated[int, Meta(tz=True)])
 
     @pytest.mark.parametrize(
         "name, val",

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -941,6 +941,20 @@ class TestDatetime:
         res = msgspec.json.decode(json_s, type=datetime.datetime)
         assert res == exp
 
+    @pytest.mark.parametrize(
+        "s",
+        [
+            "1234-01-02T03:04:05",
+            "1234-01-02T03:04:05.123",
+            "1234-01-02T03:04:05.123456",
+        ],
+    )
+    def test_decode_datetime_naive(self, s):
+        sol = datetime.datetime.fromisoformat(s)
+        msg = f'"{s}"'.encode("utf-8")
+        res = msgspec.json.decode(msg, type=datetime.datetime)
+        assert sol == res
+
     @pytest.mark.parametrize("t", ["T", "t"])
     @pytest.mark.parametrize("z", ["Z", "z"])
     def test_decode_datetime_not_case_sensitive(self, t, z):
@@ -1016,16 +1030,16 @@ class TestDatetime:
             b'"0001-02-03T04:05:06.000007+0:00"',
             b'"0001-02-03T04:05:06.000007+00:0"',
             # Trailing data
-            b'"0001-02-03T04:05:06.000007+00:00:00"',
+            b'"0001-02-03T04:05:06.000007+00:000"',
+            b'"0001-02-03T04:05:06.000007Z0"',
+            b'"0001-02-03T04:05:06a"',
+            b'"0001-02-03T04:05:06.000007a"',
             # Truncated
             b'"0001-02-03T04:05:"',
-            # Missing timezone
-            b'"0001-02-03T04:05:06"',
-            b'"0001-02-03T04:05:06.000001"',
-            b'"0001-02-03T04:05:06.00000001"',
             # Missing +/-
             b'"0001-02-03T04:05:06.00000700:00"',
             # Missing digits after decimal
+            b'"0001-02-03T04:05:06."',
             b'"0001-02-03T04:05:06.Z"',
             # Invalid characters
             b'"000a-02-03T04:05:06.000007Z"',

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -493,23 +493,19 @@ class TestEncoderMisc:
         res = msgspec.msgpack.decode(msg)
         assert buf == res
 
-    def test_encode_datetime_no_tzinfo_errors_by_default(self):
-        x = datetime.datetime.now()
-        with pytest.raises(
-            TypeError, match="Encoding timezone-naive datetime objects is unsupported"
-        ):
-            msgspec.msgpack.encode(x)
-
-    def test_encode_datetime_no_tzinfo_hits_enc_hook(self):
-        x = datetime.datetime.now()
-        res = msgspec.msgpack.encode(x.replace(tzinfo=datetime.timezone.utc))
-
-        def enc_hook(obj):
-            if isinstance(obj, datetime.datetime):
-                return obj.replace(tzinfo=datetime.timezone.utc)
-            raise TypeError(str(type(obj)))
-
-        sol = msgspec.msgpack.encode(x, enc_hook=enc_hook)
+    @pytest.mark.parametrize(
+        "dt, dt_str",
+        [
+            (datetime.datetime(1, 2, 3, 4, 5, 6), "0001-02-03T04:05:06"),
+            (
+                datetime.datetime(1234, 12, 31, 14, 56, 27, 123456),
+                "1234-12-31T14:56:27.123456",
+            ),
+        ],
+    )
+    def test_encode_datetime_naive(self, dt, dt_str):
+        res = msgspec.msgpack.encode(dt)
+        sol = msgspec.msgpack.encode(dt_str)
         assert res == sol
 
     def test_encode_datetime_non_utc_tzinfo(self):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -120,16 +120,16 @@ def test_binary(typ):
 
 
 @pytest.mark.parametrize(
-    "typ, extra",
+    "get_type, extra",
     [
-        (datetime.datetime, {}),
-        (Annotated[datetime.datetime, Meta(tz=None)], {}),
-        (Annotated[datetime.datetime, Meta(tz=True)], {"format": "date-time"}),
-        (Annotated[datetime.datetime, Meta(tz=False)], {}),
+        (lambda: datetime.datetime, {}),
+        (lambda: Annotated[datetime.datetime, Meta(tz=None)], {}),
+        (lambda: Annotated[datetime.datetime, Meta(tz=True)], {"format": "date-time"}),
+        (lambda: Annotated[datetime.datetime, Meta(tz=False)], {}),
     ],
 )
-def test_datetime(typ, extra):
-    assert msgspec.json.schema(typ) == {"type": "string", **extra}
+def test_datetime(get_type, extra):
+    assert msgspec.json.schema(get_type()) == {"type": "string", **extra}
 
 
 def test_date():


### PR DESCRIPTION
This PR addresses part of #220. It makes the following changes:

- Naive `datetime.datetime` objects are now encoded as ISO8601 compatible strings for all protocols. These are _almost_ RFC3339 compatible, but lack the timezone component.
- A `datetime.datetime` annotation now will decode both timezone-naive and timezone-aware `datetime.datetime` objects.
- A new `tz` constraint is added for configuring whether the annotated value is timezone-aware or timezone-naive (or both). Set to `True` to enforce timezone-aware and `False` to enforce timezone-naive. Defaults to `None`, which accepts both.
- The `msgpack` protocol now will also decode `datetime.datetime` objects from RFC3339/ISO8601 compatible strings. Previously it only accepted datetimes encoded using the msgpack timestamp extension.