### PR TITLE
Benchmark typedload

### DIFF
--- a/benchmarks/bench_library_size.py
+++ b/benchmarks/bench_library_size.py
@@ -23,6 +23,13 @@ def get_latest_310_manylinux_x86_64_wheel_size(library):
         if "310" in name and "manylinux_2_17" in name and "x86_64" in name:
             files[name] = url
     if len(files) != 1:
+        # No binary, could it be a pure python library? Let's see!
+        for file_info in resp["releases"][version]:
+            name = file_info["filename"]
+            url = file_info["url"]
+            if "py3" in name and "none" in name and "any" in name:
+                files[name] = url
+    if len(files) != 1:
         raise ValueError(
             f"Expected to find only 1 matching file for {library}, got {list(files)}"
         )
@@ -39,7 +46,7 @@ def get_latest_310_manylinux_x86_64_wheel_size(library):
 def main():
     data = [
         get_latest_310_manylinux_x86_64_wheel_size(lib)
-        for lib in ["msgspec", "orjson", "msgpack", "pydantic"]
+        for lib in ["msgspec", "orjson", "msgpack", "pydantic", "typedload"]
     ]
     data.sort(key=lambda x: x[2])
     msgspec_size = next(s for l, _, s in data if l == "msgspec")

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -111,6 +111,7 @@ and decoding time.
 - pydantic_
 - cattrs_
 - mashumaro_
+- typedload_
 
 The full benchmark source can be found
 `here <https://github.com/jcrist/msgspec/tree/main/benchmarks/bench_validation.py>`__.
@@ -317,17 +318,19 @@ The full benchmark source can be found `here
 
 **Results (smaller is better)**
 
-+--------------+---------+------------+-------------+
-|              | version | size (MiB) | vs. msgspec |
-+==============+=========+============+=============+
-| **msgspec**  | 0.12.0  | 0.34       | 1.00x       |
-+--------------+---------+------------+-------------+
-| **orjson**   | 3.8.5   | 0.56       | 1.64x       |
-+--------------+---------+------------+-------------+
-| **msgpack**  | 1.0.4   | 0.99       | 2.91x       |
-+--------------+---------+------------+-------------+
-| **pydantic** | 1.10.4  | 8.71       | 25.67x      |
-+--------------+---------+------------+-------------+
++---------------+---------+------------+-------------+
+|               | version | size (MiB) | vs. msgspec |
++===============+=========+============+=============+
+| **typedload** | 2.22    | 0.15       | 0.38x       |
++---------------+---------+------------+-------------+
+| **msgspec**   | 0.13.1  | 0.40       | 1.00x       |
++---------------+---------+------------+-------------+
+| **orjson**    | 3.8.7   | 0.56       | 1.41x       |
++---------------+---------+------------+-------------+
+| **msgpack**   | 1.0.4   | 0.99       | 2.48x       |
++---------------+---------+------------+-------------+
+| **pydantic**  | 1.10.5  | 8.71       | 21.85x      |
++---------------+---------+------------+-------------+
 
 The functionality available in ``msgspec`` is comparable to that of orjson_,
 msgpack_, and pydantic_ combined. However, the total installed binary size of
@@ -451,3 +454,4 @@ msgpack_, and pydantic_ combined. However, the total installed binary size of
 .. _cattrs: https://catt.rs/en/latest/
 .. _mashumaro: https://github.com/Fatal1ty/mashumaro
 .. _conda-forge: https://conda-forge.org/
+.. _typedload: https://ltworf.github.io/typedload/


### PR DESCRIPTION
Following the inclusion of a comparison to msgspec in typedload's documentation: https://github.com/ltworf/typedload/pull/390

Here is the inclusion of a comparison with typedload in msgspec's documentation.

The validation benchmark is very simple, it should at least hit some unions to become a bit more meaningful, in my opinion. Anyway that's something for the future.