### PR TITLE
Fix refcount bug in json decoding of Struct types

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -15338,7 +15338,6 @@ json_decode_struct_map_inner(
             TypeNode *type = st_type->struct_types[field_index];
             val = json_decode(self, type, &field_path);
             if (val == NULL) goto error;
-            Py_INCREF(val);
             Struct_set_index(out, field_index, val);
         }
         else if (MS_UNLIKELY(field_index == -2)) {

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2095,6 +2095,9 @@ class TestStruct:
         x = dec.decode(msg)
         assert x == Person("harry", "potter", 13, False)
 
+        # one for struct, one for output of getattr, and one for getrefcount
+        assert sys.getrefcount(x.first) == 3
+
         with pytest.raises(
             msgspec.ValidationError, match="Expected `object`, got `int`"
         ):


### PR DESCRIPTION
This bug resulted in a memory leak when decoding JSON into Struct types. This issue was introduced in 0.13.0 due to a misplaced INCREF.

This PR fixes the issue, and adds a test to prevent a regression.

Fixes #311.