### PR TITLE
Use `type` instead of `Type` when unparametrized

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -72,7 +72,7 @@ class Struct:
 
 def defstruct(
     name: str,
-    fields: Iterable[Union[str, Tuple[str, Type], Tuple[str, Type, Any]]],
+    fields: Iterable[Union[str, Tuple[str, type], Tuple[str, type, Any]]],
     *,
     bases: Tuple[Type[Struct], ...] = (),
     module: Optional[str] = None,
@@ -146,7 +146,7 @@ def to_builtins(
     obj: Any,
     *,
     str_keys: bool = False,
-    builtin_types: Union[Iterable[Type], None] = None,
+    builtin_types: Union[Iterable[type], None] = None,
     enc_hook: Optional[Callable[[Any], Any]] = None,
 ) -> Any: ...
 @overload
@@ -156,8 +156,8 @@ def from_builtins(
     *,
     str_keys: bool = False,
     str_values: bool = False,
-    builtin_types: Union[Iterable[Type], None] = None,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
+    builtin_types: Union[Iterable[type], None] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> T: ...
 @overload
 def from_builtins(
@@ -165,8 +165,8 @@ def from_builtins(
     type: Any,
     *,
     str_keys: bool = False,
-    builtin_types: Union[Iterable[Type], None] = None,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
+    builtin_types: Union[Iterable[type], None] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any: ...
 
 class MsgspecError(Exception): ...

--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -20,7 +20,7 @@ def schema(type: Any) -> dict[str, Any]:
 
     Parameters
     ----------
-    type : Type
+    type : type
         The type to generate the schema for.
 
     Returns
@@ -48,7 +48,7 @@ def schema_components(
 
     Parameters
     ----------
-    types : Iterable[Type]
+    types : Iterable[type]
         An iterable of one or more types to generate schemas for.
     ref_template : str, optional
         A template to use when generating ``"$ref"`` fields. This template is

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -15,7 +15,7 @@ from typing import (
 T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
-dec_hook_sig = Optional[Callable[[Type[Any], Any], Any]]
+dec_hook_sig = Optional[Callable[[type, Any], Any]]
 
 class Encoder:
     enc_hook: enc_hook_sig

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -15,7 +15,7 @@ from typing import (
 T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
-dec_hook_sig = Optional[Callable[[Type, Any], Any]]
+dec_hook_sig = Optional[Callable[[Type[Any], Any], Any]]
 
 class Encoder:
     enc_hook: enc_hook_sig

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
 ext_hook_sig = Optional[Callable[[int, memoryview], Any]]
-dec_hook_sig = Optional[Callable[[Type[Any], Any], Any]]
+dec_hook_sig = Optional[Callable[[type, Any], Any]]
 
 class Ext:
     code: int

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
 ext_hook_sig = Optional[Callable[[int, memoryview], Any]]
-dec_hook_sig = Optional[Callable[[Type, Any], Any]]
+dec_hook_sig = Optional[Callable[[Type[Any], Any], Any]]
 
 class Ext:
     code: int

--- a/msgspec/toml.py
+++ b/msgspec/toml.py
@@ -88,7 +88,7 @@ T = TypeVar("T")
 def decode(
     buf: Union[bytes, str],
     *,
-    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
 
@@ -98,7 +98,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
-    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> T:
     pass
 
@@ -108,7 +108,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Any = ...,
-    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
 

--- a/msgspec/toml.py
+++ b/msgspec/toml.py
@@ -86,7 +86,9 @@ T = TypeVar("T")
 
 @overload
 def decode(
-    buf: Union[bytes, str], *, dec_hook: Optional[Callable[[Type, Any], Any]] = None
+    buf: Union[bytes, str],
+    *,
+    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
 ) -> Any:
     pass
 
@@ -96,7 +98,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
+    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
 ) -> T:
     pass
 
@@ -106,7 +108,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Any = ...,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
+    dec_hook: Optional[Callable[[Type[Any], Any], Any]] = None,
 ) -> Any:
     pass
 

--- a/msgspec/yaml.py
+++ b/msgspec/yaml.py
@@ -78,7 +78,7 @@ T = TypeVar("T")
 
 @overload
 def decode(
-    buf: Union[bytes, str], *, dec_hook: Optional[Callable[[Type, Any], Any]] = None
+    buf: Union[bytes, str], *, dec_hook: Optional[Callable[[type, Any], Any]] = None
 ) -> Any:
     pass
 
@@ -88,7 +88,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> T:
     pass
 
@@ -98,7 +98,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Any = ...,
-    dec_hook: Optional[Callable[[Type, Any], Any]] = None,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
 


### PR DESCRIPTION
`pyright` doesn't treat `Type` the same as `Type[Any]` or `type` for some reason (while `mypy` does). When we mean any "type", we now use `type` instead of `typing.Type` in the annotation.

Supersedes #385.