### PR TITLE
Add `msgspec.structs.fields` utility

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,7 +18,13 @@ Structs
 
 .. autofunction:: msgspec.structs.astuple
 
+.. autofunction:: msgspec.structs.fields
+
+.. autoclass:: msgspec.structs.FieldInfo
+
 .. autoclass:: msgspec.structs.StructConfig
+
+.. autodata:: UNSET
 
 Meta
 ----
@@ -157,7 +163,6 @@ Inspect
 .. autoclass:: NamedTupleType
 .. autoclass:: DataclassType
 .. autoclass:: StructType
-.. autodata:: UNSET
 
 
 Exceptions

--- a/msgspec/structs.py
+++ b/msgspec/structs.py
@@ -1,1 +1,103 @@
-from ._core import StructConfig, asdict, astuple, replace
+from __future__ import annotations
+
+from typing import Any
+
+from . import UNSET, Struct
+from ._core import (  # noqa
+    Factory as _Factory,
+    StructConfig,
+    asdict,
+    astuple,
+    nodefault as _nodefault,
+    replace,
+)
+from ._utils import _get_type_hints
+
+__all__ = (
+    "FieldInfo",
+    "StructConfig",
+    "asdict",
+    "astuple",
+    "fields",
+    "replace",
+)
+
+
+def __dir__():
+    return __all__
+
+
+class FieldInfo(Struct):
+    """A record describing a field in a struct type.
+
+    Parameters
+    ----------
+    name: str
+        The field name as seen by Python code (e.g. ``field_one``).
+    encode_name: str
+        The name used when encoding/decoding the field. This may differ if
+        the field is renamed (e.g. ``fieldOne``).
+    type: Any
+        The full field type annotation.
+    default: Any, optional
+        A default value for the field. Will be `UNSET` if no default value is set.
+    default_factory: Any, optional
+        A callable that creates a default value for the field. Will be
+        `UNSET` if no ``default_factory`` is set.
+    """
+
+    name: str
+    encode_name: str
+    type: Any
+    default: Any = UNSET
+    default_factory: Any = UNSET
+
+    @property
+    def required(self) -> bool:
+        """A helper for checking whether a field is required"""
+        return self.default is UNSET and self.default_factory is UNSET
+
+
+def fields(type_or_instance: Struct | type[Struct]) -> tuple[FieldInfo]:
+    """Get information about the fields in a Struct.
+
+    Parameters
+    ----------
+    type_or_instance:
+        A struct type or instance.
+
+    Returns
+    -------
+    tuple[FieldInfo]
+    """
+    if isinstance(type_or_instance, Struct):
+        cls = type(type_or_instance)
+    elif isinstance(type_or_instance, type) and issubclass(type_or_instance, Struct):
+        cls = type_or_instance
+    else:
+        raise TypeError("Must be called with a struct type or instance")
+
+    hints = _get_type_hints(cls)
+    npos = len(cls.__struct_fields__) - len(cls.__struct_defaults__)
+    fields = []
+    for name, encode_name, default_obj in zip(
+        cls.__struct_fields__,
+        cls.__struct_encode_fields__,
+        (_nodefault,) * npos + cls.__struct_defaults__,
+    ):
+        default = default_factory = UNSET
+        if isinstance(default_obj, _Factory):
+            default_factory = default_obj.factory
+        elif default_obj is not _nodefault:
+            default = default_obj
+
+        field = FieldInfo(
+            name=name,
+            encode_name=encode_name,
+            type=hints[name],
+            default=default,
+            default_factory=default_factory,
+        )
+        fields.append(field)
+
+    return tuple(fields)

--- a/msgspec/structs.pyi
+++ b/msgspec/structs.pyi
@@ -1,6 +1,6 @@
 from typing import Any, TypeVar, Union
 
-from . import Struct
+from . import UNSET, Struct
 
 S = TypeVar("S", bound=Struct, covariant=True)
 
@@ -20,3 +20,15 @@ class StructConfig:
     weakref: bool
     tag: Union[str, int, None]
     tag_field: Union[str, None]
+
+class FieldInfo(Struct):
+    name: str
+    encode_name: str
+    type: Any
+    default: Any = UNSET
+    default_factory: Any = UNSET
+
+    @property
+    def required(self) -> bool: ...
+
+def fields(type_or_instance: Struct | type[Struct]) -> tuple[FieldInfo]: ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ exclude =
     basic_typing_examples.py,
     json.py,
     msgpack.py,
-    structs.py,
     test_JSONTestSuite.py,
     conf.py
 ignore =

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -397,6 +397,23 @@ def check_astuple() -> None:
     reveal_type(msgspec.structs.astuple(x))  # assert "tuple" in typ
 
 
+def check_fields() -> None:
+    class Test(msgspec.Struct):
+        x: int
+        y: int
+
+    x = Test(1, 2)
+    res1 = msgspec.structs.fields(x)
+    reveal_type(res1)  # assert "tuple" in typ.lower() and "FieldInfo" in typ
+    res2 = msgspec.structs.fields(Test)
+    reveal_type(res2)  # assert "tuple" in typ.lower() and "FieldInfo" in typ
+
+    for field in res1:
+        reveal_type(field)  # assert "FieldInfo" in typ
+        reveal_type(field.required)  # assert "bool" in typ
+        reveal_type(field.name)  # assert "str" in typ
+
+
 ##########################################################
 # Meta                                                   #
 ##########################################################


### PR DESCRIPTION
This mirrors the functionality in `dataclasses.fields`, returning a tuple of `FieldInfo` objects providing information about the individual struct fields.

Supersedes #282.