### PR TITLE
Support attrs types in json schema generation

### DIFF
--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -515,6 +515,26 @@ def test_dataclass():
     assert mi.type_info(Example) == sol
 
 
+def test_attrs():
+    attrs = pytest.importorskip("attrs")
+
+    @attrs.define
+    class Example:
+        x: int
+        y: int = 0
+        z: str = attrs.field(factory=str)
+
+    sol = mi.DataclassType(
+        Example,
+        fields=(
+            mi.Field("x", "x", mi.IntType()),
+            mi.Field("y", "y", mi.IntType(), required=False, default=0),
+            mi.Field("z", "z", mi.StrType(), required=False, default_factory=str),
+        ),
+    )
+    assert mi.type_info(Example) == sol
+
+
 @pytest.mark.parametrize("kind", ["struct", "namedtuple", "typeddict", "dataclass"])
 def test_self_referential_objects(kind):
     if kind == "struct":

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -641,6 +641,58 @@ def test_dataclass():
     }
 
 
+def test_attrs():
+    attrs = pytest.importorskip("attrs")
+
+    @attrs.define
+    class Point:
+        x: int
+        y: int
+
+    @attrs.define
+    class Polygon:
+        """An example docstring"""
+
+        vertices: List[Point]
+        name: Union[str, None] = None
+        metadata: Dict[str, str] = attrs.field(factory=dict)
+
+    assert msgspec.json.schema(Polygon) == {
+        "$ref": "#/$defs/Polygon",
+        "$defs": {
+            "Polygon": {
+                "title": "Polygon",
+                "description": "An example docstring",
+                "type": "object",
+                "properties": {
+                    "vertices": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Point"},
+                    },
+                    "name": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                },
+                "required": ["vertices"],
+            },
+            "Point": {
+                "title": "Point",
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"},
+                },
+                "required": ["x", "y"],
+            },
+        },
+    }
+
+
 @pytest.mark.parametrize("use_union_operator", [False, True])
 def test_union(use_union_operator):
     class Example(msgspec.Struct):


### PR DESCRIPTION
This adds support for attrs types to `msgspec.json.schema` and `msgspec.inspect.type_info`. This was accidentally missed when support for encoding/decoding these types was added.