### PR TITLE
Support decoding unix timestamps to datetimes when `strict=False`

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -292,6 +292,23 @@ timezone-naive by specifying a ``tz`` constraint (see
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Invalid RFC3339 encoded datetime
 
+
+Additionally, if ``strict=False`` is specified, all protocols will decode ints,
+floats, or strings containing ints/floats as timezone-aware datetimes,
+interpreting the value as seconds since the epoch in UTC (a `Unix Timestamp
+<https://en.wikipedia.org/wiki/Unix_time>`__). See :ref:`strict-vs-lax` for
+more information.
+
+.. code-block:: python
+
+    >>> msgspec.json.decode(b"1617405490.000123", type=datetime.datetime)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Expected `datetime`, got `float`
+
+    >>> msgspec.json.decode(b"1617405490.000123", type=datetime.datetime, strict=False)
+    datetime.datetime(2021, 4, 2, 18, 18, 10, 123, tzinfo=datetime.timezone.utc)
+
 ``date``
 --------
 

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -1476,6 +1476,20 @@ class TestTimestampExt:
         msg = b"\xc7\x0c\xff\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00"
         self.check(dt, msg)
 
+    @pytest.mark.parametrize(
+        "msg, secs, micros",
+        [
+            (b"\xd7\xff\x00\x00\x07\xd0\x00\x00\x00\x00", 0, 1),
+            (b"\xd7\xff\x00\x00\x07\xcc\x00\x00\x00\x00", 0, 0),
+            (b"\xd7\xff\xeek 0\x00\x00\x00\x00", 1, 0),
+            (b"\xd7\xff\xeek ,\x00\x00\x00\x00", 0, 999999),
+        ],
+    )
+    def test_timestamp_rounds_nanos(self, msg, secs, micros):
+        res = msgspec.msgpack.decode(msg)
+        assert res.second == secs
+        assert res.microsecond == micros
+
 
 class CommonTypeTestBase:
     """Test msgspec untyped encode/decode"""


### PR DESCRIPTION
This adds support for decoding float/int/numeric-strings into datetime objects when `strict=False`. These inputs are interpreted as epoch timestamps (seconds since the epoch, UTC), and are decoded as timezone-aware with a UTC timezone.

```python
In [1]: import msgspec

In [2]: import datetime

In [3]: dt = datetime.datetime.now()

In [4]: ts = dt.timestamp()

In [5]:
Out[5]: 1687578573.501321

In [6]: msgspec.convert(ts, type=datetime.datetime)  # by default not supported
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[6], line 1
----> 1 msgspec.convert(ts, type=datetime.datetime)

ValidationError: Expected `datetime`, got `float`

In [7]: msgspec.convert(ts, type=datetime.datetime, strict=False)  # works with strict=False
Out[7]: datetime.datetime(2023, 6, 24, 3, 49, 33, 501321, tzinfo=datetime.timezone.utc)

In [8]: msgspec.convert(str(ts), type=datetime.datetime, strict=False)  # numeric strings work
   ...:  too
Out[8]: datetime.datetime(2023, 6, 24, 3, 49, 33, 501321, tzinfo=datetime.timezone.utc)

In [9]: js = msgspec.json.encode(ts)

In [10]: msgspec.json.decode(js, type=datetime.datetime, strict=False)  # also works with othe
    ...: r protocols
Out[10]: datetime.datetime(2023, 6, 24, 3, 49, 33, 501321, tzinfo=datetime.timezone.utc)
```

Fixes #448.