### PR TITLE
Remove JSON compatibility checks when building TypeNodes

### DIFF
--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -70,7 +70,7 @@ def schema_components(
     --------
     schema
     """
-    type_infos = mi.multi_type_info(types, protocol="json")
+    type_infos = mi.multi_type_info(types)
 
     component_types = _collect_component_types(type_infos)
 

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -857,9 +857,9 @@ def check_inspect_type_info() -> None:
     o = msgspec.inspect.type_info(List[int])
     reveal_type(o)  # assert "Type" in typ
 
-    msgspec.inspect.type_info(int, protocol=None)
-    msgspec.inspect.type_info(int, protocol="msgpack")
-    msgspec.inspect.type_info(int, protocol="json")
+    msgspec.inspect.type_info(int)
+    msgspec.inspect.type_info(int)
+    msgspec.inspect.type_info(int)
 
 
 def check_inspect_multi_type_info() -> None:
@@ -869,9 +869,9 @@ def check_inspect_multi_type_info() -> None:
     o2 = msgspec.inspect.multi_type_info((int, float))
     reveal_type(o2)  # assert "Type" in typ and "tuple" in typ.lower()
 
-    msgspec.inspect.multi_type_info([int], protocol=None)
-    msgspec.inspect.multi_type_info([int], protocol="msgpack")
-    msgspec.inspect.multi_type_info([int], protocol="json")
+    msgspec.inspect.multi_type_info([int])
+    msgspec.inspect.multi_type_info([int])
+    msgspec.inspect.multi_type_info([int])
 
 
 def max_depth(t: msgspec.inspect.Type, depth: int = 0) -> int:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1327,37 +1327,6 @@ class TestTypedDict:
             proto.Decoder(Ex)
         assert not hasattr(Ex, "__msgspec_cache__")
 
-    @pytest.mark.parametrize("msgpack_first", [False, True])
-    @pytest.mark.parametrize("wrap", [False, True])
-    def test_type_errors_not_json(self, msgpack_first, wrap):
-        class Ex(TypedDict):
-            a: int
-            b: Dict[float, int]
-
-        if wrap:
-            typ = TypedDict("Test", {"x": Ex})
-        else:
-            typ = Ex
-
-        if msgpack_first:
-            dec = msgspec.msgpack.Decoder(typ)
-            info = Ex.__msgspec_cache__
-            assert info is not None
-            msg = {"a": 1, "b": {1: 2}}
-            if wrap:
-                msg = {"x": msg}
-            assert dec.decode(msgspec.msgpack.encode(msg)) == msg
-
-        with pytest.raises(
-            TypeError, match="Only dicts with str-like or int-like keys"
-        ):
-            msgspec.json.Decoder(typ)
-
-        if msgpack_first:
-            assert Ex.__msgspec_cache__ is info
-        else:
-            assert not hasattr(Ex, "__msgspec_cache__")
-
     def test_recursive_type(self, proto):
         source = """
         from __future__ import annotations
@@ -1377,35 +1346,6 @@ class TestTypedDict:
                 dec.decode(proto.encode({"a": 1, "b": {"a": "bad"}}))
             assert "`$.b.a`" in str(rec.value)
             assert "Expected `int`, got `str`" in str(rec.value)
-
-    @pytest.mark.parametrize("msgpack_first", [True])
-    def test_recursive_type_errors_not_json(self, msgpack_first):
-        source = """
-        from __future__ import annotations
-        from typing import TypedDict, Union, Dict
-
-        class Ex(TypedDict):
-            a: int
-            b: Union[Ex, None]
-            c: Dict[float, int]
-        """
-        with temp_module(source) as mod:
-            if msgpack_first:
-                dec = msgspec.msgpack.Decoder(mod.Ex)
-                info = mod.Ex.__msgspec_cache__
-                assert info is not None
-                msg = {"a": 1, "b": None, "c": {1: 2}}
-                assert dec.decode(msgspec.msgpack.encode(msg)) == msg
-
-            with pytest.raises(
-                TypeError, match="Only dicts with str-like or int-like keys"
-            ):
-                msgspec.json.Decoder(mod.Ex)
-
-            if msgpack_first:
-                assert mod.Ex.__msgspec_cache__ is info
-            else:
-                assert not hasattr(mod.Ex, "__msgspec_cache__")
 
     def test_total_true(self, proto):
         class Ex(TypedDict):
@@ -1549,37 +1489,6 @@ class TestNamedTuple:
             proto.Decoder(Ex)
         assert not hasattr(Ex, "__msgspec_cache__")
 
-    @pytest.mark.parametrize("msgpack_first", [False, True])
-    @pytest.mark.parametrize("wrap", [False, True])
-    def test_type_errors_not_json(self, msgpack_first, wrap):
-        class Ex(NamedTuple):
-            a: int
-            b: Dict[float, int]
-
-        if wrap:
-            typ = TypedDict("Test", {"x": Ex})
-        else:
-            typ = Ex
-
-        if msgpack_first:
-            dec = msgspec.msgpack.Decoder(typ)
-            info = Ex.__msgspec_cache__
-            assert info is not None
-            msg = Ex(1, {1: 2})
-            if wrap:
-                msg = {"x": msg}
-            assert dec.decode(msgspec.msgpack.encode(msg)) == msg
-
-        with pytest.raises(
-            TypeError, match="Only dicts with str-like or int-like keys"
-        ):
-            msgspec.json.Decoder(typ)
-
-        if msgpack_first:
-            assert Ex.__msgspec_cache__ is info
-        else:
-            assert not hasattr(Ex, "__msgspec_cache__")
-
     def test_recursive_type(self, proto):
         source = """
         from __future__ import annotations
@@ -1599,35 +1508,6 @@ class TestNamedTuple:
                 dec.decode(proto.encode(mod.Ex(1, ("bad", "two"))))
             assert "`$[1][0]`" in str(rec.value)
             assert "Expected `int`, got `str`" in str(rec.value)
-
-    @pytest.mark.parametrize("msgpack_first", [True])
-    def test_recursive_type_errors_not_json(self, msgpack_first):
-        source = """
-        from __future__ import annotations
-        from typing import NamedTuple, Union, Dict
-
-        class Ex(NamedTuple):
-            a: int
-            b: Union[Ex, None]
-            c: Dict[float, int]
-        """
-        with temp_module(source) as mod:
-            if msgpack_first:
-                dec = msgspec.msgpack.Decoder(mod.Ex)
-                info = mod.Ex.__msgspec_cache__
-                assert info is not None
-                msg = mod.Ex(1, None, {1: 2})
-                assert dec.decode(msgspec.msgpack.encode(msg)) == msg
-
-            with pytest.raises(
-                TypeError, match="Only dicts with str-like or int-like keys"
-            ):
-                msgspec.json.Decoder(mod.Ex)
-
-            if msgpack_first:
-                assert mod.Ex.__msgspec_cache__ is info
-            else:
-                assert not hasattr(mod.Ex, "__msgspec_cache__")
 
     @pytest.mark.parametrize("use_typing", [True, False])
     def test_decode_namedtuple_no_defaults(self, proto, use_typing):
@@ -1828,38 +1708,6 @@ class TestDataclass:
             proto.Decoder(Ex)
         assert not hasattr(Ex, "__msgspec_cache__")
 
-    @pytest.mark.parametrize("msgpack_first", [False, True])
-    @pytest.mark.parametrize("wrap", [False, True])
-    def test_type_errors_not_json(self, msgpack_first, wrap):
-        @dataclass
-        class Ex:
-            a: int
-            b: Dict[float, int]
-
-        if wrap:
-            typ = TypedDict("Test", {"x": Ex})
-        else:
-            typ = Ex
-
-        if msgpack_first:
-            dec = msgspec.msgpack.Decoder(typ)
-            info = Ex.__msgspec_cache__
-            assert info is not None
-            msg = Ex(a=1, b={1: 2})
-            if wrap:
-                msg = {"x": msg}
-            assert dec.decode(msgspec.msgpack.encode(msg)) == msg
-
-        with pytest.raises(
-            TypeError, match="Only dicts with str-like or int-like keys"
-        ):
-            msgspec.json.Decoder(typ)
-
-        if msgpack_first:
-            assert Ex.__msgspec_cache__ is info
-        else:
-            assert not hasattr(Ex, "__msgspec_cache__")
-
     def test_recursive_type(self, proto):
         source = """
         from __future__ import annotations
@@ -1881,37 +1729,6 @@ class TestDataclass:
                 dec.decode(proto.encode({"a": 1, "b": {"a": "bad"}}))
             assert "`$.b.a`" in str(rec.value)
             assert "Expected `int`, got `str`" in str(rec.value)
-
-    @pytest.mark.parametrize("msgpack_first", [True])
-    def test_recursive_type_errors_not_json(self, msgpack_first):
-        source = """
-        from __future__ import annotations
-        from typing import Union, Dict
-        from dataclasses import dataclass
-
-        @dataclass
-        class Ex:
-            a: int
-            b: Union[Ex, None]
-            c: Dict[float, int]
-        """
-        with temp_module(source) as mod:
-            if msgpack_first:
-                dec = msgspec.msgpack.Decoder(mod.Ex)
-                info = mod.Ex.__msgspec_cache__
-                assert info is not None
-                msg = mod.Ex(a=1, b=None, c={1: 2})
-                assert dec.decode(msgspec.msgpack.encode(msg)) == msg
-
-            with pytest.raises(
-                TypeError, match="Only dicts with str-like or int-like keys"
-            ):
-                msgspec.json.Decoder(mod.Ex)
-
-            if msgpack_first:
-                assert mod.Ex.__msgspec_cache__ is info
-            else:
-                assert not hasattr(mod.Ex, "__msgspec_cache__")
 
     def test_classvars_ignored(self, proto):
         source = """

--- a/tests/test_from_builtins.py
+++ b/tests/test_from_builtins.py
@@ -873,10 +873,8 @@ class TestDict:
     def test_non_str_keys(self):
         from_builtins({1.5: 1}, Dict[float, int]) == {1.5: 1}
 
-        with pytest.raises(
-            TypeError, match="Only dicts with str-like or int-like keys are supported"
-        ):
-            from_builtins({1.5: 1}, Dict[float, int], str_keys=True)
+        with pytest.raises(ValidationError):
+            from_builtins({"x": 1}, Dict[Tuple[int, int], int], str_keys=True)
 
     def test_dict_cyclic_recursion(self):
         depth = 50

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -643,24 +643,6 @@ def test_metadata():
     )
 
 
-@pytest.mark.parametrize("protocol", [None, "msgpack", "json"])
-def test_type_info_protocol(protocol):
-    res = mi.type_info(Dict[str, int], protocol=protocol)
-    assert res == mi.DictType(mi.StrType(), mi.IntType())
-
-    if protocol == "json":
-        with pytest.raises(TypeError):
-            mi.type_info(Dict[float, int], protocol=protocol)
-    else:
-        res = mi.type_info(Dict[float, int], protocol=protocol)
-        assert res == mi.DictType(mi.FloatType(), mi.IntType())
-
-
-def test_type_info_protocol_invalid():
-    with pytest.raises(ValueError, match="protocol must be one of"):
-        mi.type_info(int, protocol="invalid")
-
-
 def test_multi_type_info():
     class Example(msgspec.Struct):
         x: int


### PR DESCRIPTION
Previously we spent a lot of effort to detect types that could never be decoded by a JSON decoder (but could be decoded by other protocols), and raised a nicer error at Decoder-initialization-time in this case.

Due to our caching of TypeNodes, the code for doing this was some of the fiddliest bits in msgspec. If a JSON-incompatible type was already parsed and cached to build a MessagePack parser, we'd have to ignore the cached value to retraverse the type to check again.

We delete all this code in favor of erroring at runtime. I don't expect this to degrade usability - the user will still get an error, just at a later point in usage. This simplifies our type parsing code dramatically, making it easier to support new types.