### PR TITLE
Wrap dec_hook errors in `ValidationError`

### DIFF
--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -24,7 +24,12 @@ These should have the following signatures:
 
     def dec_hook(type: Type, obj: Any) -> Any:
         """Given a type in a schema, convert ``obj`` (composed of natively
-        supported objects) into an object of type ``type``"""
+        supported objects) into an object of type ``type``.
+
+        Any `TypeError` or `ValueError` exceptions raised by this method will
+        be considered "user facing" and converted into a `ValidationError` with
+        additional context. All other exceptions will be raised directly.
+        """
         pass
 
     def ext_hook(code: int, data: memoryview) -> Any:
@@ -78,8 +83,8 @@ objects to/from objects, which are then natively handled by ``msgspec``.
             # convert the complex to a tuple of real, imag
             return (obj.real, obj.imag)
         else:
-            # Raise a TypeError for other types
-            raise TypeError(f"Objects of type {type(obj)} are not supported")
+            # Raise a NotImplementedError for other types
+            raise NotImplementedError(f"Objects of type {type(obj)} are not supported")
 
 
     def dec_hook(type: Type, obj: Any) -> Any:
@@ -89,8 +94,8 @@ objects to/from objects, which are then natively handled by ``msgspec``.
             real, imag = obj
             return complex(real, imag)
         else:
-            # Raise a TypeError for other types
-            raise TypeError(f"Objects of type {type} are not supported")
+            # Raise a NotImplementedError for other types
+            raise NotImplementedError(f"Objects of type {type} are not supported")
 
 
     # Define a message that contains a complex type
@@ -161,8 +166,8 @@ buffer.
     +---------+---------+
     |  real   |  imag   |
     +---------+---------+
-      8 bytes   8 bytes 
-    
+      8 bytes   8 bytes
+
 
 Here we define ``enc_hook`` and ``ext_hook`` callbacks to convert `complex`
 objects to/from this binary representation as a MessagePack extension.
@@ -186,8 +191,8 @@ objects to/from this binary representation as a MessagePack extension.
             # Return an `Ext` object so msgspec serializes it as an extension type.
             return msgspec.msgpack.Ext(COMPLEX_TYPE_CODE, data)
         else:
-            # Raise a TypeError for other types
-            raise TypeError(f"Objects of type {type(obj)} are not supported")
+            # Raise a NotImplementedError for other types
+            raise NotImplementedError(f"Objects of type {type(obj)} are not supported")
 
 
     def ext_hook(code: int, data: memoryview) -> Any:
@@ -197,8 +202,8 @@ objects to/from this binary representation as a MessagePack extension.
             real, imag = struct.unpack('dd', data)
             return complex(real, imag)
         else:
-            # Raise a TypeError for other extension type codes
-            raise TypeError(f"Extension type code {code} is not supported")
+            # Raise a NotImplementedError for other extension type codes
+            raise NotImplementedError(f"Extension type code {code} is not supported")
 
 
     # Create an encoder and a decoder using the custom callbacks

--- a/msgspec/toml.py
+++ b/msgspec/toml.py
@@ -59,7 +59,7 @@ def encode(obj: Any, *, enc_hook: Optional[Callable[[Any], Any]] = None) -> byte
     enc_hook : callable, optional
         A callable to call for objects that aren't supported msgspec types.
         Takes the unsupported object and should return a supported object, or
-        raise a TypeError.
+        raise a ``NotImplementedError`` if unsupported.
 
     Returns
     -------
@@ -137,7 +137,7 @@ def decode(buf, *, type=Any, strict=True, dec_hook=None):
         the signature ``dec_hook(type: Type, obj: Any) -> Any``, where ``type``
         is the expected message type, and ``obj`` is the decoded representation
         composed of only basic TOML types. This hook should transform ``obj``
-        into type ``type``, or raise a ``TypeError`` if unsupported.
+        into type ``type``, or raise a ``NotImplementedError`` if unsupported.
 
     Returns
     -------

--- a/msgspec/yaml.py
+++ b/msgspec/yaml.py
@@ -38,7 +38,7 @@ def encode(obj: Any, *, enc_hook: Optional[Callable[[Any], Any]] = None) -> byte
     enc_hook : callable, optional
         A callable to call for objects that aren't supported msgspec types.
         Takes the unsupported object and should return a supported object, or
-        raise a TypeError.
+        raise a ``NotImplementedError`` if unsupported.
 
     Returns
     -------
@@ -129,7 +129,7 @@ def decode(buf, *, type=Any, strict=True, dec_hook=None):
         the signature ``dec_hook(type: Type, obj: Any) -> Any``, where ``type``
         is the expected message type, and ``obj`` is the decoded representation
         composed of only basic YAML types. This hook should transform ``obj``
-        into type ``type``, or raise a ``TypeError`` if unsupported.
+        into type ``type``, or raise a ``NotImplementedError`` if unsupported.
 
     Returns
     -------

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2267,5 +2267,8 @@ class TestCustom:
         def dec_hook(typ, x):
             raise TypeError("Oops!")
 
-        with pytest.raises(TypeError, match="Oops!"):
+        with pytest.raises(ValidationError, match="Oops!") as rec:
             convert({"x": (1, 2)}, Dict[str, complex], dec_hook=dec_hook)
+
+        assert rec.value.__cause__ is rec.value.__context__
+        assert type(rec.value.__cause__) is TypeError

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -10,7 +10,6 @@ import struct
 import sys
 from typing import (
     Any,
-    Deque,
     Dict,
     FrozenSet,
     List,
@@ -262,16 +261,6 @@ class TestDecodeFunction:
 
         with pytest.raises(TypeError, match="Extra keyword arguments"):
             msgspec.msgpack.decode(self.buf, type=List[int], extra=1)
-
-    def test_decode_dec_hook(self):
-        def dec_hook(typ, obj):
-            assert typ is Custom
-            return typ(*obj)
-
-        buf = msgspec.msgpack.encode((1, 2))
-        res = msgspec.msgpack.decode(buf, type=Custom, dec_hook=dec_hook)
-        assert res == Custom(1, 2)
-        assert isinstance(res, Custom)
 
     def test_decode_with_trailing_characters_errors(self):
         msg = msgspec.msgpack.encode([1, 2, 3]) + b"trailing"
@@ -529,108 +518,6 @@ class TestDecoderMisc:
     def test_decoder_ext_hook_not_callable(self):
         with pytest.raises(TypeError):
             msgspec.msgpack.Decoder(ext_hook=1)
-
-    def test_decoder_dec_hook_attribute(self):
-        def dec_hook(typ, obj):
-            pass
-
-        dec = msgspec.msgpack.Decoder()
-        assert dec.dec_hook is None
-
-        dec = msgspec.msgpack.Decoder(dec_hook=None)
-        assert dec.dec_hook is None
-
-        dec = msgspec.msgpack.Decoder(dec_hook=dec_hook)
-        assert dec.dec_hook is dec_hook
-
-    def test_decoder_dec_hook_not_callable(self):
-        with pytest.raises(TypeError):
-            msgspec.msgpack.Decoder(dec_hook=1)
-
-    def test_decoder_dec_hook(self):
-        called = False
-
-        def dec_hook(typ, obj):
-            nonlocal called
-            called = True
-            assert typ is Custom
-            return Custom(*obj)
-
-        dec = msgspec.msgpack.Decoder(type=List[Custom], dec_hook=dec_hook)
-        buf = msgspec.msgpack.encode([(1, 2), (3, 4), (5, 6)])
-        msg = dec.decode(buf)
-        assert called
-        assert msg == [Custom(1, 2), Custom(3, 4), Custom(5, 6)]
-        assert isinstance(msg[0], Custom)
-
-    def test_decoder_dec_hook_optional_custom_type(self):
-        called = False
-
-        def dec_hook(typ, obj):
-            nonlocal called
-            called = True
-
-        dec = msgspec.msgpack.Decoder(type=Optional[Custom], dec_hook=dec_hook)
-        msg = dec.decode(msgspec.msgpack.encode(None))
-        assert not called
-        assert msg is None
-
-    def test_decode_dec_hook_errors(self):
-        def dec_hook(typ, obj):
-            assert obj == "some string"
-            raise TypeError("Oh no!")
-
-        buf = msgspec.msgpack.encode("some string")
-        dec = msgspec.msgpack.Decoder(type=Custom, dec_hook=dec_hook)
-
-        with pytest.raises(TypeError, match="Oh no!"):
-            dec.decode(buf)
-
-    def test_decode_dec_hook_wrong_type(self):
-        dec = msgspec.msgpack.Decoder(type=Custom, dec_hook=lambda t, o: o)
-        buf = msgspec.msgpack.encode((1, 2))
-
-        with pytest.raises(
-            msgspec.ValidationError,
-            match="Expected `Custom`, got `list`",
-        ):
-            dec.decode(buf)
-
-    def test_decode_dec_hook_wrong_type_in_struct(self):
-        class Test(msgspec.Struct):
-            point: Custom
-            other: int
-
-        dec = msgspec.msgpack.Decoder(type=Test, dec_hook=lambda t, o: o)
-        buf = msgspec.msgpack.encode(Test((1, 2), 3))
-
-        with pytest.raises(msgspec.ValidationError) as rec:
-            dec.decode(buf)
-
-        assert "Expected `Custom`, got `list` - at `$.point`" == str(rec.value)
-
-    def test_decode_dec_hook_wrong_type_generic(self):
-        dec = msgspec.msgpack.Decoder(type=Deque[int], dec_hook=lambda t, o: o)
-        buf = msgspec.msgpack.encode([1, 2, 3])
-
-        with pytest.raises(msgspec.ValidationError) as rec:
-            dec.decode(buf)
-
-        assert "Expected `collections.deque`, got `list`" == str(rec.value)
-
-    def test_decode_dec_hook_isinstance_errors(self):
-        class Metaclass(type):
-            def __instancecheck__(self, obj):
-                raise TypeError("Oh no!")
-
-        class Custom(metaclass=Metaclass):
-            pass
-
-        dec = msgspec.msgpack.Decoder(type=Custom)
-        buf = msgspec.msgpack.encode(1)
-
-        with pytest.raises(TypeError, match="Oh no!"):
-            dec.decode(buf)
 
     def test_decoder_repr(self):
         typ = List[Dict[int, float]]


### PR DESCRIPTION
This modifies decoding of custom types to wrap errors raised by a `dec_hook` with `ValidationError`. Only `TypeError` or `ValueError` (and subclasses) exceptions are wrapped, all other exceptions are raised directly.

If an exception is wrapped with a `ValidationError`, the original exception is set as the `__cause__` (and `__context__`). This means the original exception will still show up in tracebacks, and is available for introspection if needed.

This also changes the recommendation for raising `TypeError` on unsupported types in `dec_hook`/`enc_hook` to raising a `NotImplementedError`. No previous functionality was based on this recommendation, so this isn't a breaking change in anyway, just a change in recommendation of how best to use `msgspec`.

Fixes #456.