### PR TITLE
Dedent docstrings

### DIFF
--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import textwrap
 from collections.abc import Iterable
 from typing import Any
 
@@ -142,6 +143,7 @@ def _get_doc(t: mi.Type) -> str:
     doc = getattr(cls, "__doc__", "")
     if not doc:
         return ""
+    doc = textwrap.dedent(doc)
     if isinstance(t, mi.EnumType):
         if doc == "An enumeration.":
             return ""

--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -143,7 +143,7 @@ def _get_doc(t: mi.Type) -> str:
     doc = getattr(cls, "__doc__", "")
     if not doc:
         return ""
-    doc = textwrap.dedent(doc)
+    doc = textwrap.dedent(doc).strip("\r\n")
     if isinstance(t, mi.EnumType):
         if doc == "An enumeration.":
             return ""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1159,3 +1159,29 @@ def test_ref_template():
             "required": ["b"],
         },
     }
+
+
+def test_multiline_docstrig():
+    class Example(msgspec.Struct):
+        """
+        first line
+
+            indented
+
+        last line.
+        """
+
+        pass
+
+    assert msgspec.json.schema(Example) == {
+        "$ref": "#/$defs/Example",
+        "$defs": {
+            "Example": {
+                "description": "\nfirst line\n\n    indented\n\nlast line.\n",
+                "title": "Example",
+                "type": "object",
+                "properties": {},
+                "required": [],
+            }
+        },
+    }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1161,7 +1161,7 @@ def test_ref_template():
     }
 
 
-def test_multiline_docstrig():
+def test_multiline_docstring():
     class Example(msgspec.Struct):
         """
         first line

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1164,9 +1164,7 @@ def test_ref_template():
 def test_multiline_docstring():
     class Example(msgspec.Struct):
         """
-        first line
-
-            indented
+            indented first line
 
         last line.
         """
@@ -1177,7 +1175,7 @@ def test_multiline_docstring():
         "$ref": "#/$defs/Example",
         "$defs": {
             "Example": {
-                "description": "\nfirst line\n\n    indented\n\nlast line.\n",
+                "description": "    indented first line\n\nlast line.",
                 "title": "Example",
                 "type": "object",
                 "properties": {},


### PR DESCRIPTION
Strip leading whitespace from docstrings using [`textwrap.dedent()`](https://docs.python.org/3.11/library/textwrap.html?t#textwrap.dedent). This fixes markdown rendering of multiline docstrings.

Without this, the leading whitespace before each line causes markdown renderers to interpret the entire docstring as a code block, and inline formatting does not work.