### PR TITLE
Support decoding unhyphenated UUIDs

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -331,6 +331,7 @@ timezone-naive by specifying a ``tz`` constraint (see
 --------
 
 `uuid.UUID` values are serialized as RFC4122_ encoded strings in all protocols.
+When decoding, both hyphenated and unhyphenated forms are supported.
 
 .. code-block:: python
 
@@ -338,12 +339,13 @@ timezone-naive by specifying a ``tz`` constraint (see
 
     >>> u = uuid.UUID("c4524ac0-e81e-4aa8-a595-0aec605a659a")
 
-    >>> msg = msgspec.json.encode(u)
-
-    >>> msg
+    >>> msgspec.json.encode(u)
     b'"c4524ac0-e81e-4aa8-a595-0aec605a659a"'
 
-    >>> msgspec.json.decode(msg, type=uuid.UUID)
+    >>> msgspec.json.decode(b'"c4524ac0-e81e-4aa8-a595-0aec605a659a"', type=uuid.UUID)
+    UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
+
+    >>> msgspec.json.decode(b'"c4524ac0e81e4aa8a5950aec605a659a"', type=uuid.UUID)
     UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
 
     >>> msgspec.json.decode(b'"oops"', type=uuid.UUID)

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -9670,8 +9670,9 @@ ms_decode_uuid(const char *buf, Py_ssize_t size, PathNode *path) {
     unsigned char *decoded = scratch;
     int segments[] = {4, 2, 2, 2, 6};
 
-    /* A valid uuid is 36 characters in length */
-    if (size != 36) goto invalid;
+    /* A valid uuid is 32 or 36 characters in length */
+    if (size != 32 && size != 36) goto invalid;
+    bool has_hyphens = size == 36;
 
     for (int i = 0; i < 5; i++) {
         for (int j = 0; j < segments[i]; j++) {
@@ -9689,7 +9690,7 @@ ms_decode_uuid(const char *buf, Py_ssize_t size, PathNode *path) {
 
             *decoded++ = ((unsigned char)hi << 4) + (unsigned char)lo;
         }
-        if (i < 4 && *buf++ != '-') goto invalid;
+        if (has_hyphens && i < 4 && *buf++ != '-') goto invalid;
     }
     PyObject *int128 = _PyLong_FromByteArray(scratch, 16, 0, 0);
     if (int128 == NULL) return NULL;

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2574,9 +2574,12 @@ class TestUUID:
             proto.encode(u)
 
     @pytest.mark.parametrize("upper", [False, True])
-    def test_decode_uuid(self, proto, upper):
+    @pytest.mark.parametrize("hyphens", [False, True])
+    def test_decode_uuid(self, proto, upper, hyphens):
         u = uuid.uuid4()
-        s = str(u).upper() if upper else str(u)
+        s = str(u) if hyphens else u.hex
+        if upper:
+            s = s.upper()
         msg = proto.encode(s)
         res = proto.decode(msg, type=uuid.UUID)
         assert res == u
@@ -2585,6 +2588,9 @@ class TestUUID:
     @pytest.mark.parametrize(
         "uuid_str",
         [
+            # Truncated
+            "12345678-1234-1234-1234-1234567890a",
+            "123456781234123412341234567890a",
             # Truncated segments
             "1234567-1234-1234-1234-1234567890abc",
             "12345678-123-1234-1234-1234567890abc",
@@ -2592,6 +2598,7 @@ class TestUUID:
             "12345678-1234-1234-123-1234567890abc",
             "12345678-1234-1234-1234-1234567890a-",
             # Invalid character
+            "123456x81234123412341234567890ab",
             "123456x8-1234-1234-1234-1234567890ab",
             "1234567x-1234-1234-1234-1234567890ab",
             "12345678-123x-1234-1234-1234567890ab",


### PR DESCRIPTION
While not strictly RFC4122 compliant, there's some precedent in other systems for supporting decoding UUIDs without hyphens. In particular, Python's `UUID` constructor accepts this form, as does the default serde implementation for Rust's uuid.

Fixes #388.