### PR TITLE
Support encoding `set`/`frozenset` subclasses

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,8 +71,8 @@ napoleon_google_docstring = False
 napoleon_custom_sections = [("Configuration", "params_style")]
 default_role = "obj"
 extlinks = {
-    "issue": ("https://github.com/jcrist/msgspec/issues/%s", "Issue #"),
-    "pr": ("https://github.com/jcrist/msgspec/pull/%s", "PR #"),
+    "issue": ("https://github.com/jcrist/msgspec/issues/%s", "Issue #%s"),
+    "pr": ("https://github.com/jcrist/msgspec/pull/%s", "PR #%s"),
 }
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: "
 copybutton_prompt_is_regexp = True

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -128,9 +128,11 @@ Most combinations of the following types are supported (see
 - `enum.Enum` subclasses
 - `enum.IntEnum` subclasses
 - `msgspec.Struct` subclasses
-- `list` subclasses (encoding only)
 - `dict` subclasses (encoding only)
+- `list` subclasses (encoding only)
 - `tuple` subclasses (encoding only)
+- `set` subclasses (encoding only)
+- `frozenset` subclasses (encoding only)
 - Custom types (see :doc:`extending`)
 
 To specify the expected type, you can pass it to ``decode``, or when creating a
@@ -211,6 +213,9 @@ Supported Types
 
 Here we document how msgspec maps Python objects to/from the JSON_/MessagePack_
 protocols.
+
+Note that except where explicitly stated, subclasses of these types are not
+supported by default (see :doc:`extending` for how to add support yourself).
 
 ``None``
 ~~~~~~~~
@@ -479,8 +484,8 @@ timezone-naive by specifying a ``tz`` constraint (see
 MessagePack.  An error is raised if the elements don't match the specified
 element type (if provided).
 
-``list`` subclasses are also supported for encoding only - to decode into a
-``list`` subclass you'll need to implement a ``dec_hook`` (see
+Subclasses of these types are also supported for encoding only. To decode into
+a ``list`` subclass you'll need to implement a ``dec_hook`` (see
 :doc:`extending`).
 
 .. code-block:: python
@@ -552,7 +557,7 @@ already using them elsewhere, or if you have downstream code that requires a
 Dicts encode/decode as JSON objects/MessagePack maps.
 
 Dict subclasses (`collections.OrderedDict`, for example) are also supported for
-encoding only - to decode into a ``dict`` subclass you'll need to implement a
+encoding only. To decode into a ``dict`` subclass you'll need to implement a
 ``dec_hook`` (see :doc:`extending`).
 
 JSON only supports `str`, `Literal`, `Enum`, `int`, and `IntEnum` key types

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -9599,9 +9599,6 @@ mpack_encode(EncoderState *self, PyObject *obj)
     else if (type == &PyMemoryView_Type) {
         return mpack_encode_memoryview(self, obj);
     }
-    else if (type == &PySet_Type || type == &PyFrozenSet_Type) {
-        return mpack_encode_set(self, obj);
-    }
     else if (PyTuple_Check(obj)) {
         return mpack_encode_tuple(self, obj);
     }
@@ -9625,6 +9622,9 @@ mpack_encode(EncoderState *self, PyObject *obj)
     }
     else if (type == (PyTypeObject *)(self->mod->UUIDType)) {
         return mpack_encode_uuid(self, obj);
+    }
+    else if (PyAnySet_Check(obj)) {
+        return mpack_encode_set(self, obj);
     }
     else if (PyDict_Contains(type->tp_dict, self->mod->str___dataclass_fields__)) {
         return mpack_encode_object(self, obj);
@@ -10413,9 +10413,6 @@ json_encode(EncoderState *self, PyObject *obj)
     else if (PyTuple_Check(obj)) {
         return json_encode_tuple(self, obj);
     }
-    else if (type == &PySet_Type || type == &PyFrozenSet_Type) {
-        return json_encode_set(self, obj);
-    }
     else if (PyDict_Check(obj)) {
         return json_encode_dict(self, obj);
     }
@@ -10448,6 +10445,9 @@ json_encode(EncoderState *self, PyObject *obj)
     }
     else if (type == (PyTypeObject *)(self->mod->UUIDType)) {
         return json_encode_uuid(self, obj);
+    }
+    else if (PyAnySet_Check(obj)) {
+        return json_encode_set(self, obj);
     }
     else if (PyDict_Contains(type->tp_dict, self->mod->str___dataclass_fields__)) {
         return json_encode_object(self, obj);

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -119,19 +119,13 @@ class TestEncodeSubclasses:
         for msg in [{}, {"a": 1, "b": 2}]:
             assert proto.encode(subclass(msg)) == proto.encode(msg)
 
-    def test_encode_list_subclass(self, proto):
-        class subclass(list):
+    @pytest.mark.parametrize("cls", [list, tuple, set, frozenset])
+    def test_encode_sequence_subclass(self, cls, proto):
+        class subclass(cls):
             pass
 
         for msg in [[], [1, 2]]:
-            assert proto.encode(subclass(msg)) == proto.encode(msg)
-
-    def test_encode_tuple_subclass(self, proto):
-        class subclass(tuple):
-            pass
-
-        for msg in [(), (1, 2)]:
-            assert proto.encode(subclass(msg)) == proto.encode(msg)
+            assert proto.encode(subclass(msg)) == proto.encode(cls(msg))
 
 
 class TestIntEnum:


### PR DESCRIPTION
This adds support for encoding `set` and `frozenset` subclasses. These are added mostly for parity with `list`/`tuple`/`dict` types - with these additions all natively supported "collection" types also support subclasses.

This PR also adds a bit of clarification around our support of subclasses for natively supported types.

Fixes #248.