### PR TITLE
Support defining struct with field with no args

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -5137,7 +5137,8 @@ structmeta_process_default(StructMetaInfo *info, PyObject *field) {
             goto done;
         }
         else {
-            if (PyDict_SetItem(info->defaults_lk, field, NODEFAULT) < 0) return -1;
+            default_val = NODEFAULT;
+            Py_INCREF(default_val);
             goto done;
         }
     }

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -864,11 +864,13 @@ def test_struct_defaults_from_field():
     default = []
 
     class Test(Struct):
+        req: int = field()
         x: int = field(default=1)
         y: int = field(default_factory=lambda: 2)
         z: List[int] = field(default=default)
 
-    t = Test()
+    t = Test(100)
+    assert t.req == 100
     assert t.x == 1
     assert t.y == 2
     assert t.z == []


### PR DESCRIPTION
Previously using `field()` (with no arguments) to define a struct field would result in a segfault. This PR resolves that issue and adds a test.

Fixes #342.