### PR TITLE
Add support for `default_factory` on `Struct` types

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,8 @@ Struct
 .. autoclass:: Struct
     :members:
 
+.. autofunction:: field
+
 .. autofunction:: defstruct
 
 .. autofunction:: replace

--- a/examples/pyproject-toml/pyproject.py
+++ b/examples/pyproject-toml/pyproject.py
@@ -67,8 +67,8 @@ class Project(Base):
 
 
 class PyProject(Base):
-    build_system: BuildSystem = BuildSystem()
-    project: Project = Project()
+    build_system: BuildSystem | None = None
+    project: Project | None = None
     tool: dict[str, dict[str, Any]] = {}
 
 

--- a/msgspec/__init__.py
+++ b/msgspec/__init__.py
@@ -1,4 +1,5 @@
 from ._core import (
+    Field as _Field,
     Struct,
     replace,
     defstruct,
@@ -17,6 +18,22 @@ from . import json
 from . import yaml
 from . import toml
 from . import inspect
+
+
+def field(*, default=UNSET, default_factory=UNSET):
+    """
+    Configuration for a Struct field.
+
+    Parameters
+    ----------
+    default : Any, optional
+        A default value to use for this field.
+    default_factory : callable, optional
+        A zero-argument function called to generate a new default value
+        per-instance, rather than using a constant value as in ``default``.
+    """
+    return _Field(default=default, default_factory=default_factory)
+
 
 from ._version import get_versions
 

--- a/msgspec/__init__.py
+++ b/msgspec/__init__.py
@@ -2,6 +2,7 @@ from ._core import (
     Struct,
     replace,
     defstruct,
+    UNSET,
     Raw,
     Meta,
     to_builtins,

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -15,6 +15,11 @@ from typing import (
     overload,
 )
 
+class _Unset:
+    pass
+
+UNSET = _Unset()
+
 # Use `__dataclass_transform__` to catch more errors under pyright. Since we don't expose
 # the underlying metaclass, hide it under an underscore name. See
 # https://github.com/microsoft/pyright/blob/main/specs/dataclass_transforms.md

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -15,26 +15,33 @@ from typing import (
     overload,
 )
 
+T = TypeVar("T")
+
 class _Unset:
     pass
 
 UNSET = _Unset()
+
+@overload
+def field(*, default: T) -> T: ...
+@overload
+def field(*, default_factory: Callable[[], T]) -> T: ...
+@overload
+def field() -> Any: ...
 
 # Use `__dataclass_transform__` to catch more errors under pyright. Since we don't expose
 # the underlying metaclass, hide it under an underscore name. See
 # https://github.com/microsoft/pyright/blob/main/specs/dataclass_transforms.md
 # for more information.
 
-_T = TypeVar("_T")
-
 def __dataclass_transform__(
     *,
     eq_default: bool = True,
     order_default: bool = False,
     kw_only_default: bool = False,
-    field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
-) -> Callable[[_T], _T]: ...
-@__dataclass_transform__()
+    field_specifiers: Tuple[Union[type, Callable[..., Any]], ...] = (),
+) -> Callable[[T], T]: ...
+@__dataclass_transform__(field_specifiers=(field,))
 class __StructMeta(type):
     def __new__(
         cls: Type[type], name: str, bases: tuple, classdict: dict
@@ -146,9 +153,6 @@ def to_builtins(
     builtin_types: Union[Iterable[Type], None] = None,
     enc_hook: Optional[Callable[[Any], Any]] = None,
 ) -> Any: ...
-
-T = TypeVar("T")
-
 @overload
 def from_builtins(
     obj: Any,

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -6770,8 +6770,6 @@ PyDoc_STRVAR(Struct__doc__,
 "\n"
 "Fields are defined using type annotations. Fields may optionally have\n"
 "default values, which result in keyword parameters to the constructor.\n"
-"Note that mutable default values are deepcopied in the constructor to\n"
-"prevent accidental sharing.\n"
 "\n"
 "Structs automatically define ``__init__``, ``__eq__``, ``__repr__``, and\n"
 "``__copy__`` methods. Additional methods can be defined on the class as\n"

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -1845,6 +1845,62 @@ PyTypeObject NoDefault_Type = {
 PyObject _NoDefault_Object = {1, &NoDefault_Type};
 
 /*************************************************************************
+ * UNSET singleton                                                       *
+ *************************************************************************/
+
+PyObject _Unset_Object;
+#define UNSET &_Unset_Object
+
+PyDoc_STRVAR(Unset__doc__,
+"Unset()\n"
+"--\n"
+"\n"
+"A singleton indicating a value is unset."
+);
+static PyObject *
+unset_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    if (PyTuple_GET_SIZE(args) || (kwargs && PyDict_GET_SIZE(kwargs))) {
+        PyErr_SetString(PyExc_TypeError, "Unset takes no arguments");
+        return NULL;
+    }
+    Py_INCREF(UNSET);
+    return UNSET;
+}
+
+static PyObject *
+unset_repr(PyObject *op)
+{
+    return PyUnicode_FromString("UNSET");
+}
+
+static PyObject *
+unset_reduce(PyObject *op, PyObject *args)
+{
+    return PyUnicode_FromString("UNSET");
+}
+
+static PyMethodDef unset_methods[] = {
+    {"__reduce__", unset_reduce, METH_NOARGS, NULL},
+    {NULL, NULL}
+};
+
+PyTypeObject Unset_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "msgspec._core.Unset",
+    .tp_doc = Unset__doc__,
+    .tp_repr = unset_repr,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = unset_methods,
+    .tp_new = unset_new,
+    .tp_dealloc = 0,
+    .tp_itemsize = 0,
+    .tp_basicsize = 0
+};
+
+PyObject _Unset_Object = {1, &Unset_Type};
+
+/*************************************************************************
  * Factory                                                               *
  *************************************************************************/
 
@@ -17749,6 +17805,8 @@ PyInit__core(void)
     StructMetaType.tp_base = &PyType_Type;
     if (PyType_Ready(&NoDefault_Type) < 0)
         return NULL;
+    if (PyType_Ready(&Unset_Type) < 0)
+        return NULL;
     if (PyType_Ready(&Factory_Type) < 0)
         return NULL;
     if (PyType_Ready(&IntLookup_Type) < 0)
@@ -17819,6 +17877,11 @@ PyInit__core(void)
     /* Add nodefault singleton */
     Py_INCREF(NODEFAULT);
     if (PyModule_AddObject(m, "nodefault", NODEFAULT) < 0)
+        return NULL;
+
+    /* Add UNSET singleton */
+    Py_INCREF(UNSET);
+    if (PyModule_AddObject(m, "UNSET", UNSET) < 0)
         return NULL;
 
     /* Initialize the Struct Type */

--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -322,6 +322,8 @@ def _to_schema(
                 required.append(field.encode_name)
             elif field.default is not mi.UNSET:
                 field_schema["default"] = to_builtins(field.default, str_keys=True)
+            elif field.default_factory in (list, dict, set, bytearray):
+                field_schema["default"] = field.default_factory()
             names.append(field.encode_name)
             fields.append(field_schema)
 

--- a/msgspec/inspect.py
+++ b/msgspec/inspect.py
@@ -22,7 +22,12 @@ except Exception:
     _types_UnionType = type("UnionType", (), {})
 
 import msgspec
-from ._core import nodefault as _nodefault, Factory as _Factory, to_builtins
+from msgspec import UNSET
+from ._core import (
+    nodefault as _nodefault,
+    Factory as _Factory,
+    to_builtins as _to_builtins,
+)
 from ._utils import _AnnotatedAlias, get_type_hints as _get_type_hints
 
 
@@ -67,19 +72,6 @@ __all__ = (
 
 def __dir__():
     return __all__
-
-
-class _UnsetSingleton:
-    """A singleton indicating a value is unset"""
-
-    def __repr__(self):
-        return "UNSET"
-
-    def __reduce__(self):
-        return "UNSET"
-
-
-UNSET = _UnsetSingleton()
 
 
 class Type(msgspec.Struct):
@@ -749,7 +741,7 @@ class _Translator:
             if meta.extra_json_schema is not None:
                 extra_json_schema = _merge_json(
                     extra_json_schema,
-                    to_builtins(meta.extra_json_schema, str_keys=True),
+                    _to_builtins(meta.extra_json_schema, str_keys=True),
                 )
             if meta.extra is not None:
                 extra.update(meta.extra)

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -38,6 +38,17 @@ def check_struct() -> None:
     reveal_type(t.y)  # assert "str" in typ
 
 
+def check_struct_field() -> None:
+    class Test(msgspec.Struct):
+        a: int
+        x: int = msgspec.field(default=1)
+        y: List[int] = msgspec.field(default_factory=lambda: [1, 2, 3])
+
+    Test(1)
+    Test(1, 2)
+    Test(1, 2, [3])
+
+
 def check_struct_kw_only() -> None:
     class Test(msgspec.Struct, kw_only=True):
         x: int

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -16,6 +16,13 @@ def check_exceptions() -> None:
     reveal_type(msgspec.DecodeError)  # assert "Any" not in typ
     reveal_type(msgspec.ValidationError)  # assert "Any" not in typ
 
+
+def check_unset() -> None:
+    reveal_type(msgspec.UNSET)  # assert "Any" not in typ
+    str(msgspec.UNSET)
+    pickle.dumps(msgspec.UNSET)
+
+
 ##########################################################
 # Structs                                                #
 ##########################################################

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1253,6 +1253,34 @@ class TestStructKeywordOnly:
             proto.decode(msg, type=Test)
 
 
+class TestStructDefaults:
+    def test_struct_defaults(self, proto):
+        class Test(msgspec.Struct):
+            a: int = 1
+            b: list = []
+            c: int = msgspec.field(default=2)
+            d: dict = msgspec.field(default_factory=dict)
+
+        sol = Test()
+
+        res = proto.decode(proto.encode(sol), type=Test)
+        assert res == sol
+
+        res = proto.decode(proto.encode({}), type=Test)
+        assert res == sol
+
+    def test_struct_default_factory_errors(self, proto):
+        def bad():
+            raise ValueError("Oh no!")
+
+        class Test(msgspec.Struct):
+            a: int = msgspec.field(default_factory=bad)
+
+        msg = proto.encode({})
+        with pytest.raises(Exception, match="Oh no!"):
+            proto.decode(msg, type=Test)
+
+
 class TestTypedDict:
     def test_type_cached(self, proto):
         class Ex(TypedDict):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -66,11 +66,6 @@ def test_merge_json(a, b, sol):
     assert b == b_orig
 
 
-def test_unset():
-    assert repr(mi.UNSET) == "UNSET"
-    assert mi.UNSET.__reduce__() == "UNSET"
-
-
 def test_inspect_module_dir():
     assert mi.__dir__() == mi.__all__
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -291,9 +291,13 @@ def test_enum():
     ],
 )
 def test_struct(kw):
+    def factory():
+        return "foo"
+
     class Example(msgspec.Struct, **kw):
         x: int
         y: int = 0
+        z: int = msgspec.field(default_factory=factory)
 
     sol = mi.StructType(
         cls=Example,
@@ -301,6 +305,13 @@ def test_struct(kw):
             mi.Field(name="x", encode_name="x", type=mi.IntType()),
             mi.Field(
                 name="y", encode_name="y", type=mi.IntType(), required=False, default=0
+            ),
+            mi.Field(
+                name="z",
+                encode_name="z",
+                type=mi.IntType(),
+                required=False,
+                default_factory=factory,
             ),
         ),
         **kw

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -713,7 +713,7 @@ def test_struct_defaults_from_field():
     class Test(Struct):
         x: int = field(default=1)
         y: int = field(default_factory=lambda: 2)
-        z: list[int] = field(default=default)
+        z: List[int] = field(default=default)
 
     t = Test()
     assert t.x == 1

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -36,6 +36,21 @@ def as_tuple(x):
     return tuple(getattr(x, f) for f in x.__struct_fields__)
 
 
+@pytest.mark.parametrize(
+    "obj, str_obj", [(msgspec.UNSET, "UNSET"), (nodefault, "nodefault")]
+)
+def test_singletons(obj, str_obj):
+    assert str(obj) == str_obj
+    assert pickle.loads(pickle.dumps(obj)) is obj
+
+    cls = type(obj)
+    assert cls() is obj
+    with pytest.raises(TypeError):
+        cls(1)
+    with pytest.raises(TypeError):
+        cls(foo=1)
+
+
 def test_struct_class_attributes():
     assert Struct.__struct_fields__ == ()
     assert Struct.__struct_encode_fields__ == ()


### PR DESCRIPTION
This PR does a few things:

- It adds a new `msgspec.field` function, which returns an *opaque* object used for configuring fields. So far this only exposes `default` and `default_factory`, both of which match the `dataclasses` kwargs of the same name.
- It adds support for init-time generated default values in `msgspec.Struct` types, through use of the new `default_factory` setting (fixes #259).

Example:

```python
import msgspec
import uuid

class Example(msgspec.Struct):
    id: uuid.UUID = msgspec.field(default_factory=uuid.uuid4)
```

### Breaking Change: mutable default values in structs are now handled differently

This also changes how mutable default values are handled. Previously msgspec's semantics were that a default value for a field would be deepcopied on `__init__` if that field wasn't provided (the implementation would avoid a deepcopy for most common types, but semantically this was the same). This proved problematic in the face of custom types, led to some unnecessary slowdowns, and didn't match the behavior of other similar libraries like `dataclasses` or `attrs`. Since we now can support arbitrarily complex default values through the `default_factory` function, we drop the old `deepcopy` behavior.

A default value on a `Struct` now has the following rules:
- Common mutable containers (list, dict, set, bytearray) will error if used as the default value *if* they aren't empty. The error points users to use a `default_factory` instead.
- Empty common mutable containers (`[]`, `{}`, `set()`, `bytearray()`) are accepted as default values. These are treated as syntactic sugar, and are automatically converted to the equivalent `default_factory` notation (`[]` -> `field(default_factory=list)`).
- Mutable struct types will error if used as default values. The error points users to use a `default_factory` instead.
- Frozen struct types are accepted as a default value, and are used directly without deepcopying. 
- All other values are used directly without deepcopying

Since most mutable default values are empty collections, I don't expect this breaking change to affect most users. To reiterate, the following type definition is still valid:

```python
class Example(Struct):
    x: list[int] = []
    y: set[int] = set()
    z: dict[str, int] = {}
```

while this one will error, and should use a `default_factory` instead:

```python
class Bad(Struct):
    x: list[int] = [1, 2, 3]

# should be
class Good(Struct):
    x: list[int] = field(default_factory=lambda: [1, 2, 3])
```

Todo:
- [x] Tests
- [x] Docs
- [x] Ensure all examples are updated to the newer syntax