### PR TITLE
Support dict key constraints in JSON

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -2885,7 +2885,10 @@ typenode_from_collect_state(TypeNodeCollectState *state, bool err_not_json, bool
         if (temp == NULL) goto error;
         out->details[e_ind++].pointer = temp;
         /* Check that JSON dict keys are strings */
-        if (temp->types & ~(MS_TYPE_ANY | MS_TYPE_STR | MS_TYPE_STRLITERAL)) {
+        if (
+            temp->types
+            & ~(MS_TYPE_ANY | MS_TYPE_STR | MS_TYPE_STRLITERAL | MS_STR_CONSTRS)
+        ) {
             if (err_not_json) {
                 PyErr_Format(
                     PyExc_TypeError,


### PR DESCRIPTION
Previously our check to ensure valid JSON types was too strict, preventing key constraints from being used. This has now been relaxed and a test added.

Fixes #238.