### PR TITLE
Support ClassVar on Struct types

### DIFF
--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -224,6 +224,37 @@ The generated ``__init__()`` for ``Subclass`` looks like:
 The field ordering rules for ``Struct`` types are identical to those for
 `dataclasses`, see the `dataclasses docs <dataclasses>`_ for more information.
 
+Class Variables
+---------------
+
+Like `dataclasses`, `msgspec.Struct` types will exclude any attribute
+annotations wrapped in `typing.ClassVar` from their fields.
+
+.. code-block:: python
+
+   >>> import msgspec
+
+   >>> from typing import ClassVar
+
+   >>> class Example(msgspec.Struct):
+   ...     x: int
+   ...     a_class_variable: ClassVar[int] = 2
+
+   >>> Example.a_class_variable
+   2
+
+   >>> Example(1)  # only `x` is counted as a field
+   Example(x=1)
+
+Note that if using `PEP 563`_ "postponed evaluation of annotations" (e.g.
+``from __future__ import annotations``) only the following spellings will work:
+
+- ``ClassVar`` or ``ClassVar[<type>]``
+- ``typing.ClassVar`` or ``typing.ClassVar[<type>]``
+
+Importing ``ClassVar`` or ``typing`` under an aliased name (e.g. ``import
+typing as typ`` or ``from typing import ClassVar as CV``) will not be properly
+detected.
 
 Type Validation
 ---------------
@@ -862,7 +893,8 @@ collected (leading to a memory leak).
 
 .. _type annotations: https://docs.python.org/3/library/typing.html
 .. _pattern matching: https://docs.python.org/3/reference/compound_stmts.html#the-match-statement
-.. _PEP 636: https://www.python.org/dev/peps/pep-0636/
+.. _PEP 636: https://peps.python.org/pep-0636/
+.. _PEP 563: https://peps.python.org/pep-0563/
 .. _dataclasses: https://docs.python.org/3/library/dataclasses.html
 .. _attrs: https://www.attrs.org/en/stable/index.html
 .. _pydantic: https://pydantic-docs.helpmanual.io/


### PR DESCRIPTION
Previously this was unsupported.

Postponed annotation evaluations are a bit of a tricky issue here. We currently don't parse type annotations at import time (we do so lazily on the first decode call). This is nice for two reasons:

- It keeps import times quick. Especially for CLI applications where not all struct types will be decoded in a single invocation, it pays off to avoid parsing types unless needed.
- It plays better with recursive structures, since we won't ever parse a type that isn't fully defined.

However, we do need to know which attributes are/aren't fields at Struct type definition time, which means we'll have to detect if an attribute is a `ClassVar` *without* eval-ing the annotation string. This is a bit tricky to get right (enough), without compromising on performance.

Our solution is to only accept `ClassVar` annotations of the following forms:

- `ClassVar` and `ClassVar[<type>]`
- `typing.ClassVar` and `typing.ClassVar[<type>]`

Importing either `ClassVar` or `typing` under an alias won't be detected with postponed annotations. I did a quick survey of projects and couldn't find a use of `ClassVar` that didn't fall into one of these cases, so I think we're fine here.

Note that this doesn't rely solely on string comparisons, that's just a fast-filter to discard the 99% of fields that aren't class variables. So the following annotation is properly detected to not be a class variable:

```python
from msgspec import Struct

ClassVar = list

class Example(Struct):
    x: ClassVar[int]  # msgspec can tell that this isn't a ClassVar
```

With this optimization, `ClassVar` detection has a negligible effect on struct import performance, while still supporting all the common cases.

Fixes #276.