### PR TITLE
defstruct accepts None for module/namespace/bases

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -74,7 +74,7 @@ def defstruct(
     name: str,
     fields: Iterable[Union[str, Tuple[str, type], Tuple[str, type, Any]]],
     *,
-    bases: Tuple[Type[Struct], ...] = (),
+    bases: Optional[Tuple[Type[Struct], ...]] = None,
     module: Optional[str] = None,
     namespace: Optional[Dict[str, Any]] = None,
     tag: Union[None, bool, str, int, Callable[[str], Union[str, int]]] = None,

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -376,15 +376,18 @@ def check_defstruct_bases() -> None:
     class Base(msgspec.Struct):
         pass
 
-    Test = msgspec.defstruct("Test", ["x", "y"], bases=(Base,))
+    msgspec.defstruct("Test", ["x", "y"], bases=(Base,))
+    msgspec.defstruct("Test2", ["x", "y"], bases=None)
 
 
 def check_defstruct_namespace() -> None:
     msgspec.defstruct("Test", ["x", "y"], namespace={"classval": 1})
+    msgspec.defstruct("Test2", ["x", "y"], namespace=None)
 
 
 def check_defstruct_module() -> None:
     msgspec.defstruct("Test", ["x", "y"], module="mymod")
+    msgspec.defstruct("Test2", ["x", "y"], module=None)
 
 
 def check_defstruct_config_options() -> None:

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1996,6 +1996,15 @@ class TestDefStruct:
         with pytest.raises(TypeError, match="items in `fields` must be one of"):
             defstruct("Test", ["x", (1, 2)])
 
+        with pytest.raises(TypeError, match="must be a tuple or None"):
+            defstruct("Test", [], bases=[])
+
+        with pytest.raises(TypeError, match="must be a str or None"):
+            defstruct("Test", [], module=1)
+
+        with pytest.raises(TypeError, match="must be a dict or None"):
+            defstruct("Test", [], namespace=1)
+
     def test_defstruct_bases(self):
         class Base(Struct):
             z: int
@@ -2006,9 +2015,18 @@ class TestDefStruct:
         assert as_tuple(Point(1, 2, 0)) == (1, 2, 0)
         assert as_tuple(Point(1, 2, 3)) == (1, 2, 3)
 
+    def test_defstruct_bases_none(self):
+        Point = defstruct("Point", ["x", "y"], bases=None)
+        assert Point.mro() == [Point, *Struct.mro()]
+        assert Point(1, 2) == Point(1, 2)
+
     def test_defstruct_module(self):
         Test = defstruct("Test", [], module="testmod")
         assert Test.__module__ == "testmod"
+
+    def test_defstruct_module_none(self):
+        Test = defstruct("Test", [], module=None)
+        assert Test.__module__ == "test_struct"
 
     def test_defstruct_namespace(self):
         Test = defstruct(
@@ -2016,6 +2034,10 @@ class TestDefStruct:
         )
         t = Test(1, 2)
         assert t.add() == 3
+
+    def test_defstruct_namespace_none(self):
+        Test = defstruct("Test", [], namespace=None)
+        assert Test() == Test()  # smoketest
 
     def test_defstruct_kw_only(self):
         Test = defstruct("Test", ["x", "y"], kw_only=True)


### PR DESCRIPTION
Previously these kwargs were documented as accepting `None`, but passing in `None` wasn't actually supported. This PR fixes this, and adds a test checking this behavior.

Fixes #444.