### PR TITLE
Add support for Generic Structs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,10 @@ jobs:
           PYTHONMALLOC: "malloc"
           ASAN_OPTIONS: "detect_leaks=0"
         run: |
-          export LD_PRELOAD=`gcc -print-file-name=libasan.so`
-          coverage run -m pytest -s -m "not mypy and not pyright"
+          LD_PRELOAD=`gcc -print-file-name=libasan.so` coverage run -m pytest -s -m "not mypy and not pyright"
+
+      - name: Generate coverage files
+        run: |
           coverage xml
           gcov -abcu `find build/ -name *.o`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
           MSGSPEC_COVERAGE: "true"
         run: |
           python setup.py clean --all
-          pip install -e .
+          # I know this is deprecated, but I can't find a way to keep the build
+          # directory around anymore on new versions of setuptools
+          python setup.py develop
 
       - name: Run tests with sanitizers
         env:

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -380,6 +380,7 @@ typedef struct {
     PyObject *typing_annotated_alias;
     PyObject *concrete_types;
     PyObject *get_type_hints;
+    PyObject *get_class_annotations;
     PyObject *get_typeddict_hints;
     PyObject *get_dataclass_info;
     PyObject *rebuild;
@@ -5952,7 +5953,7 @@ StructMeta_prep_types(PyObject *py_self) {
     nfields = PyTuple_GET_SIZE(self->struct_fields);
 
     st = msgspec_get_global_state();
-    annotations = CALL_ONE_ARG(st->get_type_hints, py_self);
+    annotations = CALL_ONE_ARG(st->get_class_annotations, py_self);
     if (annotations == NULL) goto error;
 
     struct_types = PyMem_Calloc(nfields, sizeof(TypeNode*));
@@ -18397,6 +18398,7 @@ msgspec_clear(PyObject *m)
     Py_CLEAR(st->typing_annotated_alias);
     Py_CLEAR(st->concrete_types);
     Py_CLEAR(st->get_type_hints);
+    Py_CLEAR(st->get_class_annotations);
     Py_CLEAR(st->get_typeddict_hints);
     Py_CLEAR(st->get_dataclass_info);
     Py_CLEAR(st->rebuild);
@@ -18460,6 +18462,7 @@ msgspec_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(st->typing_annotated_alias);
     Py_VISIT(st->concrete_types);
     Py_VISIT(st->get_type_hints);
+    Py_VISIT(st->get_class_annotations);
     Py_VISIT(st->get_typeddict_hints);
     Py_VISIT(st->get_dataclass_info);
     Py_VISIT(st->rebuild);
@@ -18671,6 +18674,7 @@ PyInit__core(void)
     if (temp_module == NULL) return NULL;
     SET_REF(concrete_types, "_CONCRETE_TYPES");
     SET_REF(get_type_hints, "get_type_hints");
+    SET_REF(get_class_annotations, "get_class_annotations");
     SET_REF(get_typeddict_hints, "get_typeddict_hints");
     SET_REF(get_dataclass_info, "get_dataclass_info");
     SET_REF(typing_annotated_alias, "_AnnotatedAlias");

--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -158,7 +158,7 @@ def _has_nondefault_docstring(t: mi.Type) -> bool:
     """Check if a type has a user-defined docstring.
 
     Some types like Enum or Dataclass generate a default docstring."""
-    if not (doc := getattr(t.cls, "__doc__", None)):
+    if not (doc := getattr(t.cls, "__doc__", None)):  # type: ignore
         return False
 
     if isinstance(t, mi.EnumType):
@@ -271,7 +271,7 @@ def _to_schema(
                 real_type = real_type.type
             if isinstance(real_type, mi.StructType) and not real_type.array_like:
                 tag_field = real_type.tag_field
-                structs[subtype.tag] = real_type
+                structs[real_type.tag] = real_type
             else:
                 other.append(subtype)
 

--- a/msgspec/inspect.py
+++ b/msgspec/inspect.py
@@ -8,15 +8,18 @@ from collections.abc import Iterable
 from typing import Any, Final, Literal, Tuple, Type as typing_Type, Union
 
 try:
-    from types import UnionType as _types_UnionType
+    from types import UnionType as _types_UnionType  # type: ignore
 except Exception:
-    _types_UnionType = type("UnionType", (), {})
+    _types_UnionType = type("UnionType", (), {})  # type: ignore
 
 import msgspec
 from msgspec import NODEFAULT, UNSET, UnsetType as _UnsetType
 
-from ._core import Factory as _Factory, to_builtins as _to_builtins
-from ._utils import (
+from ._core import (  # type: ignore
+    Factory as _Factory,
+    to_builtins as _to_builtins,
+)
+from ._utils import (  # type: ignore
     _CONCRETE_TYPES,
     _AnnotatedAlias,
     get_dataclass_info as _get_dataclass_info,

--- a/msgspec/structs.py
+++ b/msgspec/structs.py
@@ -10,7 +10,7 @@ from ._core import (  # noqa
     astuple,
     replace,
 )
-from ._utils import _get_type_hints
+from ._utils import get_type_hints as _get_type_hints
 
 __all__ = (
     "FieldInfo",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from typing import Generic, List, Set, TypeVar
+
+import pytest
+from utils import temp_module
+
+from msgspec._utils import get_class_annotations
+
+T = TypeVar("T")
+S = TypeVar("S")
+U = TypeVar("U")
+
+
+class Base(Generic[T]):
+    x: T
+
+
+class Base2(Generic[T, S]):
+    a: T
+    b: S
+
+
+class TestGetClassAnnotations:
+    @pytest.mark.parametrize("future_annotations", [False, True])
+    def test_eval_scopes(self, future_annotations):
+        header = "from __future__ import annotations" if future_annotations else ""
+        source = f"""
+        {header}
+        STR = str
+
+        class Ex:
+            LOCAL = float
+            x: int
+            y: LOCAL
+            z: STR
+        """
+        with temp_module(source) as mod:
+            assert get_class_annotations(mod.Ex) == {"x": int, "y": float, "z": str}
+
+    def test_none_to_nonetype(self):
+        class Ex:
+            x: None
+
+        assert get_class_annotations(Ex) == {"x": type(None)}
+
+    def test_subclass(self):
+        class Base:
+            x: int
+            y: str
+
+        class Sub(Base):
+            x: float
+            z: list
+
+        class Base2:
+            a: int
+
+        class Sub2(Sub, Base2):
+            b: float
+            y: list
+
+        assert get_class_annotations(Base) == {"x": int, "y": str}
+        assert get_class_annotations(Sub) == {"x": float, "y": str, "z": list}
+        assert get_class_annotations(Sub2) == {
+            "x": float,
+            "y": list,
+            "z": list,
+            "a": int,
+            "b": float,
+        }
+
+    def test_simple_generic(self):
+        class Test(Generic[T]):
+            x: T
+            y: List[T]
+            z: int
+
+        assert get_class_annotations(Test) == {"x": T, "y": List[T], "z": int}
+        assert get_class_annotations(Test[int]) == {"x": int, "y": List[int], "z": int}
+        assert get_class_annotations(Test[Set[T]]) == {
+            "x": Set[T],
+            "y": List[Set[T]],
+            "z": int,
+        }
+
+    def test_generic_sub1(self):
+        class Sub(Base):
+            y: int
+
+        assert get_class_annotations(Sub) == {"x": T, "y": int}
+
+    def test_generic_sub2(self):
+        class Sub(Base, Generic[T]):
+            y: List[T]
+
+        assert get_class_annotations(Sub) == {"x": T, "y": List[T]}
+        assert get_class_annotations(Sub[int]) == {"x": T, "y": List[int]}
+
+    def test_generic_sub3(self):
+        class Sub(Base[int], Generic[T]):
+            y: List[T]
+
+        assert get_class_annotations(Sub) == {"x": int, "y": List[T]}
+        assert get_class_annotations(Sub[float]) == {"x": int, "y": List[float]}
+
+    def test_generic_sub4(self):
+        class Sub(Base[T]):
+            y: List[T]
+
+        assert get_class_annotations(Sub) == {"x": T, "y": List[T]}
+        assert get_class_annotations(Sub[int]) == {"x": int, "y": List[int]}
+
+    def test_generic_sub5(self):
+        class Sub(Base[T], Generic[T]):
+            y: List[T]
+
+        assert get_class_annotations(Sub) == {"x": T, "y": List[T]}
+        assert get_class_annotations(Sub[int]) == {"x": int, "y": List[int]}
+
+    def test_generic_sub6(self):
+        class Sub(Base[S]):
+            y: List[S]
+
+        assert get_class_annotations(Sub) == {"x": S, "y": List[S]}
+        assert get_class_annotations(Sub[int]) == {"x": int, "y": List[int]}
+
+    def test_generic_sub7(self):
+        class Sub(Base[List[T]]):
+            y: Set[T]
+
+        assert get_class_annotations(Sub) == {"x": List[T], "y": Set[T]}
+        assert get_class_annotations(Sub[int]) == {"x": List[int], "y": Set[int]}
+
+    def test_generic_sub8(self):
+        class Sub(Base[int], Base2[float, str]):
+            pass
+
+        assert get_class_annotations(Sub) == {"x": int, "a": float, "b": str}
+
+    def test_generic_sub9(self):
+        class Sub(Base[U], Base2[List[U], U]):
+            y: str
+
+        assert get_class_annotations(Sub) == {"y": str, "x": U, "a": List[U], "b": U}
+        assert get_class_annotations(Sub[int]) == {
+            "y": str,
+            "x": int,
+            "a": List[int],
+            "b": int,
+        }
+
+        class Sub2(Sub[int]):
+            x: list
+
+        assert get_class_annotations(Sub2) == {
+            "x": list,
+            "y": str,
+            "a": List[int],
+            "b": int,
+        }
+
+    def test_generic_sub10(self):
+        class Sub(Base[U], Base2[List[U], U]):
+            y: str
+
+        class Sub3(Sub[List[T]]):
+            c: T
+
+        assert get_class_annotations(Sub3) == {
+            "c": T,
+            "y": str,
+            "x": List[T],
+            "a": List[List[T]],
+            "b": List[T],
+        }
+        assert get_class_annotations(Sub3[int]) == {
+            "c": int,
+            "y": str,
+            "x": List[int],
+            "a": List[List[int]],
+            "b": List[int],
+        }


### PR DESCRIPTION
This adds full support for encoding/decoding generic `msgspec.Struct` types. Fixes #193.

A quick demo:

```python
from typing import Generic, TypeVar

from msgspec import Struct, json, ValidationError

T = TypeVar("T")

class Paginated(Struct, Generic[T]):
    page: int
    per_page: int
    total_count: int
    items: list[T]


class Order(Struct):
    item: str
    count: int


msg = """
{
    "page": 2,
    "per_page": 5,
    "total_count": 99,
    "items": [
        {"item": "apple", "count": 3},
        {"item": "banana", "count": 2},
        {"item": "carrot", "count": 10},
        {"item": "durian", "count": 1},
        {"item": "eggplant", "count": 4}
    ]
}
"""

# Decoding uses the parametrized type to validate
print(json.decode(msg, type=Paginated[Order]))
#> Paginated(
#>     page=2,
#>     per_page=5,
#>     total_count=99,
#>     items=[
#>         Order(item='apple', count=3),
#>         Order(item='banana', count=2),
#>         Order(item='carrot', count=10),
#>         Order(item='durian', count=1),
#>         Order(item='eggplant', count=4)
#>     ]
#> )

# A validation error is raised if the message doesn't match
bad_msg = """
{
    "page": 1,
    "per_page": 1,
    "total_count": 1,
    "items": [
        {"item": "apple", "count": "oops"}
    ]
}
"""
try:
    json.decode(bad_msg, type=Paginated[Order])
except ValidationError as err:
    print(err)
#> ValidationError("Expected `int`, got `str` - at `$.items[0].count`")
```

Recursive and complicated parametrizations also should work, including [the weird challenge posted on the pydantic twitter](https://twitter.com/samuel_colvin/status/1633881290280939520):

```python
from __future__ import annotations
from typing import Generic, TypeVar

import msgspec

T = TypeVar("T")

class MyGenericModel(msgspec.Struct, Generic[T]):
    foobar: list[MyGenericModel[T]] | None
    spam: T


MyGenericModelList = MyGenericModel[list[T]]

class MyGenericModelIntList(MyGenericModelList[int]):
    pass

msg = b'{"foobar": [{"foobar": null, "spam": [1]}], "spam": [1, 2, 3]}'

m = msgspec.json.decode(msg, type=MyGenericModelIntList)
print(m)
#> MyGenericModelIntList(
#>   foobar=[MyGenericModel(foobar=None, spam=[1])],
#>   spam=[1, 2, 3]
#> )
```

In common usage, generics should have no runtime overhead. Since msgspec doesn't validate on `__init__` we don't need to generate a new type for each parametrization - type type of `Paginated[Order]` is `typing._GenericAlias`. No magic on our side needed!

The scoping rules and behavior for handling complicated parametrized generics are underdocumented in the corresponding PEPs. I _believe_ we've covered all the edge cases here, but would still love for a few users to try this out before it's released. If this passes tests I plan on merging it early, but would hope someone could try this out before it's released.