### PR TITLE
Improve error for invalid kwarg in `Struct.__init__`

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -6038,7 +6038,7 @@ Struct_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyObj
         }
 
         /* Unknown keyword */
-        PyErr_SetString(PyExc_TypeError, "Extra keyword arguments provided");
+        PyErr_Format(PyExc_TypeError, "Unexpected keyword argument '%U'", kwname);
         goto error;
 
 kw_found:

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -421,7 +421,7 @@ class TestStructInit:
         with pytest.raises(TypeError, match="Argument 'a' given by name and position"):
             Test(1, 2, a=3)
 
-        with pytest.raises(TypeError, match="Extra keyword arguments provided"):
+        with pytest.raises(TypeError, match="Unexpected keyword argument 'e'"):
             Test(1, 2, e=5)
 
     def test_init_kw_only(self):
@@ -441,7 +441,7 @@ class TestStructInit:
         with pytest.raises(TypeError, match="Extra positional arguments provided"):
             Test(1)
 
-        with pytest.raises(TypeError, match="Extra keyword arguments provided"):
+        with pytest.raises(TypeError, match="Unexpected keyword argument 'e'"):
             Test(a=1, e=5)
 
     def test_init_kw_only_mixed(self):
@@ -468,7 +468,7 @@ class TestStructInit:
         with pytest.raises(TypeError, match="Extra positional arguments provided"):
             Test(1, 5.0, 3)
 
-        with pytest.raises(TypeError, match="Extra keyword arguments provided"):
+        with pytest.raises(TypeError, match="Unexpected keyword argument 'e'"):
             Test(1, e=5)
 
 


### PR DESCRIPTION
We now include the name of the first invalid keyword argument, which should make it easier to debug keyword arg typos.

This request came as feedback over email:

> when providing an incorrect kwarg, it would be great if the error message could tell you which kwarg was incorrect, e.g. right now its just 'Extra keyword arguments provided'.