### PR TITLE
Support encoding UUID subclasses

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -330,6 +330,8 @@ timezone-naive by specifying a ``tz`` constraint (see
 --------
 
 `uuid.UUID` values are serialized as RFC4122_ encoded strings in all protocols.
+Subclasses of `uuid.UUID` are also supported for encoding only.
+
 When decoding, both hyphenated and unhyphenated forms are supported.
 
 .. code-block:: python

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -10660,11 +10660,11 @@ mpack_encode_uncommon(EncoderState *self, PyTypeObject *type, PyObject *obj)
     else if (Py_TYPE(type) == self->mod->EnumMetaType) {
         return mpack_encode_enum(self, obj);
     }
-    else if (type == (PyTypeObject *)(self->mod->UUIDType)) {
-        return mpack_encode_uuid(self, obj);
-    }
     else if (type == (PyTypeObject *)(self->mod->DecimalType)) {
         return mpack_encode_decimal(self, obj);
+    }
+    else if (PyType_IsSubtype(type, (PyTypeObject *)(self->mod->UUIDType))) {
+        return mpack_encode_uuid(self, obj);
     }
     else if (PyAnySet_Check(obj)) {
         return mpack_encode_set(self, obj);
@@ -11209,9 +11209,6 @@ json_encode_dict_key(EncoderState *self, PyObject *obj) {
     else if (Py_TYPE(type) == self->mod->EnumMetaType) {
         return json_encode_enum(self, obj, true);
     }
-    else if (type == (PyTypeObject *)(self->mod->UUIDType)) {
-        return json_encode_uuid(self, obj);
-    }
     else if (type == PyDateTimeAPI->DateTimeType) {
         return json_encode_datetime(self, obj);
     }
@@ -11226,6 +11223,9 @@ json_encode_dict_key(EncoderState *self, PyObject *obj) {
     }
     else if (type == (PyTypeObject *)(self->mod->DecimalType)) {
         return json_encode_decimal(self, obj);
+    }
+    else if (PyType_IsSubtype(type, (PyTypeObject *)(self->mod->UUIDType))) {
+        return json_encode_uuid(self, obj);
     }
     else {
         PyErr_SetString(
@@ -11495,7 +11495,7 @@ json_encode_uncommon(EncoderState *self, PyTypeObject *type, PyObject *obj) {
     else if (Py_TYPE(type) == self->mod->EnumMetaType) {
         return json_encode_enum(self, obj, false);
     }
-    else if (type == (PyTypeObject *)(self->mod->UUIDType)) {
+    else if (PyType_IsSubtype(type, (PyTypeObject *)(self->mod->UUIDType))) {
         return json_encode_uuid(self, obj);
     }
     else if (type == (PyTypeObject *)(self->mod->DecimalType)) {
@@ -17162,10 +17162,6 @@ to_builtins(ToBuiltinsState *self, PyObject *obj, bool is_key) {
         if (self->builtin_types & MS_BUILTIN_TIME) goto builtin;
         return to_builtins_time(self, obj);
     }
-    else if (type == (PyTypeObject *)(self->mod->UUIDType)) {
-        if (self->builtin_types & MS_BUILTIN_UUID) goto builtin;
-        return to_builtins_uuid(self, obj);
-    }
     else if (type == (PyTypeObject *)(self->mod->DecimalType)) {
         if (self->builtin_types & MS_BUILTIN_DECIMAL) goto builtin;
         return to_builtins_decimal(self, obj);
@@ -17184,6 +17180,10 @@ to_builtins(ToBuiltinsState *self, PyObject *obj, bool is_key) {
     }
     else if (Py_TYPE(type) == self->mod->EnumMetaType) {
         return to_builtins_enum(self, obj);
+    }
+    else if (PyType_IsSubtype(type, (PyTypeObject *)(self->mod->UUIDType))) {
+        if (self->builtin_types & MS_BUILTIN_UUID) goto builtin;
+        return to_builtins_uuid(self, obj);
     }
     else if (PyAnySet_Check(obj)) {
         return to_builtins_set(self, obj, is_key);

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2951,6 +2951,13 @@ class TestUUID:
         sol = proto.encode(str(u))
         assert res == sol
 
+    def test_encode_uuid_subclass(self, proto):
+        class Ex(uuid.UUID):
+            pass
+
+        s = "4184defa-4d1a-4497-a140-fd1ec0b22383"
+        assert proto.encode(Ex(s)) == proto.encode(s)
+
     def test_encode_uuid_malformed_internals(self, proto):
         """Ensure that if some other code mutates the uuid object, we error
         nicely rather than segfaulting"""

--- a/tests/test_to_builtins.py
+++ b/tests/test_to_builtins.py
@@ -172,6 +172,13 @@ class TestToBuiltins:
         msg = uuid.uuid4()
         assert to_builtins(msg) == str(msg)
 
+    def test_uuid_subclass(self):
+        class Ex(uuid.UUID):
+            pass
+
+        s = "4184defa-4d1a-4497-a140-fd1ec0b22383"
+        assert to_builtins(Ex(s)) == s
+
     def test_uuid_builtin_types(self):
         msg = uuid.uuid4()
         res = to_builtins(msg, builtin_types=(uuid.UUID,))


### PR DESCRIPTION
This lets msgspec work out-of-the-box with `asyncpg.pgproto.pgproto.UUID` types, rather than requiring these be handled with `enc_hook`.

Fixes #428.