### PR TITLE
Support encoding/decoding dict int keys for JSON

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -555,9 +555,12 @@ Dict subclasses (`collections.OrderedDict`, for example) are also supported for
 encoding only - to decode into a ``dict`` subclass you'll need to implement a
 ``dec_hook`` (see :doc:`extending`).
 
-Note that JSON only supports string keys, while MessagePack supports any
-hashable for the key type. An error is raised during decoding if the keys or
-values don't match their respective types (if specified).
+JSON only supports `str`, `Literal`, `Enum`, `int`, and `IntEnum` key types
+(integers are encoded as strings). MessagePack supports any hashable for the
+key type.
+
+An error is raised during decoding if the keys or values don't match their
+respective types (if specified).
 
 .. code-block:: python
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1299,7 +1299,7 @@ class TestTypedDict:
     def test_type_errors_not_json(self, msgpack_first, wrap):
         class Ex(TypedDict):
             a: int
-            b: Dict[int, int]
+            b: Dict[float, int]
 
         if wrap:
             typ = TypedDict("Test", {"x": Ex})
@@ -1315,7 +1315,7 @@ class TestTypedDict:
                 msg = {"x": msg}
             assert dec.decode(msgspec.msgpack.encode(msg)) == msg
 
-        with pytest.raises(TypeError, match="JSON doesn't support"):
+        with pytest.raises(TypeError, match="Only dicts with `str` or `int` keys"):
             msgspec.json.Decoder(typ)
 
         if msgpack_first:
@@ -1352,7 +1352,7 @@ class TestTypedDict:
         class Ex(TypedDict):
             a: int
             b: Union[Ex, None]
-            c: Dict[int, int]
+            c: Dict[float, int]
         """
         with temp_module(source) as mod:
             if msgpack_first:
@@ -1362,7 +1362,7 @@ class TestTypedDict:
                 msg = {"a": 1, "b": None, "c": {1: 2}}
                 assert dec.decode(msgspec.msgpack.encode(msg)) == msg
 
-            with pytest.raises(TypeError, match="JSON doesn't support"):
+            with pytest.raises(TypeError, match="Only dicts with `str` or `int` keys"):
                 msgspec.json.Decoder(mod.Ex)
 
             if msgpack_first:
@@ -1517,7 +1517,7 @@ class TestNamedTuple:
     def test_type_errors_not_json(self, msgpack_first, wrap):
         class Ex(NamedTuple):
             a: int
-            b: Dict[int, int]
+            b: Dict[float, int]
 
         if wrap:
             typ = TypedDict("Test", {"x": Ex})
@@ -1533,7 +1533,7 @@ class TestNamedTuple:
                 msg = {"x": msg}
             assert dec.decode(msgspec.msgpack.encode(msg)) == msg
 
-        with pytest.raises(TypeError, match="JSON doesn't support"):
+        with pytest.raises(TypeError, match="Only dicts with `str` or `int` keys"):
             msgspec.json.Decoder(typ)
 
         if msgpack_first:
@@ -1570,7 +1570,7 @@ class TestNamedTuple:
         class Ex(NamedTuple):
             a: int
             b: Union[Ex, None]
-            c: Dict[int, int]
+            c: Dict[float, int]
         """
         with temp_module(source) as mod:
             if msgpack_first:
@@ -1580,7 +1580,7 @@ class TestNamedTuple:
                 msg = mod.Ex(1, None, {1: 2})
                 assert dec.decode(msgspec.msgpack.encode(msg)) == msg
 
-            with pytest.raises(TypeError, match="JSON doesn't support"):
+            with pytest.raises(TypeError, match="Only dicts with `str` or `int` keys"):
                 msgspec.json.Decoder(mod.Ex)
 
             if msgpack_first:
@@ -1793,7 +1793,7 @@ class TestDataclass:
         @dataclass
         class Ex:
             a: int
-            b: Dict[int, int]
+            b: Dict[float, int]
 
         if wrap:
             typ = TypedDict("Test", {"x": Ex})
@@ -1809,7 +1809,7 @@ class TestDataclass:
                 msg = {"x": msg}
             assert dec.decode(msgspec.msgpack.encode(msg)) == msg
 
-        with pytest.raises(TypeError, match="JSON doesn't support"):
+        with pytest.raises(TypeError, match="Only dicts with `str` or `int` keys"):
             msgspec.json.Decoder(typ)
 
         if msgpack_first:
@@ -1850,7 +1850,7 @@ class TestDataclass:
         class Ex:
             a: int
             b: Union[Ex, None]
-            c: Dict[int, int]
+            c: Dict[float, int]
         """
         with temp_module(source) as mod:
             if msgpack_first:
@@ -1860,7 +1860,7 @@ class TestDataclass:
                 msg = mod.Ex(a=1, b=None, c={1: 2})
                 assert dec.decode(msgspec.msgpack.encode(msg)) == msg
 
-            with pytest.raises(TypeError, match="JSON doesn't support"):
+            with pytest.raises(TypeError, match="Only dicts with `str` or `int` keys"):
                 msgspec.json.Decoder(mod.Ex)
 
             if msgpack_first:


### PR DESCRIPTION
JSON as a protocol only supports string keys in objects, which means that arbitrary key types can't be used. Previously we only allowed `str` and `Literal[strings...]` types for dict keys. This PR relaxes this restriction to also support int-like keys. The following key types are now supported for JSON:

- `str`
- `Literal[strings...]`
- `Enum`
- `int`
- `Literal[integers...]`
- `IntEnum`

along with constraints on these types.

Integer keys are encoded/decoded as integer strings (e.g. `1 -> "1"`). There is precedent for this change - the stdlib `json` library does this automatically for `int` keys, as does `orjson` (opt in with `OPT_NON_STR_KEYS`). Golang's `json` library and protobuf-json also does this for integer keys. The standard `citm_catalog.json` benchmark file also has a schema that uses integer-string keys. It makes sense for us to support this use case.

Fixes #241.