### PR TITLE
Support str subclasses as dict keys in encode/to_builtins

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1840,6 +1840,13 @@ class TestDict:
         with pytest.raises(msgspec.ValidationError, match="Invalid enum value 3"):
             dec.decode(b'{"-1": 10, "3": 20}')
 
+    def test_encode_dict_str_subclass_key(self):
+        class mystr(str):
+            pass
+
+        msg = msgspec.json.encode({mystr("test"): 1})
+        assert msg == b'{"test":1}'
+
     @pytest.mark.parametrize(
         "s, error",
         [

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -1026,6 +1026,14 @@ class TestTypedDecoder:
         ):
             dec.decode(enc.encode({1: 2}))
 
+    def test_dict_str_subclass_key(self):
+        class mystr(str):
+            pass
+
+        msg1 = msgspec.msgpack.encode({mystr("test"): 1})
+        msg2 = msgspec.msgpack.encode({"test": 1})
+        assert msg1 == msg2
+
     def test_dict_typed(self):
         enc = msgspec.msgpack.Encoder()
         dec = msgspec.msgpack.Decoder(Dict[str, int])

--- a/tests/test_to_builtins.py
+++ b/tests/test_to_builtins.py
@@ -262,6 +262,14 @@ class TestToBuiltins:
         res = to_builtins(in_type())
         assert res == {}
 
+    def test_dict_str_subclass_key(self):
+        class mystr(str):
+            pass
+
+        msg = to_builtins({mystr("test"): 1})
+        assert msg == {"test": 1}
+        assert type(list(msg.keys())[0]) is str
+
     def test_dict_unsupported_key(self):
         msg = {Bad(): 1}
         with pytest.raises(TypeError, match="Encoding objects of type Bad"):


### PR DESCRIPTION
Previously we only supported `str` types exactly, or types that would be natively mapped to `str`. We now natively support `str` subclasses as dict keys in `msgspec.to_builtins` as well as all `encode` functions.

This is a bit inconsistent with the rest of msgspec, where `str` subclasses aren't natively supported and require an `enc_hook` to support. I think making an exception for dict keys is fine since:

- In the long term the `enc_hook` design should be reworked, allowing us to natively handle `str` subclasses everywhere, provided the user doesn't override a serializer for that type. When that's done dicts with str subclasses as keys will "just work" out of the box, I see no reason not to allow that now as well.

- The main reason we don't natively support encoding str subclasses (or most subclasses) is that there's no way for a user to override behavior for a natively supported object. Subclassing a str lets the user change how that str is serialized. While I still want to support this for *values*, I find it highly unlikely that a user would want to change how a dict key is serialized. Again, in the long run users should be able to override this behavior in an ergonomic way, but for now I'm making (IMO) the pragmatic choice of supporting the common case without requiring extra effort from users.

Fixes #450.