### PR TITLE
Don't convert sets to ordered types in `from_builtins`

### DIFF
--- a/tests/test_from_builtins.py
+++ b/tests/test_from_builtins.py
@@ -744,6 +744,9 @@ class TestSequences:
         with pytest.raises(ValidationError, match="Expected `array`, got `int`"):
             from_builtins(1, typ)
 
+        with pytest.raises(ValidationError, match="Expected `array`, got `set`"):
+            from_builtins({1, 2, 3}, typ)
+
         with pytest.raises(ValidationError, match="Expected `array` of length 3"):
             from_builtins((1, "two"), typ)
 
@@ -755,6 +758,9 @@ class TestSequences:
 
         with pytest.raises(ValidationError, match="Expected `bool`"):
             from_builtins([1, "two", "three"], typ)
+
+        with pytest.raises(ValidationError, match="Expected `array`, got `set`"):
+            from_builtins({1, 2, 3}, typ)
 
         with pytest.raises(ValidationError, match="Expected `array` of length 3"):
             from_builtins((1, "two"), typ)


### PR DESCRIPTION
In #418  we added support for converting set/frozenset inputs to any sequence type. However, since sets/frozensets are unordered, we shouldn't convert these to sequences where the order matters. We now limit `from_builtins(<set>, ...)` to convert to `set`, `frozenset`, `list`, or variable length `tuple` types.