### PR TITLE
Fix integer `lt` constraint bug

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -3006,7 +3006,6 @@ typenode_collect_constraints(
         if (constraints->lt != NULL) {
             state->types |= MS_CONSTR_INT_MAX;
             if (!_constr_as_i64(constraints->lt, &(state->c_int_max), -1)) return -1;
-            state->c_int_min -= 1;
         }
         else if (constraints->le != NULL) {
             state->types |= MS_CONSTR_INT_MAX;

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -345,6 +345,7 @@ class TestIntConstraints:
             (Meta(ge=0, multiple_of=2), [0, 2**63 + 2], [-2, 2**63 + 1]),
             (Meta(le=0, multiple_of=2), [0, -(2**63)], [-1, 2, 2**63]),
             (Meta(ge=0, le=10), [0, 10], [-1, 11]),
+            (Meta(gt=0, lt=10), [1, 2, 9], [-1, 0, 10]),
         ],
     )
     def test_combinations(self, proto, meta, good, bad):


### PR DESCRIPTION
There was a bug in the handling of integer `lt` constraints that would only show up if that constraint was also mixed with a lower bound (`gt`/`ge`) constraint.

```python
Annotated[int, Meta(gt=0, lt=10)]
```

The bug is specific to `lt`, and doesn't appear when using `le`. A workaround to use for past releases is to use `le` instead of `lt` for integer lower bounds.

```python
Annotated[int, Meta(gt=0, le=11)]
```

Fixes #334.