### PR TITLE
Add support for abstract types

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -4,6 +4,8 @@ Supported Types
 ``msgspec`` uses Python `type annotations`_ to describe the expected types.
 Most combinations of the following types are supported (with a few restrictions):
 
+**Builtin Types**
+
 - `None`
 - `bool`
 - `int`
@@ -16,11 +18,26 @@ Most combinations of the following types are supported (with a few restrictions)
 - `dict` / `typing.Dict`
 - `set` / `typing.Set`
 - `frozenset` / `typing.FrozenSet`
+
+**Msgspec types**
+
+- `msgspec.msgpack.Ext`
+- `msgspec.Raw`
+- `msgspec.Struct` types
+
+**Standard Library Types**
+
 - `datetime.datetime`
 - `datetime.date`
 - `datetime.time`
 - `uuid.UUID`
 - `decimal.Decimal`
+- `enum.Enum` types
+- `enum.IntEnum` types
+- `dataclasses.dataclass` types
+
+**Typing module types**
+
 - `typing.Any`
 - `typing.Optional`
 - `typing.Union`
@@ -28,13 +45,18 @@ Most combinations of the following types are supported (with a few restrictions)
 - `typing.NewType`
 - `typing.NamedTuple` / `collections.namedtuple`
 - `typing.TypedDict`
-- `dataclasses.dataclass` types
-- `msgspec.msgpack.Ext`
-- `msgspec.Raw`
-- `enum.Enum` types
-- `enum.IntEnum` types
-- `msgspec.Struct` types
-- Custom types (see :doc:`extending`)
+
+**Abstract types**
+
+- `collections.abc.Collection` / `typing.Collection`
+- `collections.abc.Sequence` / `typing.Sequence`
+- `collections.abc.MutableSequence` / `typing.MutableSequence`
+- `collections.abc.Set` / `typing.AbstractSet`
+- `collections.abc.MutableSet` / `typing.MutableSet`
+- `collections.abc.Mapping` / `typing.Mapping`
+- `collections.abc.MutableMapping` / `typing.MutableMapping`
+
+Additional types may be supported through :doc:`extensions <extending>`.
 
 Note that except where explicitly stated, subclasses of these types are not
 supported by default (see :doc:`extending` for how to add support yourself).
@@ -724,6 +746,40 @@ support here is purely to aid static analysis tools like mypy_ or pyright_.
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `int`, got `str`
+
+Abstract Types
+--------------
+
+``msgspec`` supports several "abstract" types, decoding them as
+instances of their most common concrete type.
+
+**Decoded as lists**
+
+- `collections.abc.Collection` / `typing.Collection`
+- `collections.abc.Sequence` / `typing.Sequence`
+- `collections.abc.MutableSequence` / `typing.MutableSequence`
+
+**Decoded as sets**
+
+- `collections.abc.Set` / `typing.AbstractSet`
+- `collections.abc.MutableSet` / `typing.MutableSet`
+
+**Decoded as dicts**
+
+- `collections.abc.Mapping` / `typing.Mapping`
+- `collections.abc.MutableMapping` / `typing.MutableMapping`
+
+.. code-block:: python
+
+    >>> from typing import MutableMapping
+
+    >>> msgspec.json.decode(b'{"x": 1}', type=MutableMapping[str, int])
+    {"x": 1}
+
+    >>> msgspec.json.decode(b'{"x": "oops"}', type=MutableMapping[str, int])
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Expected `int`, got `str` - at `$[...]`
 
 ``Union`` /  ``Optional``
 -------------------------

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -1,4 +1,7 @@
 # type: ignore
+import typing
+import collections
+
 try:
     from typing_extensions import _AnnotatedAlias
 except Exception:
@@ -28,6 +31,53 @@ else:
 
     def get_type_hints(obj):
         return _get_type_hints(obj, include_extras=True)
+
+
+# A mapping from a type annotation (or annotation __origin__) to the concrete
+# python type that msgspec will use when decoding. Note that non-collection
+# types don't strict need to be in this mapping. Common ones are added to avoid
+# an unnecessary `getattr(t, "__origin__", None)` call on them.
+# THIS IS PRIVATE FOR A REASON. DON'T MUCK WITH THIS.
+_CONCRETE_TYPES = {
+    t: t
+    for t in [
+        None,
+        bool,
+        int,
+        float,
+        str,
+        bytes,
+        bytearray,
+        list,
+        tuple,
+        set,
+        frozenset,
+        dict,
+    ]
+}
+_CONCRETE_TYPES.update(
+    {
+        typing.List: list,
+        typing.Tuple: tuple,
+        typing.Set: set,
+        typing.FrozenSet: frozenset,
+        typing.Dict: dict,
+        typing.Collection: list,
+        typing.MutableSequence: list,
+        typing.Sequence: list,
+        typing.MutableMapping: dict,
+        typing.Mapping: dict,
+        typing.MutableSet: set,
+        typing.AbstractSet: set,
+        collections.abc.Collection: list,
+        collections.abc.MutableSequence: list,
+        collections.abc.Sequence: list,
+        collections.abc.MutableSet: set,
+        collections.abc.Set: set,
+        collections.abc.MutableMapping: dict,
+        collections.abc.Mapping: dict,
+    }
+)
 
 
 def get_typeddict_hints(obj):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
-import enum
 import datetime
 import decimal
+import enum
+import typing
 import uuid
 from base64 import b64encode
 from collections import namedtuple
@@ -207,6 +208,21 @@ def test_dict_any(typ):
 @pytest.mark.parametrize("cls", [dict, Dict])
 def test_dict_typed(cls):
     typ = type_index(cls, (str, int))
+    assert msgspec.json.schema(typ) == {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+    }
+
+
+def test_abstract_sequence():
+    # Only testing one here, the main tests are in `test_inspect`
+    typ = typing.Sequence[int]
+    assert msgspec.json.schema(typ) == {"type": "array", "items": {"type": "integer"}}
+
+
+def test_abstract_mapping():
+    # Only testing one here, the main tests are in `test_inspect`
+    typ = typing.MutableMapping[str, int]
     assert msgspec.json.schema(typ) == {
         "type": "object",
         "additionalProperties": {"type": "integer"},


### PR DESCRIPTION
This adds support for the following abstract types, mapping them to the most common concrete instance of that type:

**Decoded as lists**

- `collections.abc.Collection` / `typing.Collection`
- `collections.abc.Sequence` / `typing.Sequence`
- `collections.abc.MutableSequence` / `typing.MutableSequence`

**Decoded as sets**

- `collections.abc.Set` / `typing.AbstractSet`
- `collections.abc.MutableSet` / `typing.MutableSet`

**Decoded as dicts**

- `collections.abc.Mapping` / `typing.Mapping`
- `collections.abc.MutableMapping` / `typing.MutableMapping`