### PR TITLE
Support NewType

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -120,6 +120,7 @@ Most combinations of the following types are supported (see
 - `typing.Optional`
 - `typing.Union`
 - `typing.Literal`
+- `typing.NewType`
 - `typing.NamedTuple` / `collections.namedtuple`
 - `typing.TypedDict`
 - `dataclasses.dataclass` types
@@ -835,6 +836,29 @@ values, or doesn't match any of their component types.
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `int`, got `str`
 
+``NewType``
+~~~~~~~~~~~
+
+`typing.NewType` types are treated identically to their base type. Their
+support here is purely to aid static analysis tools like mypy_ or pyright_.
+
+.. code-block:: python
+
+    >>> from typing import NewType
+
+    >>> UserId = NewType("UserId", int)
+
+    >>> msgspec.json.encode(UserId(1234))
+    b'1234'
+
+    >>> msgspec.json.decode(b'1234', type=UserId)
+    1234
+
+    >>> msgspec.json.decode(b'"oops"', type=UserId)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Expected `int`, got `str`
+
 ``Union`` /  ``Optional``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1107,3 +1131,5 @@ efficiently skipped without decoding.
 .. _dataclasses: https://docs.python.org/3/library/dataclasses.html
 .. _attrs: https://www.attrs.org/en/stable/index.html
 .. _timezone-aware: https://docs.python.org/3/library/datetime.html#aware-and-naive-objects
+.. _mypy: https://mypy.readthedocs.io
+.. _pyright: https://github.com/microsoft/pyright

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -341,6 +341,7 @@ typedef struct {
     PyObject *str__field_defaults;
     PyObject *str___dataclass_fields__;
     PyObject *str___post_init__;
+    PyObject *str___supertype__;
     PyObject *str_int;
     PyObject *str_is_safe;
     PyObject *UUIDType;
@@ -3926,6 +3927,17 @@ typenode_collect_type_full(
     if (PyType_Check(obj)
         && PyObject_HasAttr(obj, state->mod->str___dataclass_fields__)) {
         return typenode_collect_dataclass(state, obj);
+    }
+
+    /* Check if NewType through duck-typing */
+    PyObject *supertype = PyObject_GetAttr(obj, state->mod->str___supertype__);
+    if (supertype != NULL) {
+        int out = typenode_collect_type_full(state, supertype, kind);
+        Py_DECREF(supertype);
+        return out;
+    }
+    else {
+        PyErr_Clear();
     }
 
     /* Attempt to extract __origin__/__args__ from the obj as a typing object */
@@ -15615,6 +15627,7 @@ msgspec_clear(PyObject *m)
     Py_CLEAR(st->str__field_defaults);
     Py_CLEAR(st->str___dataclass_fields__);
     Py_CLEAR(st->str___post_init__);
+    Py_CLEAR(st->str___supertype__);
     Py_CLEAR(st->str_int);
     Py_CLEAR(st->str_is_safe);
     Py_CLEAR(st->UUIDType);
@@ -15985,6 +15998,7 @@ PyInit__core(void)
     CACHED_STRING(str__field_defaults, "_field_defaults");
     CACHED_STRING(str___dataclass_fields__, "__dataclass_fields__");
     CACHED_STRING(str___post_init__, "__post_init__");
+    CACHED_STRING(str___supertype__, "__supertype__");
     CACHED_STRING(str_int, "int");
     CACHED_STRING(str_is_safe, "is_safe");
 

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -252,6 +252,10 @@ def origin_args_metadata(t):
     else:
         args = None
 
+    # Strip out NewType types
+    while hasattr(t, "__supertype__"):
+        t = t.__supertype__
+
     return t, args, metadata
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,6 +17,7 @@ from typing import (
     Tuple,
     TypedDict,
     Union,
+    NewType,
 )
 
 import pytest
@@ -162,6 +163,15 @@ def test_uuid():
     assert msgspec.json.schema(uuid.UUID) == {
         "type": "string",
         "format": "uuid",
+    }
+
+
+def test_newtype():
+    UserId = NewType("UserId", str)
+    assert msgspec.json.schema(UserId) == {"type": "string"}
+    assert msgspec.json.schema(Annotated[UserId, Meta(max_length=10)]) == {
+        "type": "string",
+        "maxLength": 10,
     }
 
 


### PR DESCRIPTION
`NewType` types are treated identically to their base types by msgspec. Support here is purely to aid with static type checking systems like mypy or pyright.

~Still needs docs, just putting this up since it's quick and easy to do.~

Fixes #250.