### PR TITLE
Don't use the trashcan for gc=False structs

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -4724,14 +4724,12 @@ clear_slots(PyTypeObject *type, PyObject *self)
 
 static void
 Struct_dealloc_nogc(PyObject *self) {
-    Py_TRASHCAN_BEGIN(self, Struct_dealloc_nogc)
-
     PyTypeObject *type = Py_TYPE(self);
 
     /* Maybe call a finalizer */
     if (type->tp_finalize) {
         /* If resurrected, exit early */
-        if (PyObject_CallFinalizerFromDealloc(self) < 0) goto done;
+        if (PyObject_CallFinalizerFromDealloc(self) < 0) return;
     }
 
     /* Maybe clear weakrefs */
@@ -4751,8 +4749,6 @@ Struct_dealloc_nogc(PyObject *self) {
     type->tp_free(self);
     /* Decref the object type immediately */
     Py_DECREF(type);
-done:
-    Py_TRASHCAN_END
 }
 
 static MS_INLINE Py_ssize_t

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1156,9 +1156,6 @@ class TestStructDealloc:
     @pytest.mark.parametrize("has_gc", [False, True])
     def test_struct_dealloc_trashcan(self, has_gc):
         N = 100
-        # XXX: Python <= 3.10 may run __del__ more than once for non-gc types
-        # if the trashcan mechanism is invoked. As such, we keep a set to track
-        # if it was called, not how many times it was called.
         called = set()
 
         class Node(Struct, gc=has_gc):


### PR DESCRIPTION
It's not well documented, but CPython's trashcan mechanism only works for GC types. As such, we drop the usage of the trashcan for Structs with `gc=False`.