### PR TITLE
Don't encode dataclass attributes with leading `_`

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -621,9 +621,13 @@ already using them elsewhere, or if you have downstream code that requires a
 ``dataclasses``
 ~~~~~~~~~~~~~~~
 
-`dataclasses` map to JSON objects/MessagePack maps. During decoding, any extra
-fields are ignored. An error is raised during decoding if the type doesn't
-match or if any required fields are missing.
+`dataclasses` map to JSON objects/MessagePack maps.
+
+During encoding, all attributes without a leading underscore (``"_"``) are
+encoded.
+
+During decoding, any extra fields are ignored. An error is raised if a field's
+type doesn't match or if any required fields are missing.
 
 If a ``__post_init__`` method is defined on the dataclass, it is called after
 the object is decoded. Note that `"Init-only parameters"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1668,6 +1668,20 @@ class TestDataclass:
         res = proto.decode(proto.encode(x))
         assert res == {"x": 1, "y": 2}
 
+    @py310_plus
+    @pytest.mark.parametrize("slots", [True, False])
+    def test_encode_dataclass_skip_leading_underscore(self, proto, slots):
+        @dataclass(slots=slots)
+        class Test:
+            x: int
+            y: int
+            _z: int
+
+        x = Test(1, 2, 3)
+        res = proto.encode(x)
+        sol = proto.encode({"x": 1, "y": 2})
+        assert res == sol
+
     def test_type_cached(self, proto):
         @dataclass
         class Ex:


### PR DESCRIPTION
Previously we encoded all attributes set on a dataclass object. Unfortunately the pydantic implementation of dataclasses hides some pydantic-specific stuff in private attributes set on the object. To avoid encoding these attributes, we now skip any attribute that starts with a leading `_`.

Fixes #233.