### PR TITLE
Fixup issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,13 +9,15 @@ body:
     id: description
     attributes:
       label: Description
-      description: |
+      description: >
         Describe the bug. What happened? What did you expect to happen?
+
 
         When possible, please also include a [minimal, complete, verifiable
         example](https://stackoverflow.com/help/minimal-reproducible-example).
         Ideally this should be code that can be run without modification to
         demonstrate the problem.
+
 
         When including errors and tracebacks, please include the _full
         traceback_ as well as the code that generated the error (or at least

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -9,12 +9,14 @@ body:
     id: description
     attributes:
       label: Description
-      description: |
+      description: >
         Describe the feature. What problems does it solve?
+
 
         If the feature is to related to a problem, please describe in detail
         your use case. What would this new feature help you do that you
         couldn't do before? Why is this useful?
+
 
         When relevant, please also include example code making use of your
         proposed feature. How would you use this feature? What would code using


### PR DESCRIPTION
Manually fix whitespace/newline issues in the markdown, since the markdown renderer here doesn't seem to handle whitespace the same way github's markdown renderer does elsewhere.