### PR TITLE
Support encoding and decoding attrs types

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -12916,7 +12916,7 @@ mpack_decode_dataclass(
             PathNode field_path = {path, PATH_STR, field};
             PyObject *val = mpack_decode(self, field_type, &field_path, false);
             if (val == NULL) goto error;
-            int status = PyObject_SetAttr(out, field, val);
+            int status = PyObject_GenericSetAttr(out, field, val);
             Py_DECREF(val);
             if (status < 0) goto error;
         }
@@ -15520,7 +15520,7 @@ json_decode_dataclass(
             PathNode field_path = {path, PATH_STR, field};
             PyObject *val = json_decode(self, field_type, &field_path);
             if (val == NULL) goto error;
-            int status = PyObject_SetAttr(out, field, val);
+            int status = PyObject_GenericSetAttr(out, field, val);
             Py_DECREF(val);
             if (status < 0) goto error;
         }
@@ -18270,7 +18270,7 @@ from_builtins_dataclass(
             PathNode field_path = {path, PATH_STR, field};
             PyObject *val = from_builtins(self, val_obj, field_type, &field_path);
             if (val == NULL) goto error;
-            int status = PyObject_SetAttr(out, field, val);
+            int status = PyObject_GenericSetAttr(out, field, val);
             Py_DECREF(val);
             if (status < 0) goto error;
         }

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -362,6 +362,7 @@ typedef struct {
     PyObject *str__field_defaults;
     PyObject *str___dataclass_fields__;
     PyObject *str___post_init__;
+    PyObject *str___attrs_attrs__;
     PyObject *str___supertype__;
     PyObject *str_int;
     PyObject *str_is_safe;
@@ -10664,6 +10665,9 @@ mpack_encode_uncommon(EncoderState *self, PyTypeObject *type, PyObject *obj)
     else if (PyDict_Contains(type->tp_dict, self->mod->str___dataclass_fields__)) {
         return mpack_encode_object(self, obj);
     }
+    else if (PyDict_Contains(type->tp_dict, self->mod->str___attrs_attrs__)) {
+        return mpack_encode_object(self, obj);
+    }
 
     if (self->enc_hook != NULL) {
         int status = -1;
@@ -11525,6 +11529,9 @@ json_encode_uncommon(EncoderState *self, PyTypeObject *type, PyObject *obj) {
         return json_encode_set(self, obj);
     }
     else if (PyDict_Contains(type->tp_dict, self->mod->str___dataclass_fields__)) {
+        return json_encode_object(self, obj);
+    }
+    else if (PyDict_Contains(type->tp_dict, self->mod->str___attrs_attrs__)) {
         return json_encode_object(self, obj);
     }
 
@@ -17170,6 +17177,9 @@ to_builtins(ToBuiltinsState *self, PyObject *obj, bool is_key) {
     else if (PyDict_Contains(type->tp_dict, self->mod->str___dataclass_fields__)) {
         return to_builtins_object(self, obj);
     }
+    else if (PyDict_Contains(type->tp_dict, self->mod->str___attrs_attrs__)) {
+        return to_builtins_object(self, obj);
+    }
     else if (self->enc_hook != NULL) {
         PyObject *out = NULL;
         PyObject *temp;
@@ -18534,6 +18544,7 @@ msgspec_clear(PyObject *m)
     Py_CLEAR(st->str__field_defaults);
     Py_CLEAR(st->str___dataclass_fields__);
     Py_CLEAR(st->str___post_init__);
+    Py_CLEAR(st->str___attrs_attrs__);
     Py_CLEAR(st->str___supertype__);
     Py_CLEAR(st->str_int);
     Py_CLEAR(st->str_is_safe);
@@ -18919,6 +18930,7 @@ PyInit__core(void)
     CACHED_STRING(str__field_defaults, "_field_defaults");
     CACHED_STRING(str___dataclass_fields__, "__dataclass_fields__");
     CACHED_STRING(str___post_init__, "__post_init__");
+    CACHED_STRING(str___attrs_attrs__, "__attrs_attrs__");
     CACHED_STRING(str___supertype__, "__supertype__");
     CACHED_STRING(str_int, "int");
     CACHED_STRING(str_is_safe, "is_safe");

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ ext_modules = [
 yaml_deps = ["pyyaml"]
 toml_deps = ['tomli ; python_version < "3.11"', "tomli_w"]
 doc_deps = ["sphinx", "furo", "sphinx-copybutton", "sphinx-design", "ipython"]
-test_deps = ["pytest", "mypy", "pyright", "msgpack", *yaml_deps, *toml_deps]
+test_deps = ["pytest", "mypy", "pyright", "msgpack", "attrs", *yaml_deps, *toml_deps]
 dev_deps = ["pre-commit", "coverage", "gcovr", *doc_deps, *test_deps]
 
 extras_require = {

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2018,6 +2018,16 @@ class TestDataclass:
         with pytest.raises(ValueError, match="Oh no!"):
             proto.decode(proto.encode({}), type=Example)
 
+    def test_decode_dataclass_frozen(self, proto):
+        @dataclass(frozen=True)
+        class Point:
+            x: int
+            y: int
+
+        msg = proto.encode(Point(1, 2))
+        res = proto.decode(msg, type=Point)
+        assert res == Point(1, 2)
+
     def test_decode_dataclass_post_init(self, proto):
         called = False
 
@@ -2203,6 +2213,16 @@ class TestAttrs:
 
         with pytest.raises(ValueError, match="Oh no!"):
             proto.decode(proto.encode({}), type=Example)
+
+    def test_decode_attrs_frozen(self, proto):
+        @attrs.define(frozen=True)
+        class Example:
+            x: int
+            y: int
+
+        msg = Example(1, 2)
+        res = proto.decode(proto.encode(msg), type=Example)
+        assert res == Example(1, 2)
 
     def test_decode_attrs_post_init(self, proto):
         called = False

--- a/tests/test_from_builtins.py
+++ b/tests/test_from_builtins.py
@@ -1055,6 +1055,16 @@ class TestAttrs:
         with pytest.raises(ValidationError, match="missing required field `a`"):
             roundtrip({"c": 1, "d": 2, "e": 3}, Example)
 
+    def test_attrs_frozen(self):
+        @attrs.define(frozen=True)
+        class Example:
+            x: int
+            y: int
+
+        msg = Example(1, 2)
+        res = roundtrip(msg, Example)
+        assert res == msg
+
     def test_attrs_pre_init(self):
         called = False
 

--- a/tests/test_to_builtins.py
+++ b/tests/test_to_builtins.py
@@ -416,6 +416,18 @@ class TestToBuiltins:
         with pytest.raises(TypeError, match="Encoding objects of type Bad"):
             to_builtins(msg)
 
+    @pytest.mark.parametrize("slots", [True, False])
+    def test_attrs(self, slots):
+        attrs = pytest.importorskip("attrs")
+
+        @attrs.define(slots=slots)
+        class Ex:
+            x: int
+            y: FruitInt
+
+        msg = Ex(1, FruitInt.APPLE)
+        assert to_builtins(msg) == {"x": 1, "y": -1}
+
     def test_custom(self):
         with pytest.raises(TypeError, match="Encoding objects of type Bad"):
             to_builtins(Bad())


### PR DESCRIPTION
This adds support for encoding/decoding attrs types. It's mostly built off of our existing `dataclasses` functionality, and has the same restrictions:

- When encoding, any *object* attribute without a leading underscore is encoded using the attribute name, even if it's not marked as an attribute as part of the class definition. This is for performance reasons, accessing `__attrs_attrs__` at encoding time comes at a perf cost.
- When decoding, the `__init__` method on the class is not called. This is for both efficiency and correctness reasons. As such, classes that define their own `__init__` or `__attrs_init__` will not have this called during the decoding process. `__attrs_pre_init__` and `__attrs_post_init__` methods are called at the proper times though.
- Currently default factories with `takes_self=True` are not supported. We could support this, but it was more work than I wanted to do right now.

Note that right now neither attrs' validators or convertors are run on decode. This is fixable, but would require a lot more work since this would diverge from the existing `dataclasses` implementation.

All in all this was pretty straightforward to get working. It's nice that `dataclasses` and `attrs` implementations haven't diverged too much here.

This also fixes a bug in the existing dataclass decoder that prevented decoding dataclasses with `frozen=True` configured.

Fixes #51.

Related to (but doesn't resolve) #316.