### PR TITLE
Work around spurious mypy test errors

### DIFF
--- a/msgspec/structs.pyi
+++ b/msgspec/structs.pyi
@@ -2,7 +2,7 @@ from typing import Any, TypeVar, Union
 
 from . import NODEFAULT, Struct
 
-S = TypeVar("S", bound=Struct, covariant=True)
+S = TypeVar("S", bound=Struct)
 
 def replace(struct: S, /, **changes: Any) -> S: ...
 def asdict(struct: Struct) -> dict[str, Any]: ...

--- a/msgspec/toml.py
+++ b/msgspec/toml.py
@@ -16,14 +16,14 @@ def __dir__():
 
 def _import_tomllib():
     try:
-        import tomllib
+        import tomllib  # type: ignore
 
         return tomllib
     except ImportError:
         pass
 
     try:
-        import tomli
+        import tomli  # type: ignore
 
         return tomli
     except ImportError:
@@ -37,7 +37,7 @@ def _import_tomllib():
 
 def _import_tomli_w():
     try:
-        import tomli_w
+        import tomli_w  # type: ignore
 
         return tomli_w
     except ImportError:
@@ -111,12 +111,7 @@ def decode(
     pass
 
 
-def decode(
-    buf: Union[bytes, str],
-    *,
-    type: Type[T] = Any,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
-) -> T:
+def decode(buf, *, type=Any, dec_hook=None):
     """Deserialize an object from TOML.
 
     Parameters

--- a/msgspec/yaml.py
+++ b/msgspec/yaml.py
@@ -16,7 +16,7 @@ def __dir__():
 
 def _import_pyyaml(name):
     try:
-        import yaml
+        import yaml  # type: ignore
     except ImportError:
         raise ImportError(
             f"`msgspec.yaml.{name}` requires PyYAML be installed.\n\n"
@@ -103,12 +103,7 @@ def decode(
     pass
 
 
-def decode(
-    buf: Union[bytes, str],
-    *,
-    type: Type[T] = Any,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
-) -> T:
+def decode(buf, *, type=Any, dec_hook=None):
     """Deserialize an object from YAML.
 
     Parameters


### PR DESCRIPTION
Not sure why, but the mypy tests have suddenly started failing in CI only. The failure is due to type stubs missing for an optional dependency (the type stubs should only be needed for type checking the internals of `msgspec`, not checking user usage of it). I cannot reproduce these issues locally.

By changing around our type annotations and adding a few `type: ignore` comments, I believe this change should resolve the issues on CI.