### PR TITLE
Support `strict` setting in all decoders

### DIFF
--- a/benchmarks/bench_encodings.py
+++ b/benchmarks/bench_encodings.py
@@ -31,7 +31,7 @@ class Directory(msgspec.Struct, tag="directory"):
 def bench(dumps, loads, ndata, schema=None):
     data = make_filesystem_data(ndata)
     if schema:
-        data = msgspec.from_builtins(data, schema)
+        data = msgspec.convert(data, schema)
     timer = timeit.Timer("func(data)", globals={"func": dumps, "data": data})
     n, t = timer.autorange()
     dumps_time = t / n

--- a/benchmarks/bench_validation.py
+++ b/benchmarks/bench_validation.py
@@ -40,7 +40,7 @@ def bench_msgspec(n):
     dec = msgspec.json.Decoder(Directory)
 
     def convert(data):
-        return msgspec.from_builtins(data, Directory)
+        return msgspec.convert(data, Directory)
 
     return bench(enc.encode, dec.decode, n, convert)
 

--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -87,6 +87,15 @@ lacks a ``null`` value, attempted to encode a message containing ``None`` to
     >>> msgspec.json.decode(b'null')
     None
 
+If ``strict=False`` is specified, a string value of ``"null"`` (case
+insensitive) may also be coerced to ``None``. See :ref:`strict-vs-lax` for more
+information.
+
+.. code-block:: python
+
+   >>> msgspec.json.decode(b'"null"', type=None, strict=False)
+   None
+
 ``bool``
 --------
 
@@ -100,6 +109,18 @@ supported protocols.
 
     >>> msgspec.json.decode(b'true')
     True
+
+If ``strict=False`` is specified, string values of ``"true"``/``"1"`` or
+``"false"``/``"0"`` (case insensitive) may also be coerced to
+``True``/``False`` respectively. See :ref:`strict-vs-lax` for more information.
+
+.. code-block:: python
+
+   >>> msgspec.json.decode(b'"false"', type=bool, strict=False)
+   False
+
+   >>> msgspec.json.decode(b'"TRUE"', type=bool, strict=False)
+   True
 
 ``int``
 -------
@@ -121,6 +142,15 @@ Support for large integers varies by protocol:
 
     >>> msgspec.json.decode(b"123", type=int)
     123
+
+If ``strict=False`` is specified, string values may also be coerced to
+integers, following the same restrictions as above. See :ref:`strict-vs-lax`
+for more information.
+
+.. code-block:: python
+
+   >>> msgspec.json.decode(b'"123"', type=int, strict=False)
+   123
 
 
 ``float``
@@ -150,6 +180,19 @@ provided, the `int` will be automatically converted.
     >>> # Ints are automatically converted to floats
     ... msgspec.json.decode(b"123", type=float)
     123.0
+
+If ``strict=False`` is specified, string values may also be coerced to floats.
+Note that in this case the strings ``"nan"``, ``"inf"``/``"infinity"``,
+``"-inf"``/``"-infinity"`` (case insensitive) will coerce to
+``nan``/``inf``/``-inf``. See :ref:`strict-vs-lax` for more information.
+
+.. code-block:: python
+
+   >>> msgspec.json.decode(b'"123.45"', type=float, strict=False)
+   123.45
+
+   >>> msgspec.json.decode(b'"-inf"', type=float, strict=False)
+   -inf
 
 ``str``
 -------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -131,10 +131,15 @@ If a message doesn't match the expected type, an error is raised.
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `str`, got `int` - at `$.groups[1]`
 
+.. _strict-vs-lax:
+
+"Strict" vs "Lax" Mode
+~~~~~~~~~~~~~~~~~~~~~~
+
 Unlike some other libraries (e.g. pydantic_), ``msgspec`` won't perform any
-unsafe implicit conversion. For example, if an integer is specified and a
-string is decoded instead, an error is raised rather than attempting to cast
-the string to an int.
+unsafe implicit conversion by default ("strict" mode). For example, if an
+integer is specified and a string is provided instead, an error is raised
+rather than attempting to cast the string to an int.
 
 .. code-block:: python
 
