### PR TITLE
Support decoding JSON from a `str` object

### DIFF
--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -6,6 +6,7 @@ from typing import (
     TypeVar,
     Generic,
     Optional,
+    Union,
     Callable,
     overload,
 )
@@ -54,24 +55,24 @@ class Decoder(Generic[T]):
         *,
         dec_hook: dec_hook_sig = None,
     ) -> None: ...
-    def decode(self, data: bytes) -> T: ...
+    def decode(self, data: Union[bytes, str]) -> T: ...
 
 @overload
 def decode(
-    buf: bytes,
+    buf: Union[bytes, str],
     *,
     dec_hook: dec_hook_sig = None,
 ) -> Any: ...
 @overload
 def decode(
-    buf: bytes,
+    buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
     dec_hook: dec_hook_sig = None,
 ) -> T: ...
 @overload
 def decode(
-    buf: bytes,
+    buf: Union[bytes, str],
     *,
     type: Any = ...,
     dec_hook: dec_hook_sig = None,
@@ -81,4 +82,7 @@ def schema(type: Any) -> Dict[str, Any]: ...
 def schema_components(
     types: Iterable[Any], ref_template: str = "#/$defs/{name}"
 ) -> Tuple[Tuple[Dict[str, Any], ...], Dict[str, Any]]: ...
+@overload
+def format(buf: str, *, indent: int = 2) -> str: ...
+@overload
 def format(buf: bytes, *, indent: int = 2) -> bytes: ...

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -531,6 +531,12 @@ def check_json_Decoder_decode_union() -> None:
     reveal_type(o)  # assert ("int" in typ and "str" in typ)
 
 
+def check_json_Decoder_decode_from_str() -> None:
+    dec = msgspec.json.Decoder(List[int])
+    o = dec.decode("[1, 2, 3]")
+    reveal_type(o)  # assert ("List" in typ or "list" in typ) and "int" in typ
+
+
 def check_json_decode_any() -> None:
     b = msgspec.json.encode([1, 2, 3])
     o = msgspec.json.decode(b)
@@ -548,6 +554,13 @@ def check_json_decode_typed() -> None:
 def check_json_decode_typed_union() -> None:
     o: Union[int, str] = msgspec.json.decode(b"", type=Union[int, str])
     reveal_type(o)  # assert "int" in typ and "str" in typ
+
+
+def check_json_decode_from_str() -> None:
+    msgspec.json.decode("[1, 2, 3]")
+
+    o = msgspec.json.decode("[1, 2, 3]", type=List[int])
+    reveal_type(o)  # assert ("List" in typ or "list" in typ) and "int" in typ
 
 
 def check_json_encode_enc_hook() -> None:
@@ -569,6 +582,8 @@ def check_json_decode_dec_hook() -> None:
 def check_json_format() -> None:
     reveal_type(msgspec.json.format(b"test"))  # assert "bytes" in typ
     reveal_type(msgspec.json.format(b"test", indent=4))  # assert "bytes" in typ
+    reveal_type(msgspec.json.format("test"))  # assert "str" in typ
+    reveal_type(msgspec.json.format("test", indent=4))  # assert "str" in typ
 
 
 ##########################################################

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -444,6 +444,12 @@ class TestDecodeFunction:
     def test_decode(self):
         assert msgspec.json.decode(b"[1, 2, 3]") == [1, 2, 3]
 
+    def test_decode_from_str(self):
+        assert msgspec.json.decode("[1, 2, 3]") == [1, 2, 3]
+
+        with pytest.raises(msgspec.DecodeError, match="truncated"):
+            assert msgspec.json.decode("[1, 2, 3")
+
     def test_decode_type_keyword(self):
         assert msgspec.json.decode(b"[1, 2, 3]", type=Set[int]) == {1, 2, 3}
 
@@ -519,6 +525,13 @@ class TestDecodeFunction:
 
 
 class TestDecoderMisc:
+    def test_decode_from_str(self):
+        dec = msgspec.json.Decoder()
+        assert dec.decode("[1, 2, 3]") == [1, 2, 3]
+
+        with pytest.raises(msgspec.DecodeError, match="truncated"):
+            assert dec.decode("[1, 2, 3")
+
     def test_decoder_type_attribute(self):
         dec = msgspec.json.Decoder()
         assert dec.type is Any
@@ -2720,9 +2733,12 @@ class TestFormat:
 
         assert res == sol
 
+    def test_format_str(self):
+        assert msgspec.json.format("[1,     2]", indent=0) == "[1, 2]"
+
     def test_format_bad_calls(self):
         with pytest.raises(TypeError):
-            msgspec.json.format("[]")
+            msgspec.json.format(1)
 
         with pytest.raises(TypeError):
             msgspec.json.format(b"[]", indent=None)


### PR DESCRIPTION
This adds support for decoding JSON from `str` objects, rather than just `bytes` (or bytes-like) objects.

For peak performance it's still recommended to decode from a bytes-like object, but native support for decoding from str types is faster than forcing the user to call `str_message.encode("utf-8")` themselves.

This also adds support for formatting str JSON messages using `msgspec.json.format`. If a str is passed in the return type is a str, otherwise the return type is `bytes`.