### PR TITLE
Support decoding `Decimal` types from numeric (int/float) values

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -674,8 +674,8 @@ class TestUUID:
 
 class TestDecimal:
     def test_decimal_wrong_type(self):
-        with pytest.raises(ValidationError, match="Expected `decimal`, got `float`"):
-            convert(1.5, decimal.Decimal)
+        with pytest.raises(ValidationError, match="Expected `decimal`, got `array`"):
+            convert([], decimal.Decimal)
 
     def test_decimal_builtin(self):
         x = decimal.Decimal("1.5")
@@ -687,9 +687,24 @@ class TestDecimal:
         assert res == sol
         assert type(res) is decimal.Decimal
 
-    def test_decimal_str_disabled(self):
-        with pytest.raises(ValidationError, match="Expected `decimal`, got `str`"):
-            convert("1.5", decimal.Decimal, builtin_types=(decimal.Decimal,))
+    @pytest.mark.parametrize("val", [1.3, float("nan"), float("inf"), float("-inf")])
+    def test_decimal_float(self, val):
+        sol = decimal.Decimal(str(val))
+        res = convert(val, decimal.Decimal)
+        assert str(res) == str(sol)  # compare strs to support NaN
+        assert type(res) is decimal.Decimal
+
+    @pytest.mark.parametrize("val", [0, 1234, -1234])
+    def test_decimal_int(self, val):
+        sol = decimal.Decimal(val)
+        res = convert(val, decimal.Decimal)
+        assert res == sol
+        assert type(res) is decimal.Decimal
+
+    @pytest.mark.parametrize("val, typ", [("1.5", "str"), (123, "int"), (1.3, "float")])
+    def test_decimal_conversion_disabled(self, val, typ):
+        with pytest.raises(ValidationError, match=f"Expected `decimal`, got `{typ}`"):
+            convert(val, decimal.Decimal, builtin_types=(decimal.Decimal,))
 
 
 class TestExt:


### PR DESCRIPTION
This adds support for converting int/float inputs to `decimal.Decimal` types for all protocols' `decode` methods, as well `msgspec.convert`.

The intent of this is to provide more flexible input support for `decimal.Decimal` types, since not everyone wants to encode them as strings.

For JSON fields there is no loss of precision, the numeric representation is parsed directly into the Decimal object, same as if it was a string.

For all other protocols, there is a possibility of precision loss, when converting from float -> decimal. We don't pass the value directly to `decimal.Decimal`, but instead convert to a str expressing the shortest roundtrippable value for the IEEE754 decimal. This is effectively equivalent to

```
if isinstance(input, float):
    return decimal.Decimal(str(input))
```

In common simple cases this likely does what the user wants. Still, there's a chance of precision loss, see the added documentation for examples of cases where this matters.

For YAML/TOML inputs we _could_ ensure zero precision loss if needed with some extra work, since floats for these protocols are also serialized as str values (same as JSON). I'm punting on this for now until someone asks about it.

For msgpack there's no way around this; since it's a binary protocol, float values are serialized as their binary inputs.

In all cases you really should be serializing `decimal.Decimal` values as strings, since this is the format that is easiest to avoid precision loss, and is widely and uniformly supported across tools.