### PR TITLE
Support decoding ints outside int64/uint64

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -132,9 +132,7 @@ Support for large integers varies by protocol:
 
 - ``msgpack`` only supports encoding/decoding integers within
   ``[-2**63, 2**64 - 1]``, inclusive.
-- ``json`` will encode any integer, but will decode large integers (outside of
-  ``[-2**63, 2**64 - 1]``, inclusive) as floats.
-- ``yaml`` and ``toml`` have no restrictions on encode or decode.
+- ``json``, ``yaml``, and ``toml`` have no restrictions on encode or decode.
 
 .. code-block:: python
 
@@ -1282,9 +1280,8 @@ JSON_ types are decoded to Python types as follows:
 - ``object``: `dict`
 
 .. [#number_json] Numbers are decoded as integers if they contain no decimal or
-   exponent components (e.g. ``1`` but not ``1.0`` or ``1e10``), and fit in either
-   an ``int64`` or ``uint64`` (within ``[-2**63, 2**64 - 1]``, inclusive). All
-   other numbers decode as floats.
+   exponent components (e.g. ``1`` but not ``1.0`` or ``1e10``). All other
+   numbers decode as floats.
 
 **MessagePack**
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3611,9 +3611,9 @@ class TestLax:
         "x, err",
         [
             ("-1", "`int` >= 0"),
-            ("184467440737095516100", "out of range"),
-            ("18446744073709551617", "out of range"),
-            ("-9223372036854775809", "out of range"),
+            ("2000", "`int` <= 1000"),
+            ("18446744073709551616", "`int` <= 1000"),
+            ("-9223372036854775809", "`int` >= 0"),
             ("100.5", "`float` <= 100.0"),
             ("x" * 11, "length <= 10"),
         ],
@@ -3623,7 +3623,7 @@ class TestLax:
         constraints error with a specific constraint error"""
         msg = proto.encode(x)
         typ = Union[
-            Annotated[int, Meta(ge=0)],
+            Annotated[int, Meta(ge=0), Meta(le=1000)],
             Annotated[float, Meta(le=100)],
             Annotated[str, Meta(max_length=10)],
         ]


### PR DESCRIPTION
Previously all `decode` methods would only support integers that fit in a `uint64`/`int64`. This PR removes that restriction for everything _except_ MessagePack which as a binary protocol cannot support arbitrarily large integers.

To handle the parsing of these "big ints" we use CPython's builtin `str -> int` routine. This is slower than our custom `str -> int` function, but since integers of this scale are rare this should be fine in practice.

Note that currently CPython's `str -> int` routine exhibits quadratic behavior in the length of its input. This led to a DDOS CVE which was mitigated in 3.11 by adding a configurable max str length for int parsing. We hardcode the limit of 4300 chars here to support older python versions, while still properly handling cases where the user may have reduced this limit further. I think relying on this routine is fine, but if it becomes a problem later on we can rethink and maybe implement our own parsing routine. Parsing bigints will always be slower than parsing int64/uint64s, but there are better algorithms than the one currently used by CPython for handling this behavior.

BREAKING CHANGE: previously parsing a JSON "integer" (a number with no decimal or exponent components) into an `Any` or `int | float` field large would convert to a float if it didn't fit into an `int64` or `uint64`. This is no longer the case. Unless a `float` is explicitly requested, a JSON number with no decimal or exponent components will always be parsed as an integer.