### PR TITLE
Fix deallocation of Structs with `dict=True` in CPython 3.11

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -4724,18 +4724,9 @@ clear_slots(PyTypeObject *type, PyObject *self)
 
 static void
 Struct_dealloc_nogc(PyObject *self) {
-    PyTypeObject *type, *base;
-    bool is_gc;
-
-    type = Py_TYPE(self);
-
-    is_gc = MS_TYPE_IS_GC(type);
-
-    if (is_gc) {
-        PyObject_GC_UnTrack(self);
-    }
-
     Py_TRASHCAN_BEGIN(self, Struct_dealloc_nogc)
+
+    PyTypeObject *type = Py_TYPE(self);
 
     /* Maybe call a finalizer */
     if (type->tp_finalize) {
@@ -4749,7 +4740,7 @@ Struct_dealloc_nogc(PyObject *self) {
     }
 
     /* Clear all slots */
-    base = type;
+    PyTypeObject *base = type;
     while (base != NULL) {
         if (Py_SIZE(base)) {
             clear_slots(base, self);


### PR DESCRIPTION
Fixes #364, Fixes #362.

Both of these were caused by `tp_dealloc` being broken on CPython 3.11+ for structs with `dict=True` enabled. The root cause in both cases was our freelist implementation. Changes to CPython in 3.11 made it pretty much impossible to correctly implement a freelist this way for classes that include a `__dict__` on them. Since the freelist only shaves ~10-20% off allocation costs for a Struct in a hotloop (~5-15ns for typical structs on my machine), we just drop usage of the freelist entirely. It's too hard to maintain now across interpreter versions.

This also adds a new restriction where you can't set `gc=False` & `dict=True`, as correctly freeing `__dict__` values prevents dropping the gc from these types.