### PR TITLE
Support encoding/decoding time objects

### DIFF
--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -379,10 +379,15 @@ class SchemaBuilder:
                 schema["multipleOf"] = meta.multiple_of
             if meta.pattern is not None:
                 schema["pattern"] = meta.pattern
-            if meta.tz is True:
-                if t is datetime.datetime:
+            if t is datetime.datetime:
+                if meta.tz is True:
                     schema["format"] = "date-time"
-            if t is str:
+            elif t is datetime.time:
+                if meta.tz is True:
+                    schema["format"] = "time"
+                elif meta.tz is False:
+                    schema["format"] = "partial-time"
+            elif t is str:
                 if meta.max_length is not None:
                     schema["maxLength"] = meta.max_length
                 if meta.min_length is not None:
@@ -433,6 +438,10 @@ class SchemaBuilder:
             schema["type"] = "string"
             schema["contentEncoding"] = "base64"
         elif t is datetime.datetime:
+            # When possible, format is set in _process_metadata
+            schema["type"] = "string"
+        elif t is datetime.time:
+            # When possible, format is set in _process_metadata
             schema["type"] = "string"
         elif t is datetime.date:
             schema["type"] = "string"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -120,16 +120,35 @@ def test_binary(typ):
 
 
 @pytest.mark.parametrize(
-    "get_type, extra",
+    "annot, extra",
     [
-        (lambda: datetime.datetime, {}),
-        (lambda: Annotated[datetime.datetime, Meta(tz=None)], {}),
-        (lambda: Annotated[datetime.datetime, Meta(tz=True)], {"format": "date-time"}),
-        (lambda: Annotated[datetime.datetime, Meta(tz=False)], {}),
+        (None, {}),
+        (Meta(tz=None), {}),
+        (Meta(tz=True), {"format": "date-time"}),
+        (Meta(tz=False), {}),
     ],
 )
-def test_datetime(get_type, extra):
-    assert msgspec.json.schema(get_type()) == {"type": "string", **extra}
+def test_datetime(annot, extra):
+    typ = datetime.datetime
+    if annot is not None:
+        typ = Annotated[typ, annot]
+    assert msgspec.json.schema(typ) == {"type": "string", **extra}
+
+
+@pytest.mark.parametrize(
+    "annot, extra",
+    [
+        (None, {}),
+        (Meta(tz=None), {}),
+        (Meta(tz=True), {"format": "time"}),
+        (Meta(tz=False), {"format": "partial-time"}),
+    ],
+)
+def test_time(annot, extra):
+    typ = datetime.time
+    if annot is not None:
+        typ = Annotated[typ, annot]
+    assert msgspec.json.schema(typ) == {"type": "string", **extra}
 
 
 def test_date():


### PR DESCRIPTION
Final part of #220. Adds support for encoding and decoding `datetime.time` objects, following the same rules as `datetime.datetime` objects.

Fixes #220.