### PR TITLE
Json extended dict key types

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -449,9 +449,9 @@ Dict subclasses (`collections.OrderedDict`, for example) are also supported for
 encoding only. To decode into a ``dict`` subclass you'll need to implement a
 ``dec_hook`` (see :doc:`extending`).
 
-JSON and TOML only support `str`, `Literal`, `Enum`, `int`, and `IntEnum` key
-types (integers are encoded as strings). MessagePack and YAML support any
-hashable for the key type.
+JSON and TOML only support key types that encode as strings or integers (for
+example `str`, `int`, `enum.Enum`, `datetime.datetime`, `uuid.UUID`, ...).
+MessagePack and YAML support any hashable for the key type.
 
 An error is raised during decoding if the keys or values don't match their
 respective types (if specified).

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1863,11 +1863,14 @@ class TestDict:
             decimal.Decimal("1.5"),
         ],
     )
-    def test_encode_dict_key_types(self, key):
+    def test_roundtrip_dict_key_types(self, key):
         msg = {key: 100}
         sol = msgspec.json.encode(msgspec.to_builtins(msg, str_keys=True))
         res = msgspec.json.encode(msg)
         assert res == sol
+
+        msg2 = msgspec.json.decode(sol, type=Dict[type(key), int])
+        assert msg == msg2
 
     def test_decode_dict_int_enum_key(self):
         dec = msgspec.json.Decoder(Dict[FruitInt, int])


### PR DESCRIPTION
Support JSON encoding and decoding any str-like or int-like dict key
    
Previously the JSON encoder/decoder only supported dicts with `str` or `int` keys. We now support using any type that maps to an `int` or `str` as a dict key.