### PR TITLE
Use `__qualname__` for struct tags

### DIFF
--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -506,7 +506,7 @@ A struct's tagging configuration is determined as follows.
 - If a struct is tagged, ``tag`` defaults to the class name (e.g. ``"Get"``) if
   not provided or inherited. This can be overridden by passing a string (or
   less commonly an integer) value explicitly (e.g. ``tag="get"``).  ``tag`` can
-  also be passed a callable that takes the class name and returns a valid tag
+  also be passed a callable that takes the class qualname and returns a valid tag
   value (e.g. ``tag=str.lower``). Note that tag values must be unique for all
   struct types in a union, and ``str`` and ``int`` tag types cannot both be
   used within the same union.

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1693,6 +1693,21 @@ class TestTagAndTagField:
         assert S2.__struct_config__.tag_field == tag_field
         assert S2.__struct_config__.tag == tag
 
+    def test_tag_uses_simple_qualname(self):
+        class S1(Struct, tag=True):
+            class S2(Struct, tag=True):
+                pass
+
+        assert S1.__struct_config__.tag == "S1"
+        assert S1.S2.__struct_config__.tag == "S1.S2"
+
+        class S1(Struct, tag=str.lower):
+            class S2(Struct, tag=str.lower):
+                pass
+
+        assert S1.__struct_config__.tag == "s1"
+        assert S1.S2.__struct_config__.tag == "s1.s2"
+
     @pytest.mark.parametrize("tag", [b"bad", lambda n: b"bad"])
     def test_tag_wrong_type(self, tag):
         with pytest.raises(TypeError, match="`tag` must be a `str` or an `int`"):
@@ -2059,6 +2074,12 @@ class TestDefStruct:
         assert Test.__struct_config__.dict
 
     def test_defstruct_tag_and_tag_field(self):
+        Test = defstruct("Test", [], tag=True)
+        assert Test.__struct_config__.tag == "Test"
+
+        Test = defstruct("Test", [], namespace={"__qualname__": "Foo.Test"}, tag=True)
+        assert Test.__struct_config__.tag == "Foo.Test"
+
         Test = defstruct("Test", [], tag="mytag", tag_field="mytagfield")
         config = Test.__struct_config__
         assert config.tag_field == "mytagfield"


### PR DESCRIPTION
Previously a struct's tag was generated from its `__name__`. We now generate it from its `__qualname__`, excluding any leading namespaces from nested functions. This means that (nested) structs should be tagged the same if defined dynamically within a function as if they were defined at the top level.

This is a breaking change, but should only affect users making use of tagged nested structs relying on the default tagging behavior. A user falling into this category seems unlikely.

Fixes #395.