### PR TITLE
Fix docs build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -1048,7 +1048,7 @@ Raw_New(PyObject *msg) {
 }
 
 PyDoc_STRVAR(Raw__doc__,
-"Raw(msg=b"", /)\n"
+"Raw(msg="", /)\n"
 "--\n"
 "\n"
 "A buffer containing an encoded message.\n"
@@ -1065,10 +1065,10 @@ PyDoc_STRVAR(Raw__doc__,
 "\n"
 "Parameters\n"
 "----------\n"
-"msg : bytes, bytearray, memoryview, or str, optional\n"
+"msg: bytes, bytearray, memoryview, or str, optional\n"
 "    A buffer containing an encoded message. One of bytes, bytearray, memoryview,\n"
 "    str, or any object that implements the buffer protocol. If not present,\n"
-"    defaults to a zero-length bytes object (``b""``)."
+"    defaults to an empty buffer."
 );
 static PyObject *
 Raw_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {


### PR DESCRIPTION
The recent changes to `Raw` broke the docs build, which went unnoticed since warnings in the docs build were being silently ignored. This commit fixes the docs build, and also updates the sphinx config to make warnings result in a build failure.