@@ -142,6 +147,17 @@ the string to an int.
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `int`, got `str` - at `$[2]`
+
+For cases where you'd like a more lax set of conversion rules, you can pass
+``strict=False`` to any ``decode`` function or ``Decoder`` class ("lax" mode).
+See :doc:`supported-types` for information on how this affects individual
+types.
+
+.. code-block:: python
+
+    >>> msgspec.json.decode(b'[1, 2, "3"]', type=list[int], strict=False)
+    [1, 2, 3]
+
 
 .. _JSON: https://json.org
 .. _MessagePack: https://msgpack.org

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -13551,6 +13551,7 @@ static struct PyMethodDef Decoder_methods[] = {
 
 static PyMemberDef Decoder_members[] = {
     {"type", T_OBJECT_EX, offsetof(Decoder, orig_type), READONLY, "The Decoder type"},
+    {"strict", T_BOOL, offsetof(Decoder, strict), READONLY, "The Decoder strict setting"},
     {"dec_hook", T_OBJECT, offsetof(Decoder, dec_hook), READONLY, "The Decoder dec_hook"},
     {"ext_hook", T_OBJECT, offsetof(Decoder, ext_hook), READONLY, "The Decoder ext_hook"},
     {NULL},

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -33,12 +33,14 @@ class Encoder:
 
 class Decoder(Generic[T]):
     type: Type[T]
+    strict: bool
     dec_hook: dec_hook_sig
 
     @overload
     def __init__(
         self: Decoder[Any],
         *,
+        strict: bool = True,
         dec_hook: dec_hook_sig = None,
     ) -> None: ...
     @overload
@@ -46,6 +48,7 @@ class Decoder(Generic[T]):
         self: Decoder[T],
         type: Type[T] = ...,
         *,
+        strict: bool = True,
         dec_hook: dec_hook_sig = None,
     ) -> None: ...
     @overload
@@ -53,6 +56,7 @@ class Decoder(Generic[T]):
         self: Decoder[Any],
         type: Any = ...,
         *,
+        strict: bool = True,
         dec_hook: dec_hook_sig = None,
     ) -> None: ...
     def decode(self, data: Union[bytes, str]) -> T: ...
@@ -61,6 +65,7 @@ class Decoder(Generic[T]):
 def decode(
     buf: Union[bytes, str],
     *,
+    strict: bool = True,
     dec_hook: dec_hook_sig = None,
 ) -> Any: ...
 @overload
@@ -68,6 +73,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
+    strict: bool = True,
     dec_hook: dec_hook_sig = None,
 ) -> T: ...
 @overload
@@ -75,6 +81,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Any = ...,
+    strict: bool = True,
     dec_hook: dec_hook_sig = None,
 ) -> Any: ...
 def encode(obj: Any, *, enc_hook: enc_hook_sig = None) -> bytes: ...

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -24,12 +24,14 @@ class Ext:
 
 class Decoder(Generic[T]):
     type: Type[T]
+    strict: bool
     dec_hook: dec_hook_sig
     ext_hook: ext_hook_sig
     @overload
     def __init__(
         self: Decoder[Any],
         *,
+        strict: bool = True,
         dec_hook: dec_hook_sig = None,
         ext_hook: ext_hook_sig = None,
     ) -> None: ...
@@ -38,6 +40,7 @@ class Decoder(Generic[T]):
         self: Decoder[T],
         type: Type[T] = ...,
         *,
+        strict: bool = True,
         dec_hook: dec_hook_sig = None,
         ext_hook: ext_hook_sig = None,
     ) -> None: ...
@@ -46,6 +49,7 @@ class Decoder(Generic[T]):
         self: Decoder[Any],
         type: Any = ...,
         *,
+        strict: bool = True,
         dec_hook: dec_hook_sig = None,
         ext_hook: ext_hook_sig = None,
     ) -> None: ...
@@ -69,6 +73,7 @@ class Encoder:
 def decode(
     buf: bytes,
     *,
+    strict: bool = True,
     dec_hook: dec_hook_sig = None,
     ext_hook: ext_hook_sig = None,
 ) -> Any: ...
@@ -77,6 +82,7 @@ def decode(
     buf: bytes,
     *,
     type: Type[T] = ...,
+    strict: bool = True,
     dec_hook: dec_hook_sig = None,
     ext_hook: ext_hook_sig = None,
 ) -> T: ...
@@ -85,6 +91,7 @@ def decode(
     buf: bytes,
     *,
     type: Any = ...,
+    strict: bool = True,
     dec_hook: dec_hook_sig = None,
     ext_hook: ext_hook_sig = None,
 ) -> Any: ...

