### PR TITLE
Decimal support

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -133,6 +133,7 @@ Inspect
 .. autoclass:: TimeType
 .. autoclass:: DateType
 .. autoclass:: UUIDType
+.. autoclass:: DecimalType
 .. autoclass:: ExtType
 .. autoclass:: RawType
 .. autoclass:: EnumType

--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -20,6 +20,7 @@ Most combinations of the following types are supported (with a few restrictions)
 - `datetime.date`
 - `datetime.time`
 - `uuid.UUID`
+- `decimal.Decimal`
 - `typing.Any`
 - `typing.Optional`
 - `typing.Union`
@@ -317,6 +318,31 @@ timezone-naive by specifying a ``tz`` constraint (see
         File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Invalid UUID
 
+``decimal``
+-----------
+
+`decimal.Decimal` values are serialized as their string representation in all
+protocols. This ensures no precision loss during serialization, as would happen
+with a float representation.
+
+.. code-block:: python
+
+    >>> import decimal
+
+    >>> x = decimal.Decimal("1.2345")
+
+    >>> msg = msgspec.json.encode(x)
+
+    >>> msg
+    b'"1.2345"'
+
+    >>> msgspec.json.decode(msg, type=decimal.Decimal)
+    Decimal('1.2345')
+
+    >>> msgspec.json.decode(b'"oops"', type=decimal.Decimal)
+    Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Invalid decimal string
 
 ``list`` / ``tuple`` / ``set`` / ``frozenset``
 ----------------------------------------------
@@ -714,9 +740,9 @@ Union restrictions are as follows:
 
 - Unions may contain at most one type that encodes to a string (`str`,
   `enum.Enum`, `bytes`, `bytearray`, `datetime.datetime`, `datetime.date`,
-  `datetime.time`, `uuid.UUID`). Note that this restriction is fixable with
-  some work, if this is a feature you need please `open an issue
-  <https://github.com/jcrist/msgspec/issues>`__.
+  `datetime.time`, `uuid.UUID`, `decimal.Decimal`). Note that this restriction
+  is fixable with some work, if this is a feature you need please `open an
+  issue <https://github.com/jcrist/msgspec/issues>`__.
 
 - Unions may contain at most one type that encodes to an object (`dict`,
   `typing.TypedDict`, `dataclasses.dataclass`, `Struct` with

--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -233,6 +233,9 @@ def _to_schema(
     elif isinstance(t, mi.UUIDType):
         schema["type"] = "string"
         schema["format"] = "uuid"
+    elif isinstance(t, mi.DecimalType):
+        schema["type"] = "string"
+        schema["format"] = "decimal"
     elif isinstance(t, mi.CollectionType):
         schema["type"] = "array"
         if not isinstance(t.item_type, mi.AnyType):

--- a/msgspec/inspect.py
+++ b/msgspec/inspect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import decimal
 import enum
 import uuid
 from collections.abc import Iterable
@@ -48,6 +49,7 @@ __all__ = (
     "TimeType",
     "DateType",
     "UUIDType",
+    "DecimalType",
     "ExtType",
     "RawType",
     "EnumType",
@@ -248,6 +250,10 @@ class DateType(Type):
 
 class UUIDType(Type):
     """A type corresponding to `uuid.UUID`."""
+
+
+class DecimalType(Type):
+    """A type corresponding to `decimal.Decimal`."""
 
 
 class ExtType(Type):
@@ -795,6 +801,8 @@ class _Translator:
             return DateType()
         elif t is uuid.UUID:
             return UUIDType()
+        elif t is decimal.Decimal:
+            return DecimalType()
         elif t is msgspec.Raw:
             return RawType()
         elif t is msgspec.msgpack.Ext:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import decimal
 import enum
 import gc
 import sys
@@ -2435,3 +2436,22 @@ class TestNewType:
         for bad in [-1, 11]:
             with pytest.raises(msgspec.ValidationError):
                 dec.decode(proto.encode(bad))
+
+
+class TestDecimal:
+    def test_encode_decimal(self, proto):
+        d = decimal.Decimal("1.5")
+        s = str(d)
+        assert proto.encode(d) == proto.encode(s)
+
+    def test_decode_decimal(self, proto):
+        d = decimal.Decimal("1.5")
+        msg = proto.encode(d)
+        res = proto.decode(msg, type=decimal.Decimal)
+        assert type(res) is decimal.Decimal
+        assert res == d
+
+    def test_decode_decimal_invalid(self, proto):
+        msg = proto.encode("1..5")
+        with pytest.raises(msgspec.ValidationError, match="Invalid decimal string"):
+            proto.decode(msg, type=decimal.Decimal)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -146,6 +146,10 @@ def test_uuid():
     assert mi.type_info(uuid.UUID) == mi.UUIDType()
 
 
+def test_decimal():
+    assert mi.type_info(decimal.Decimal) == mi.DecimalType()
+
+
 def test_raw():
     assert mi.type_info(msgspec.Raw) == mi.RawType()
 
@@ -177,7 +181,7 @@ def test_newtype():
 
 
 def test_custom():
-    assert mi.type_info(decimal.Decimal) == mi.CustomType(decimal.Decimal)
+    assert mi.type_info(complex) == mi.CustomType(complex)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -57,12 +57,12 @@ def test_msgpack_ext():
 
 def test_custom():
     with pytest.raises(TypeError, match="Custom types"):
-        assert msgspec.json.schema(decimal.Decimal)
+        assert msgspec.json.schema(complex)
 
-    schema = {"type": "string", "format": "decimal"}
+    schema = {"type": "string", "format": "complex"}
 
     assert (
-        msgspec.json.schema(Annotated[decimal.Decimal, Meta(extra_json_schema=schema)])
+        msgspec.json.schema(Annotated[complex, Meta(extra_json_schema=schema)])
         == schema
     )
 
@@ -138,6 +138,13 @@ def test_uuid():
     assert msgspec.json.schema(uuid.UUID) == {
         "type": "string",
         "format": "uuid",
+    }
+
+
+def test_decimal():
+    assert msgspec.json.schema(decimal.Decimal) == {
+        "type": "string",
+        "format": "decimal",
     }
 
 

--- a/tests/test_to_builtins.py
+++ b/tests/test_to_builtins.py
@@ -1,5 +1,6 @@
 import base64
 import datetime
+import decimal
 import enum
 import os
 import sys
@@ -175,6 +176,15 @@ class TestToBuiltins:
     def test_uuid_builtin_types(self):
         msg = uuid.uuid4()
         res = to_builtins(msg, builtin_types=(uuid.UUID,))
+        assert res is msg
+
+    def test_decimal(self):
+        msg = decimal.Decimal("1.5")
+        assert to_builtins(msg) == str(msg)
+
+    def test_decimal_builtin_types(self):
+        msg = decimal.Decimal("1.5")
+        res = to_builtins(msg, builtin_types=(decimal.Decimal,))
         assert res is msg
 
     def test_intenum(self):


### PR DESCRIPTION
This adds builtin support for `decimal.Decimal` types. These are encoded/decoded as their string representation, ensuring now precision loss on roundtripping.

Fixes #287 