### PR TITLE
Support encoding large integers in JSON

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -102,10 +102,15 @@ supported protocols.
 ``int``
 -------
 
-Integers map to integers in all supported protocols. Only values that fit in an
-``int64`` or ``uint64`` (within ``[-2**63, 2**64 - 1]``, inclusive) are
-supported. Values outside this range will raise a `msgspec.ValidationError`
-during decoding.
+Integers map to integers in all supported protocols.
+
+Support for large integers varies by protocol:
+
+- ``msgpack`` only supports encoding/decoding integers within
+  ``[-2**63, 2**64 - 1]``, inclusive.
+- ``json`` will encode any integer, but will decode large integers (outside of
+  ``[-2**63, 2**64 - 1]``, inclusive) as floats.
+- ``yaml`` and ``toml`` have no restrictions on encode or decode.
 
 .. code-block:: python
 


### PR DESCRIPTION
This removes the previous bounds restrictions when encoding integers to JSON. The JSON encoder will now happily encode any integer value.

When decoding, integers that don't fit into an int64/uint64 still decode as floats. I think this limitation is fine, large integers are generally not supported in most languages, and many JSON decoders have the same behavior here.

Fixes #377.