### PR TITLE
Fix typo in docs for runtime definition of Struct

### DIFF
--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -651,7 +651,7 @@ has a signature similar to `dataclasses.make_dataclass`. See
 
     >>> import msgspec
 
-    >>> Point = msgspec.defstruct("Point", [("x", float), ("y": float)])
+    >>> Point = msgspec.defstruct("Point", [("x", float), ("y", float)])
 
     >>> p = Point(1.0, 2.0)
 


### PR DESCRIPTION
Noticed this small typo in the Struct documentation. The example appears to be valid now.