### PR TITLE
Support `__post_init__` for `Struct` types

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -38,7 +38,7 @@ except ImportError:
     attrs = None
 
 import msgspec
-from msgspec import Meta, ValidationError
+from msgspec import Meta, Struct, ValidationError
 
 UTC = datetime.timezone.utc
 
@@ -1383,6 +1383,74 @@ class TestGenericStruct:
             proto.Decoder(List[T])
 
         assert "Unbound TypeVar `~T` has constraints" in str(rec.value)
+
+
+class TestStructPostInit:
+    @pytest.mark.parametrize("array_like", [False, True])
+    @pytest.mark.parametrize("union", [False, True])
+    def test_struct_post_init(self, array_like, union, proto):
+        count = 0
+        singleton = object()
+
+        class Ex(Struct, array_like=array_like, tag=union):
+            x: int
+
+            def __post_init__(self):
+                nonlocal count
+                count += 1
+                return singleton
+
+        if union:
+
+            class Ex2(Struct, array_like=array_like, tag=True):
+                pass
+
+            typ = Union[Ex, Ex2]
+        else:
+            typ = Ex
+
+        msg = Ex(1)
+        buf = proto.encode(msg)
+        res = proto.decode(buf, type=typ)
+        assert res == msg
+        assert count == 2  # 1 for Ex(), 1 for decode
+        assert sys.getrefcount(singleton) == 2  # 1 for ref, 1 for call
+
+    @pytest.mark.parametrize("array_like", [False, True])
+    @pytest.mark.parametrize("union", [False, True])
+    @pytest.mark.parametrize("exc_class", [ValueError, TypeError, OSError])
+    def test_struct_post_init_errors(self, array_like, union, exc_class, proto):
+        error = False
+
+        class Ex(Struct, array_like=array_like, tag=union):
+            x: int
+
+            def __post_init__(self):
+                if error:
+                    raise exc_class("Oh no!")
+
+        if union:
+
+            class Ex2(Struct, array_like=array_like, tag=True):
+                pass
+
+            typ = Union[Ex, Ex2]
+        else:
+            typ = Ex
+
+        msg = proto.encode([Ex(1)])
+        error = True
+
+        if exc_class in (ValueError, TypeError):
+            expected = ValidationError
+        else:
+            expected = exc_class
+
+        with pytest.raises(expected, match="Oh no!") as rec:
+            proto.decode(msg, type=List[typ])
+
+        if expected is ValidationError:
+            assert "- at `$[0]`" in str(rec.value)
 
 
 @pytest.fixture(params=["dataclass", "attrs"])


### PR DESCRIPTION
This adds support for an optional `__post_init__` hook method on `msgspec.Struct` types. If defined, this method is called at the end of the generated `__init__` method. It can be used to customize the builtin `__init__` as needed, as well as provides a spot to do some additional validation.

As with `dec_hook` errors, any `ValueError` or `TypeError` raised in `__post_init__` will be wrapped in a `ValidationError` when decoding. In the long run I plan to add support for more granular (and obviously named) custom validator support, but for now doing some validation in `__post_init__` is a fine and simple solution. There are other use cases for `__post_init__` besides validation, so we'd want to add this ability either way.

Fixes #442.
