### PR TITLE
Support CPython 3.12 pre-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,16 @@ jobs:
       - name: Set up Environment
         if: github.event_name != 'release'
         run: |
-            echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64" >> $GITHUB_ENV
+            echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64" >> $GITHUB_ENV
+
+      - name: Enable CPython 3.12 prerelease builds for Linux testing
+        if: github.event_name != 'release' && runner.os == 'Linux'
+        run: |
+          echo "CIBW_PRERELEASE_PYTHONS=True" >> $GITHUB_ENV
+          echo "CIBW_BUILD=cp38-* cp39-* cp310-* cp311-* cp312-*" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.13.1
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1913,7 +1913,7 @@ class TestTypedDict:
         if not hasattr(ns, "Required"):
             pytest.skip(f"{module}.Required is not available")
 
-        if not hasattr(ns.TypedDict("C"), "__required_keys__"):
+        if not hasattr(ns.TypedDict("C", {}), "__required_keys__"):
             # This should be Python 3.8, builtin typing only
             pytest.skip("partially optional TypedDict not supported")
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -52,6 +52,7 @@ except ImportError:
 
 PY310 = sys.version_info[:2] >= (3, 10)
 PY311 = sys.version_info[:2] >= (3, 11)
+PY312 = sys.version_info[:2] >= (3, 12)
 
 uses_annotated = pytest.mark.skipif(Annotated is None, reason="Annotated not available")
 
@@ -883,6 +884,10 @@ class TestSequences:
             assert convert(1, out_type)
 
     @pytest.mark.parametrize("kind", ["list", "tuple", "fixtuple", "set"])
+    @pytest.mark.skipif(
+        PY312,
+        reason="CPython 3.12 internal changes prevent testing for recursion issues this way",
+    )
     def test_sequence_cyclic_recursion(self, kind):
         depth = 50
         if kind == "list":
@@ -1107,6 +1112,10 @@ class TestDict:
         with pytest.raises(ValidationError):
             convert(dictcls({"x": 1}), Dict[Tuple[int, int], int], str_keys=True)
 
+    @pytest.mark.skipif(
+        PY312,
+        reason="CPython 3.12 internal changes prevent testing for recursion issues this way",
+    )
     def test_dict_cyclic_recursion(self, dictcls):
         depth = 50
         typ = Dict[str, int]


### PR DESCRIPTION
This fixes compatibility with cpython 3.12's beta releases. For the most part this was an uneventful release, the two major issues were:

- CPython 3.12 changed the internal representation of integers, which we (probably unadvisably) poke at.
- The idiom for statically declaring instances of singleton values (like `None`) has changed. We use this for declaring `msgspec.NODEFAULT`/`msgspec.UNSET`.

Fixes #462.