### PR TITLE
Add support for parametrizing Decoders at runtime

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -13329,6 +13329,9 @@ static struct PyMethodDef Decoder_methods[] = {
         "decode", (PyCFunction) Decoder_decode, METH_FASTCALL,
         Decoder_decode__doc__,
     },
+#if PY_VERSION_HEX >= 0x03090000
+    {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS},
+#endif
     {NULL, NULL}                /* sentinel */
 };
 
@@ -16589,6 +16592,9 @@ static struct PyMethodDef JSONDecoder_methods[] = {
         "decode", (PyCFunction) JSONDecoder_decode, METH_FASTCALL,
         JSONDecoder_decode__doc__,
     },
+#if PY_VERSION_HEX >= 0x03090000
+    {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS},
+#endif
     {NULL, NULL}                /* sentinel */
 };
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -45,6 +45,7 @@ PY39 = sys.version_info[:2] >= (3, 9)
 PY310 = sys.version_info[:2] >= (3, 10)
 PY311 = sys.version_info[:2] >= (3, 11)
 
+py39_plus = pytest.mark.skipif(not PY39, reason="3.9+ only")
 py310_plus = pytest.mark.skipif(not PY310, reason="3.10+ only")
 py311_plus = pytest.mark.skipif(not PY311, reason="3.11+ only")
 
@@ -142,6 +143,15 @@ class TestEncodeSubclasses:
 
         for msg in [[], [1, 2]]:
             assert proto.encode(subclass(msg)) == proto.encode(cls(msg))
+
+
+class TestDecoder:
+    @py39_plus
+    def test_decoder_runtime_type_parameters(self, proto):
+        dec = proto.Decoder[int](int)
+        assert isinstance(dec, proto.Decoder)
+        msg = proto.encode(2)
+        assert dec.decode(msg) == 2
 
 
 class TestThreadSafe:


### PR DESCRIPTION
Previously `Decoder` types could be parametrized in annotations, but only if `__future__.annotations` was imported (they only worked for static analysis tools like mypy/pyright). We now support parametrizing `Decoder` types in python code without `__future__.annotations` for Python 3.9+.

Fixes #414