### PR TITLE
Add generic args to typing.Type

### DIFF
--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -15,7 +15,7 @@ from typing import (
 T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
-dec_hook_sig = Optional[Callable[[Type[Any], Any], Any]]
+dec_hook_sig = Optional[Callable[[type, Any], Any]]
 
 class Encoder:
     enc_hook: enc_hook_sig

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -15,7 +15,7 @@ from typing import (
 T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
-dec_hook_sig = Optional[Callable[[Type, Any], Any]]
+dec_hook_sig = Optional[Callable[[Type[Any], Any], Any]]
 
 class Encoder:
     enc_hook: enc_hook_sig

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
 ext_hook_sig = Optional[Callable[[int, memoryview], Any]]
-dec_hook_sig = Optional[Callable[[Type[Any], Any], Any]]
+dec_hook_sig = Optional[Callable[[type, Any], Any]]
 
 class Ext:
     code: int

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
 ext_hook_sig = Optional[Callable[[int, memoryview], Any]]
-dec_hook_sig = Optional[Callable[[Type, Any], Any]]
+dec_hook_sig = Optional[Callable[[Type[Any], Any], Any]]
 
 class Ext:
     code: int

--- a/msgspec/toml.py
+++ b/msgspec/toml.py
@@ -88,7 +88,7 @@ T = TypeVar("T")
 def decode(
     buf: Union[bytes, str],
     *,
-    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
 
@@ -98,7 +98,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
-    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> T:
     pass
 
@@ -108,7 +108,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Any = ...,
-    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
 

--- a/msgspec/toml.py
+++ b/msgspec/toml.py
@@ -86,7 +86,9 @@ T = TypeVar("T")
 
 @overload
 def decode(
-    buf: Union[bytes, str], *, dec_hook: Optional[Callable[[Type, Any], Any]] = None
+    buf: Union[bytes, str],
+    *,
+    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
 ) -> Any:
     pass
 
@@ -96,7 +98,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
+    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
 ) -> T:
     pass
 
@@ -106,7 +108,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Any = ...,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
+    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
 ) -> Any:
     pass
 


### PR DESCRIPTION
  Allows this to work better with strict use of pyright, see
  https://github.com/microsoft/pyright/issues/4988

mypy seems to accept either as equivalent, whereas pyright does not.