--- a/msgspec/toml.py
+++ b/msgspec/toml.py
@@ -88,6 +88,7 @@ T = TypeVar("T")
 def decode(
     buf: Union[bytes, str],
     *,
+    strict: bool = True,
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
@@ -98,6 +99,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
+    strict: bool = True,
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> T:
     pass
@@ -108,12 +110,13 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Any = ...,
+    strict: bool = True,
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
 
 
-def decode(buf, *, type=Any, dec_hook=None):
+def decode(buf, *, type=Any, strict=True, dec_hook=None):
     """Deserialize an object from TOML.
 
     Parameters
@@ -125,6 +128,10 @@ def decode(buf, *, type=Any, dec_hook=None):
         provided, the message will be type checked and decoded as the specified
         type. Defaults to `Any`, in which case the message will be decoded
         using the default TOML types.
+    strict : bool, optional
+        Whether type coercion rules should be strict. Setting to False enables
+        a wider set of coercion rules from string to non-string types for all
+        values. Default is True.
     dec_hook : callable, optional
         An optional callback for handling decoding custom types. Should have
         the signature ``dec_hook(type: Type, obj: Any) -> Any``, where ``type``
@@ -161,5 +168,6 @@ def decode(buf, *, type=Any, dec_hook=None):
         type,
         builtin_types=(_datetime.datetime, _datetime.date, _datetime.time),
         str_keys=True,
+        strict=strict,
         dec_hook=dec_hook,
     )

--- a/msgspec/yaml.py
+++ b/msgspec/yaml.py
@@ -78,7 +78,10 @@ T = TypeVar("T")
 
 @overload
 def decode(
-    buf: Union[bytes, str], *, dec_hook: Optional[Callable[[type, Any], Any]] = None
+    buf: Union[bytes, str],
+    *,
+    strict: bool = True,
+    dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
 
@@ -88,6 +91,7 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Type[T] = ...,
+    strict: bool = True,
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> T:
     pass
@@ -98,12 +102,13 @@ def decode(
     buf: Union[bytes, str],
     *,
     type: Any = ...,
+    strict: bool = True,
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
 ) -> Any:
     pass
 
 
-def decode(buf, *, type=Any, dec_hook=None):
+def decode(buf, *, type=Any, strict=True, dec_hook=None):
     """Deserialize an object from YAML.
 
     Parameters
@@ -115,6 +120,10 @@ def decode(buf, *, type=Any, dec_hook=None):
         provided, the message will be type checked and decoded as the specified
         type. Defaults to `Any`, in which case the message will be decoded
         using the default YAML types.
+    strict : bool, optional
+        Whether type coercion rules should be strict. Setting to False enables
+        a wider set of coercion rules from string to non-string types for all
+        values. Default is True.
     dec_hook : callable, optional
         An optional callback for handling decoding custom types. Should have
         the signature ``dec_hook(type: Type, obj: Any) -> Any``, where ``type``
@@ -150,5 +159,9 @@ def decode(buf, *, type=Any, dec_hook=None):
     if type is Any:
         return obj
     return _convert(
-        obj, type, builtin_types=(_datetime.datetime, _datetime.date), dec_hook=dec_hook
+        obj,
+        type,
+        builtin_types=(_datetime.datetime, _datetime.date),
+        strict=strict,
+        dec_hook=dec_hook,
     )

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -654,6 +654,16 @@ def check_msgpack_decode_ext_hook() -> None:
     msgspec.msgpack.Decoder(ext_hook=ext_hook)
 
 
+def check_msgpack_Decoder_strict() -> None:
+    dec = msgspec.msgpack.Decoder(List[int], strict=False)
+    reveal_type(dec.strict)  # assert "bool" in typ
+
+
+def check_msgpack_decode_strict() -> None:
+    out = msgspec.msgpack.decode(b'', type=List[int], strict=False)
+    reveal_type(out)  # assert "list" in typ.lower()
+
+
 def check_msgpack_Ext() -> None:
     ext = msgspec.msgpack.Ext(1, b"test")
     reveal_type(ext.code)  # assert "int" in typ
@@ -765,6 +775,16 @@ def check_json_decode_dec_hook() -> None:
     msgspec.json.Decoder(dec_hook=dec_hook)
 
 
+def check_json_Decoder_strict() -> None:
+    dec = msgspec.json.Decoder(List[int], strict=False)
+    reveal_type(dec.strict)  # assert "bool" in typ
+
+
+def check_json_decode_strict() -> None:
+    out = msgspec.json.decode(b'', type=List[int], strict=False)
+    reveal_type(out)  # assert "list" in typ.lower()
+
+
 def check_json_format() -> None:
     reveal_type(msgspec.json.format(b"test"))  # assert "bytes" in typ
     reveal_type(msgspec.json.format(b"test", indent=4))  # assert "bytes" in typ
@@ -812,6 +832,12 @@ def check_yaml_decode_dec_hook() -> None:
 
     msgspec.yaml.decode(b"test", dec_hook=dec_hook)
 
+
+def check_yaml_decode_strict() -> None:
+    out = msgspec.yaml.decode(b'', type=List[int], strict=False)
+    reveal_type(out)  # assert "list" in typ.lower()
+
+
 ##########################################################
 # TOML                                                   #
 ##########################################################
@@ -847,6 +873,11 @@ def check_toml_decode_dec_hook() -> None:
         return typ(obj)
 
     msgspec.toml.decode(b"a = 1", dec_hook=dec_hook)
+
+
+def check_toml_decode_strict() -> None:
+    out = msgspec.toml.decode(b'', type=List[int], strict=False)
+    reveal_type(out)  # assert "list" in typ.lower()
 
 
 ##########################################################

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3212,7 +3212,7 @@ class TestFinal:
 class TestLax:
     @pytest.mark.parametrize("strict", [True, False])
     def test_strict_lax_decoder(self, proto, strict):
-        dec = proto.Decoder(list[int], strict=strict)
+        dec = proto.Decoder(List[int], strict=strict)
 
         assert dec.strict is strict
 

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -180,6 +180,20 @@ def test_decode_validation_error():
 
 
 @needs_decode
+@pytest.mark.parametrize("strict", [True, False])
+def test_decode_strict_or_lax(strict):
+    msg = b"a = ['1', '2']"
+    typ = Dict[str, List[int]]
+
+    if strict:
+        with pytest.raises(msgspec.ValidationError, match="Expected `int`"):
+            msgspec.toml.decode(msg, type=typ, strict=strict)
+    else:
+        res = msgspec.toml.decode(msg, type=typ, strict=strict)
+        assert res == {"a": [1, 2]}
+
+
+@needs_decode
 def test_decode_dec_hook():
     def dec_hook(typ, val):
         if typ is Decimal:

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -145,6 +145,19 @@ def test_decode_validation_error():
         msgspec.yaml.decode(b"[1, 2, 3]", type=List[str])
 
 
+@pytest.mark.parametrize("strict", [True, False])
+def test_decode_strict_or_lax(strict):
+    msg = b"a: ['1', '2']"
+    typ = Dict[str, List[int]]
+
+    if strict:
+        with pytest.raises(msgspec.ValidationError, match="Expected `int`"):
+            msgspec.yaml.decode(msg, type=typ, strict=strict)
+    else:
+        res = msgspec.yaml.decode(msg, type=typ, strict=strict)
+        assert res == {"a": [1, 2]}
+
+
 def test_decode_dec_hook():
     def dec_hook(typ, val):
         if typ is Decimal:


### PR DESCRIPTION
This adds a new `strict` boolean config kwarg to all `decode` functions (as well as all `Decoder` classes). The default is `True`, matching the existing strict type coercion rules. Setting to `False` enables a wider set of coercion rules, which may be useful in some scenarios. Currently setting `strict=False` enables coercing:

- the string `"null"` (case insensitive) to `None`
- the strings `"false"` or `"0"` (case insensitive) to `False`
- the strings `"true"` or `"1"` (case insensitive) to `True`
- any int-like string to an integer
- any float-like string to a float

Additional coercion rules may be added to `strict=False` ("lax mode") in the future.

Note that coercion still only happens if the requested type (e.g. `int`) doesn't match the provided type (e.g. `str`). When not using `msgspec.json.decode` without a type specified no coercion will happen.

```python
In [1]: import msgspec

In [2]: msg = b'["1", "2"]'  # a list of int-like strings

In [3]: msgspec.json.decode(msg, strict=False)  # untyped decoding, no coercion
Out[3]: ['1', '2']

In [4]: msgspec.json.decode(msg, type=list[int])  # typed decoding, errors by default
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[4], line 1
----> 1 msgspec.json.decode(msg, type=list[int])

ValidationError: Expected `int`, got `str` - at `$[0]`

In [5]: msgspec.json.decode(msg, type=list[int], strict=False)  # typed decoding, strict=False, coerces str -> int
Out[5]: [1, 2]
```

Fixes #424.