### PR TITLE
Add `msgspec.replace` function

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,6 +11,8 @@ Struct
 
 .. autofunction:: defstruct
 
+.. autofunction:: replace
+
 
 Meta
 ----

--- a/msgspec/__init__.py
+++ b/msgspec/__init__.py
@@ -1,5 +1,6 @@
 from ._core import (
     Struct,
+    replace,
     defstruct,
     Raw,
     Meta,

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -61,6 +61,9 @@ class Struct(metaclass=__StructMeta):
     ) -> None: ...
     def __rich_repr__(self) -> Iterable[Tuple[str, Any]]: ...
 
+S = TypeVar("S", bound=Struct, covariant=True)
+
+def replace(struct: S, /, **changes: Any) -> S: ...
 def defstruct(
     name: str,
     fields: Iterable[Union[str, Tuple[str, Type], Tuple[str, Type, Any]]],

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -313,6 +313,21 @@ def check_defstruct_config_options() -> None:
     )
 
 ##########################################################
+# replace                                                #
+##########################################################
+
+def check_replace() -> None:
+    class Test(msgspec.Struct):
+        x: int
+        y: int
+        struct: int
+
+    struct = Test(1, 2, 3)
+    reveal_type(msgspec.replace(struct))  # assert "Test" in typ
+    reveal_type(msgspec.replace(struct, x=1))  # assert "Test" in typ
+    reveal_type(msgspec.replace(struct, struct=1))  # assert "Test" in typ
+
+##########################################################
 # Meta                                                   #
 ##########################################################
 


### PR DESCRIPTION
This adds a new `msgspec.replace` function, mirroring the functionality of `dataclasses.replace`/`NamedTuple._replace`/`attrs.evolve`. It takes an existing `Struct` instance, and returns a copy with any fields passed as `**changes` replacing the original values.

Note that:
- This works on any struct (including frozen structs), since this returns a new instance rather than mutating the old instance.
- This doesn't do a deepcopy of any of the field values. If the input struct had a list on a field, the output struct will have the same instance of that list (unless that field was passed in `**changes`).

Fixes #261.