### PR TITLE
Support `typing.Final` annotations

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -44,6 +44,7 @@ Most combinations of the following types are supported (with a few restrictions)
 - `typing.Union`
 - `typing.Literal`
 - `typing.NewType`
+- `typing.Final`
 - `typing.NamedTuple` / `collections.namedtuple`
 - `typing.TypedDict`
 

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -34,50 +34,34 @@ else:
 
 
 # A mapping from a type annotation (or annotation __origin__) to the concrete
-# python type that msgspec will use when decoding. Note that non-collection
-# types don't strict need to be in this mapping. Common ones are added to avoid
-# an unnecessary `getattr(t, "__origin__", None)` call on them.
-# THIS IS PRIVATE FOR A REASON. DON'T MUCK WITH THIS.
+# python type that msgspec will use when decoding. THIS IS PRIVATE FOR A
+# REASON. DON'T MUCK WITH THIS.
 _CONCRETE_TYPES = {
-    t: t
-    for t in [
-        None,
-        bool,
-        int,
-        float,
-        str,
-        bytes,
-        bytearray,
-        list,
-        tuple,
-        set,
-        frozenset,
-        dict,
-    ]
+    list: list,
+    tuple: tuple,
+    set: set,
+    frozenset: frozenset,
+    dict: dict,
+    typing.List: list,
+    typing.Tuple: tuple,
+    typing.Set: set,
+    typing.FrozenSet: frozenset,
+    typing.Dict: dict,
+    typing.Collection: list,
+    typing.MutableSequence: list,
+    typing.Sequence: list,
+    typing.MutableMapping: dict,
+    typing.Mapping: dict,
+    typing.MutableSet: set,
+    typing.AbstractSet: set,
+    collections.abc.Collection: list,
+    collections.abc.MutableSequence: list,
+    collections.abc.Sequence: list,
+    collections.abc.MutableSet: set,
+    collections.abc.Set: set,
+    collections.abc.MutableMapping: dict,
+    collections.abc.Mapping: dict,
 }
-_CONCRETE_TYPES.update(
-    {
-        typing.List: list,
-        typing.Tuple: tuple,
-        typing.Set: set,
-        typing.FrozenSet: frozenset,
-        typing.Dict: dict,
-        typing.Collection: list,
-        typing.MutableSequence: list,
-        typing.Sequence: list,
-        typing.MutableMapping: dict,
-        typing.Mapping: dict,
-        typing.MutableSet: set,
-        typing.AbstractSet: set,
-        collections.abc.Collection: list,
-        collections.abc.MutableSequence: list,
-        collections.abc.Sequence: list,
-        collections.abc.MutableSet: set,
-        collections.abc.Set: set,
-        collections.abc.MutableMapping: dict,
-        collections.abc.Mapping: dict,
-    }
-)
 
 
 def get_typeddict_hints(obj):

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import datetime
 import pickle
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, Final, List, Type, Union
 
 import msgspec
 
@@ -98,6 +98,18 @@ def check_struct_kw_only_subclass() -> None:
 
     Test(b"foo", a=1)
     Test(b"foo", "test", a=1, b=[1, 2, 3])
+
+
+def check_struct_final_fields() -> None:
+    """Test that type checkers support `Final` fields for
+    dataclass_transform"""
+    class Test(msgspec.Struct):
+        x: Final[int] = 0
+
+    t = Test()
+    t2 = Test(x=1)
+    reveal_type(t.x)  # assert "int" in typ
+    reveal_type(t2.x)  # assert "int" in typ
 
 
 def check_struct_repr_omit_defaults() -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import (
     Deque,
     Dict,
+    Final,
     List,
     Literal,
     NamedTuple,
@@ -2817,3 +2818,27 @@ class TestUnset:
             res = proto.encode(x)
             sol = proto.encode(y)
             assert res == sol
+
+
+class TestFinal:
+    def test_decode_final(self, proto):
+        dec = proto.Decoder(Final[int])
+
+        assert dec.decode(proto.encode(1)) == 1
+        with pytest.raises(msgspec.ValidationError):
+            dec.decode(proto.encode("bad"))
+
+    def test_decode_final_annotated(self, proto, Annotated):
+        dec = proto.Decoder(Final[Annotated[int, msgspec.Meta(ge=0)]])
+
+        assert dec.decode(proto.encode(1)) == 1
+        with pytest.raises(msgspec.ValidationError):
+            dec.decode(proto.encode(-1))
+
+    def test_decode_final_newtype(self, proto):
+        UserId = NewType("UserId", int)
+        dec = proto.Decoder(Final[UserId])
+
+        assert dec.decode(proto.encode(1)) == 1
+        with pytest.raises(msgspec.ValidationError):
+            dec.decode(proto.encode("bad"))

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import (
     Any,
     Dict,
+    Final,
     FrozenSet,
     List,
     Literal,
@@ -184,6 +185,21 @@ def test_newtype():
     assert mi.type_info(Annotated[UserId2, Meta(min_length=2)]) == mi.StrType(
         min_length=2, max_length=10
     )
+
+
+def test_final(Annotated):
+    cases = [
+        (int, mi.IntType()),
+        (Annotated[int, Meta(ge=0)], mi.IntType(ge=0)),
+        (NewType("UserId", Annotated[int, Meta(ge=0)]), mi.IntType(ge=0)),
+    ]
+    for typ, sol in cases:
+
+        class Ex(msgspec.Struct):
+            x: Final[typ]
+
+        info = mi.type_info(Ex)
+        assert info.fields[0].type == sol
 
 
 def test_custom():


### PR DESCRIPTION
This adds support for `typing.Final` annotations. `Final` can be used to wrap an existing field annotation, marking it as a field that can't be modified once it's initialized. This has the same semantics as `frozen=True`, but only for a single field, and not enforced at runtime.

The `Frozen` annotation may be used to wrap field annotations on any object-like type we support (`msgspec.Struct`, `attrs`, or `dataclasses`).

```python
import msgspec

class Test(msgspec.Struct):
    x: Final[int] = 0

t = Test(1)
t.x = 2  # mypy and pyright will complain here
```

---

Note that currently `mypy` has a bug (https://github.com/python/mypy/issues/5608) where `Final` annotations in dataclass-like things require a default value (the bug seems to be early on in mypy's type processing pipeline). This is to enforce some vague wording in the `Final` PEP that indicates it should be an error to not have a value when defining a `Final` annotation on a class where that value isn't set in the `__init__`. Since dataclass-like-types don't have a visible `__init__`, this error is triggered. However! If you add `# type: ignore` on that line then the rest works fine, including all the normal dataclass type annotation validation.

```python
class Test(msgspec.Struct):
    # Without the type: ignore below, mypy will complain about Final needing an initialized value.
    # pyright works fine either way.
    x: Final[int]  # type: ignore

t = Test(1)  # mypy still knows the dataclass-like-thing's signature though, so no harm to the type: ignore
t2 = Test("bad")  # this means that mypy will still error here
```

---

Adding this since it was asked for in [cattrs](https://github.com/python-attrs/cattrs/issues/340), and it's nice to have compatibility across these kinds of libraries.

I'm also happy to see that the refactor needed to our type parsing routine also leads to a measurable speedup when processing type annotations into our own internal format. Nice when a new feature also leads to faster code.