### PR TITLE
Passthrough input unchanged for `convert` to `Any` type

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -269,6 +269,12 @@ class TestConvert:
             convert(val, typ)
 
 
+class TestAny:
+    @pytest.mark.parametrize("msg", [(1, 2), {"a": 1}, object(), {1, 2}])
+    def test_any_passthrough(self, msg):
+        assert convert(msg, Any) is msg
+
+
 class TestNone:
     def test_none(self):
         assert convert(None, Any) is None
@@ -764,7 +770,8 @@ class TestLiteral:
 
 class TestSequences:
     def test_any_sequence(self):
-        assert convert((1, 2, 3), Any) == [1, 2, 3]
+        msg = (1, 2, 3)
+        assert convert(msg, Any) is msg
 
     @pytest.mark.parametrize("in_type", [list, tuple, set, frozenset])
     @pytest.mark.parametrize("out_type", [list, tuple, set, frozenset])


### PR DESCRIPTION
Previously when converting a value to an `Any` type, we'd recurse through the input if the input was a known builtin type. We now return the input unchanged when converting to an `Any` field. This is significantly more efficient in these cases, as it doesn't require recursing through the input data.