### PR TITLE
Support encoding decimals as numbers

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -419,8 +419,8 @@ When decoding, both hyphenated and unhyphenated forms are supported.
 -----------
 
 `decimal.Decimal` values are encoded as their string representation in all
-protocols. This ensures no precision loss during serialization, as would happen
-with a float representation.
+protocols by default. This ensures no precision loss during serialization, as
+would happen with a float representation.
 
 .. code-block:: python
 
@@ -440,6 +440,19 @@ with a float representation.
     Traceback (most recent call last):
         File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Invalid decimal string
+
+For JSON and MessagePack you may instead encode decimal values the same as
+numbers by creating a ``Encoder`` and specifying ``decimal_format='number'``.
+
+.. code-block:: python
+
+    >>> encoder = msgspec.json.Encoder(decimal_format="number")
+
+    >>> encoder.encode(x)
+    b'1.2345'
+
+This setting is not yet supported for YAML or TOML - if this option is
+important for you please `open an issue`_.
 
 All protocols will also decode `decimal.Decimal` values from ``int`` or
 ``float`` inputs. For JSON the value is parsed directly from the serialized
@@ -1123,8 +1136,7 @@ Union restrictions are as follows:
 - Unions may contain at most one type that encodes to a string (`str`,
   `enum.Enum`, `bytes`, `bytearray`, `datetime.datetime`, `datetime.date`,
   `datetime.time`, `uuid.UUID`, `decimal.Decimal`). Note that this restriction
-  is fixable with some work, if this is a feature you need please `open an
-  issue <https://github.com/jcrist/msgspec/issues>`__.
+  is fixable with some work, if this is a feature you need please `open an issue`_.
 
 - Unions may contain at most one type that encodes to an object (`dict`,
   `typing.TypedDict`, dataclasses_, attrs_, `Struct` with ``array_like=False``)
@@ -1339,3 +1351,4 @@ TOML_ types are decoded to Python types as follows:
 .. _pyright: https://github.com/microsoft/pyright
 .. _generic types:
 .. _user-defined generic types: https://docs.python.org/3/library/typing.html#user-defined-generic-types
+.. _open an issue: https://github.com/jcrist/msgspec/issues>

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -4,6 +4,7 @@ from typing import (
     Callable,
     Dict,
     Generic,
+    Literal,
     Optional,
     Tuple,
     Type,
@@ -19,12 +20,13 @@ dec_hook_sig = Optional[Callable[[type, Any], Any]]
 
 class Encoder:
     enc_hook: enc_hook_sig
-    write_buffer_size: int
+    decimal_format: Literal["string", "number"]
+
     def __init__(
         self,
         *,
         enc_hook: enc_hook_sig = None,
-        write_buffer_size: int = ...,
+        decimal_format: Literal["string", "number"] = "string",
     ): ...
     def encode(self, obj: Any) -> bytes: ...
     def encode_into(

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -2,6 +2,7 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Literal,
     Optional,
     Type,
     TypeVar,
@@ -57,12 +58,12 @@ class Decoder(Generic[T]):
 
 class Encoder:
     enc_hook: enc_hook_sig
-    write_buffer_size: int
+    decimal_format: Literal["string", "number"]
     def __init__(
         self,
         *,
         enc_hook: enc_hook_sig = None,
-        write_buffer_size: int = ...,
+        decimal_format: Literal["string", "number"] = "string",
     ): ...
     def encode(self, obj: Any) -> bytes: ...
     def encode_into(

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -641,6 +641,12 @@ def check_msgpack_Encoder_enc_hook() -> None:
     msgspec.msgpack.Encoder(enc_hook=lambda x: None)
 
 
+def check_msgpack_Encoder_decimal_format() -> None:
+    enc = msgspec.msgpack.Encoder(decimal_format="string")
+    msgspec.msgpack.Encoder(decimal_format="number")
+    reveal_type(enc.decimal_format)  # assert "string" in typ.lower() and "number" in typ.lower()
+
+
 def check_msgpack_decode_dec_hook() -> None:
     def dec_hook(typ: Type, obj: Any) -> Any:
         return typ(obj)
@@ -768,6 +774,12 @@ def check_json_encode_enc_hook() -> None:
 
 def check_json_Encoder_enc_hook() -> None:
     msgspec.json.Encoder(enc_hook=lambda x: None)
+
+
+def check_json_Encoder_decimal_format() -> None:
+    enc = msgspec.json.Encoder(decimal_format="string")
+    msgspec.json.Encoder(decimal_format="number")
+    reveal_type(enc.decimal_format)  # assert "string" in typ.lower() and "number" in typ.lower()
 
 
 def check_json_decode_dec_hook() -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3184,6 +3184,46 @@ class TestNewType:
 
 
 class TestDecimal:
+    def test_encoder_decimal_format(self, proto):
+        assert proto.Encoder().decimal_format == "string"
+        assert proto.Encoder(decimal_format="string").decimal_format == "string"
+        assert proto.Encoder(decimal_format="number").decimal_format == "number"
+
+    def test_encoder_invalid_decimal_format(self, proto):
+        with pytest.raises(ValueError, match="must be 'string' or 'number', got 'bad'"):
+            proto.Encoder(decimal_format="bad")
+
+        with pytest.raises(ValueError, match="must be 'string' or 'number', got 1"):
+            proto.Encoder(decimal_format=1)
+
+    def test_encoder_encode_decimal(self, proto):
+        enc = proto.Encoder()
+        d = decimal.Decimal("1.5")
+        s = str(d)
+        assert enc.encode(d) == enc.encode(s)
+
+    def test_Encoder_encode_decimal_string(self, proto):
+        enc = proto.Encoder(decimal_format="string")
+        d = decimal.Decimal("1.5")
+        sol = enc.encode(str(d))
+
+        assert enc.encode(d) == sol
+
+        buf = bytearray()
+        enc.encode_into(d, buf)
+        assert buf == sol
+
+    def test_Encoder_encode_decimal_number(self, proto):
+        enc = proto.Encoder(decimal_format="number")
+        d = decimal.Decimal("1.5")
+        sol = enc.encode(float(d))
+
+        assert enc.encode(d) == sol
+
+        buf = bytearray()
+        enc.encode_into(d, buf)
+        assert buf == sol
+
     def test_encode_decimal(self, proto):
         d = decimal.Decimal("1.5")
         s = str(d)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1440,6 +1440,11 @@ class TestDecimal:
     """Most decimal tests are in test_common.py, the ones here are for json
     specific behaviors"""
 
+    def test_decimal_to_number_keeps_precision(self):
+        enc = msgspec.json.Encoder(decimal_format="number")
+        msg = enc.encode(Decimal("1.3000"))
+        assert msg == b"1.3000"
+
     @pytest.mark.parametrize(
         "msg",
         [


### PR DESCRIPTION
Previously we always encoded `decimal.Decimal` values as strings. While this is the best format for these types (prevents precision loss, widely supported), sometimes there is a need to encode `Decimal` objects the same as numbers. This adds a new `decimal_format` option to all `Encoder` classes. This value defaults to `"string"` (to encode decimals as strings), but may be set to `"number"` to encode them the same as the protocol's numeric types.

We opt not to support this configuration in the top-level `encode` functions for now, since this is a less-common setting.

Fixes #440.