### PR TITLE
Add option to define `__dict__` on `Struct` type

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -74,6 +74,7 @@ class Struct(metaclass=__StructMeta):
         array_like: bool = False,
         gc: bool = True,
         weakref: bool = False,
+        dict: bool = False,
     ) -> None: ...
     def __rich_repr__(self) -> Iterable[Tuple[str, Any]]: ...
 
@@ -102,6 +103,7 @@ def defstruct(
     array_like: bool = False,
     gc: bool = True,
     weakref: bool = False,
+    dict: bool = False,
 ) -> Type[Struct]: ...
 
 # Lie and say `Raw` is a subclass of `bytes`, so mypy will accept it in most

--- a/msgspec/structs.pyi
+++ b/msgspec/structs.pyi
@@ -18,6 +18,7 @@ class StructConfig:
     omit_defaults: bool
     forbid_unknown_fields: bool
     weakref: bool
+    dict: bool
     tag: Union[str, int, None]
     tag_field: Union[str, None]
 

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -227,6 +227,15 @@ def check_struct_weakref() -> None:
     reveal_type(t.y)  # assert "str" in typ
 
 
+def check_struct_dict() -> None:
+    class Test(msgspec.Struct, dict=True):
+        x: int
+        y: str
+
+    t = Test(1, "foo")
+    reveal_type(t)  # assert "Test" in typ
+
+
 def check_struct_tag_tag_field() -> None:
     class Test1(msgspec.Struct, tag=None):
         pass
@@ -307,6 +316,7 @@ def check_struct_config() -> None:
     reveal_type(config.omit_defaults)  # assert "bool" in typ
     reveal_type(config.forbid_unknown_fields)  # assert "bool" in typ
     reveal_type(config.weakref)  # assert "bool" in typ
+    reveal_type(config.dict)  # assert "bool" in typ
     reveal_type(config.tag)  # assert "str" in typ and "int" in typ
     reveal_type(config.tag_field)  # assert "str" in typ
 


### PR DESCRIPTION
This adds a new `dict` option on a `Struct` type, disabled by default. Enabling this will add a lazily-allocated `__dict__` attribute to all instances of that type, which can be used to store additional runtime state. Note that any data stored in the `__dict__` is _not_ encoded/decoded/pickled/copied by default.

One use of this is to support `functools.cached_property` on `Struct` instances, since this decorator stores the cached value on the instance `__dict__`.

Fixes #324, fixes #204.