### PR TITLE
Add `attributes` option to `from_builtins`

### DIFF
--- a/docs/source/converters.rst
+++ b/docs/source/converters.rst
@@ -86,6 +86,12 @@ configuration options:
   supports string values. This is useful for completely untyped protocols like
   URL querystrings, where only string values exist.
 
+- ``attributes``: `from_builtins` only. If True, input objects may be coerced
+  to ``Struct``/``dataclass``/``attrs`` types by extracting attributes from the
+  input matching fields in the output type. One use case is converting database
+  query results (ORM or otherwise) to msgspec structured types. The default is
+  False.
+
 - ``enc_hook``/``dec_hook``: the standard keyword arguments used for
   :doc:`extending` msgspec to support additional types.
 

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -157,6 +157,7 @@ def from_builtins(
     str_keys: bool = False,
     str_values: bool = False,
     builtin_types: Union[Iterable[type], None] = None,
+    attributes: bool = False,
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> T: ...
 @overload
@@ -166,6 +167,7 @@ def from_builtins(
     *,
     str_keys: bool = False,
     builtin_types: Union[Iterable[type], None] = None,
+    attributes: bool = False,
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any: ...
 

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -953,3 +953,6 @@ def check_from_builtins() -> None:
 
     o6 = msgspec.from_builtins(1, int, dec_hook=lambda typ, x: None)
     reveal_type(o6)  # assert "int" in typ.lower()
+
+    o7 = msgspec.from_builtins(1, int, attributes=True)
+    reveal_type(o7)  # assert "int" in typ.lower()


### PR DESCRIPTION
This adds a new `attributes` option to `from_builtins`. If enabled, arbitrary objects may be coerced to `Struct`/`dataclasses`/`attrs` types by extracting attributes from the input object matching fields in the output type. One use case is converting database query results (ORM or otherwise) to msgspec structured types.

Fixes #416.