### PR TITLE
Add new `msgspec.structs` module

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -155,6 +155,16 @@ Inspect
 .. autodata:: UNSET
 
 
+Struct Utilities
+----------------
+
+.. currentmodule:: msgspec.structs
+
+.. autoclass:: StructInfo
+.. autoclass:: StructField
+.. autofunction:: info
+
+
 Exceptions
 ----------
 

--- a/msgspec/__init__.py
+++ b/msgspec/__init__.py
@@ -18,6 +18,7 @@ from . import json
 from . import yaml
 from . import toml
 from . import inspect
+from . import structs
 
 
 def field(*, default=UNSET, default_factory=UNSET):

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -182,5 +182,6 @@ from . import json
 from . import yaml
 from . import toml
 from . import inspect
+from . import structs
 
 __version__: str

--- a/msgspec/structs.py
+++ b/msgspec/structs.py
@@ -1,0 +1,132 @@
+from typing import Any, Tuple, Type, Union
+
+import msgspec
+from msgspec import UNSET
+from ._core import nodefault as _nodefault, Factory as _Factory
+from ._utils import get_type_hints as _get_type_hints
+
+__all__ = ("info", "StructField", "StructInfo", "UNSET")
+
+
+def __dir__():
+    return __all__
+
+
+class StructField(msgspec.Struct):
+    """A record describing a field in a struct type.
+
+    Parameters
+    ----------
+    name: str
+        The field name as seen by Python code (e.g. ``field_one``).
+    encode_name: str
+        The name used when encoding/decoding the field. This may differ if
+        the field is renamed (e.g. ``fieldOne``).
+    annotation: Any
+        The full field type annotation.
+    default: Any, optional
+        A default value for the field. Will be `UNSET` if no default value is set.
+    default_factory: Any, optional
+        A callable that creates a default value for the field. Will be
+        `UNSET` if no ``default_factory`` is set.
+    """
+
+    name: str
+    encode_name: str
+    annotation: Any
+    default: Any = UNSET
+    default_factory: Any = UNSET
+
+    @property
+    def required(self) -> bool:
+        """A helper for checking whether a field is required"""
+        return self.default is UNSET and self.default_factory is UNSET
+
+
+class StructInfo(msgspec.Struct):
+    """Information about a Struct type.
+
+    Parameters
+    ----------
+    cls: type
+        The corresponding Struct type.
+    fields: Tuple[StructField, ...]
+        A tuple of fields in the Struct.
+    tag_field: str or None, optional
+        If set, the field name used for the tag in a tagged union.
+    tag: str, int, or None, optional
+        If set, the value used for hte tag in a tagged union.
+    array_like: bool, optional
+        Whether the struct is encoded as an array rather than an object.
+    forbid_unknown_fields: bool, optional
+        If ``False`` (the default) unknown fields are ignored when decoding. If
+        ``True`` any unknown fields will result in an error.
+    """
+
+    cls: Type[msgspec.Struct]
+    fields: Tuple[StructField, ...]
+    tag_field: Union[str, None] = None
+    tag: Union[str, int, None] = None
+    array_like: bool = False
+    forbid_unknown_fields: bool = False
+
+
+def info(type: Type[msgspec.Struct]) -> StructInfo:
+    """Get information about a Struct type.
+
+    Parameters
+    ----------
+    type: type
+        The Struct type to inspect.
+
+    Returns
+    -------
+    info: StructInfo
+
+    Notes
+    -----
+    This differs from `msgspec.inspect.type_info` in two ways:
+
+    - It only works on `msgspec.Struct` types.
+    - It doesn't recurse down into the field types.
+
+    In many cases you probably want to use `msgspec.inspect.type_info` instead,
+    as it handles all the types msgspec supports, and normalizes the various
+    ways identical Python type annotations may be spelled into a type checked
+    and consistent tree.
+
+    See Also
+    --------
+    msgspec.inspect.type_info
+    """
+    hints = _get_type_hints(type)
+    npos = len(type.__struct_fields__) - len(type.__struct_defaults__)
+    fields = []
+    for name, encode_name, default_obj in zip(
+        type.__struct_fields__,
+        type.__struct_encode_fields__,
+        (_nodefault,) * npos + type.__struct_defaults__,
+    ):
+        default = default_factory = UNSET
+        if isinstance(default_obj, _Factory):
+            default_factory = default_obj.factory
+        elif default_obj is not _nodefault:
+            default = default_obj
+
+        field = StructField(
+            name=name,
+            encode_name=encode_name,
+            annotation=hints[name],
+            default=default,
+            default_factory=default_factory,
+        )
+        fields.append(field)
+
+    return StructInfo(
+        type,
+        tuple(fields),
+        tag_field=type.__struct_tag_field__,
+        tag=type.__struct_tag__,
+        array_like=type.array_like,
+        forbid_unknown_fields=type.forbid_unknown_fields,
+    )

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -789,6 +789,20 @@ def check_consume_inspect_types() -> None:
 
 
 ##########################################################
+# msgspec.structs                                        #
+##########################################################
+
+def check_structs_info() -> None:
+    class Point(msgspec.Struct):
+        x: int
+        y: int
+
+    o = msgspec.structs.info(Point)
+    reveal_type(o)  # assert "StructInfo" in typ
+    reveal_type(o.fields[0])  # assert "StructField" in typ
+
+
+##########################################################
 # JSON Schema                                            #
 ##########################################################
 

--- a/tests/test_struct_utils.py
+++ b/tests/test_struct_utils.py
@@ -1,0 +1,98 @@
+import pytest
+
+import msgspec
+import msgspec.structs as ms
+
+
+class TestStructInfo:
+    def test_struct_field(self):
+        def factory():
+            return 1
+
+        class Example(msgspec.Struct):
+            x: int
+            y: int = 0
+            z: int = msgspec.field(default_factory=factory)
+
+        info = ms.info(Example)
+        x_field, y_field, z_field = info.fields
+
+        assert x_field.required
+        assert x_field.default is ms.UNSET
+        assert x_field.default_factory is ms.UNSET
+
+        assert not y_field.required
+        assert y_field.default == 0
+        assert y_field.default_factory is ms.UNSET
+
+        assert not z_field.required
+        assert z_field.default is ms.UNSET
+        assert z_field.default_factory is factory
+
+    @pytest.mark.parametrize(
+        "kw",
+        [
+            {},
+            {"array_like": True},
+            {"forbid_unknown_fields": True},
+            {"tag": "Example", "tag_field": "type"},
+        ],
+    )
+    def test_struct_info(self, kw):
+        def factory():
+            return "foo"
+
+        class Example(msgspec.Struct, **kw):
+            x: int
+            y: int = 0
+            z: int = msgspec.field(default_factory=factory)
+
+        sol = ms.StructInfo(
+            cls=Example,
+            fields=(
+                ms.StructField("x", "x", int),
+                ms.StructField("y", "y", int, default=0),
+                ms.StructField("z", "z", int, default_factory=factory),
+            ),
+            **kw
+        )
+        assert ms.info(Example) == sol
+
+    def test_struct_info_no_fields(self):
+        class Example(msgspec.Struct):
+            pass
+
+        sol = ms.StructInfo(Example, fields=())
+        assert ms.info(Example) == sol
+
+    def test_struct_info_keyword_only(self):
+        class Example(msgspec.Struct, kw_only=True):
+            a: int
+            b: int = 1
+            c: int
+            d: int = 2
+
+        sol = ms.StructInfo(
+            Example,
+            fields=(
+                ms.StructField("a", "a", int),
+                ms.StructField("b", "b", int, default=1),
+                ms.StructField("c", "c", int),
+                ms.StructField("d", "d", int, default=2),
+            ),
+        )
+        assert ms.info(Example) == sol
+
+    def test_struct_info_encode_name(self):
+        class Example(msgspec.Struct, rename="camel"):
+            field_one: int
+            field_two: int
+
+        sol = ms.StructInfo(
+            Example,
+            fields=(
+                ms.StructField("field_one", "fieldOne", int),
+                ms.StructField("field_two", "fieldTwo", int),
+            ),
+        )
+        assert ms.info(Example) == sol


### PR DESCRIPTION
This adds a new `msgspec.structs` module. The purpose of this module is to include struct-related utilities that aren't worth surfacing to the top-level namespace, but don't really belong anywhere else either.

So far this just includes a new `msgspec.structs.info` function (and return types) for inspecting information about a struct type. This is a shallow-version of the full-featured `msgspec.inspect.type_info` function:

- It only works for struct types
- It doesn't recurse into the field types

Most use cases where you're inspecting msgspec types you probably want to use `msgspec.inspect.type_info` instead.

(Maybe) fixes #275.