### PR TITLE
Support decoding 1/0 into True/False in lax mode

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -111,8 +111,8 @@ supported protocols.
     >>> msgspec.json.decode(b'true')
     True
 
-If ``strict=False`` is specified, string values of ``"true"``/``"1"`` or
-``"false"``/``"0"`` (case insensitive) may also be coerced to
+If ``strict=False`` is specified, values of ``"true"``/``"1"``/``1`` or
+``"false"``/``"0"``/``0`` (case insensitive for strings) may also be coerced to
 ``True``/``False`` respectively. See :ref:`strict-vs-lax` for more information.
 
 .. code-block:: python
@@ -121,6 +121,9 @@ If ``strict=False`` is specified, string values of ``"true"``/``"1"`` or
    False
 
    >>> msgspec.json.decode(b'"TRUE"', type=bool, strict=False)
+   True
+
+   >>> msgspec.json.decode(b'1', type=bool, strict=False)
    True
 
 ``int``

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -8583,6 +8583,37 @@ static PyGetSetDef Encoder_getset[] = {
  * Shared Decoding Utilities                                             *
  *************************************************************************/
 
+static PyObject *
+ms_maybe_decode_bool_from_uint64(uint64_t x) {
+    if (x == 0) {
+        Py_RETURN_FALSE;
+    }
+    else if (x == 1) {
+        Py_RETURN_TRUE;
+    }
+    return NULL;
+}
+
+static PyObject *
+ms_maybe_decode_bool_from_int64(int64_t x) {
+    if (x == 0) {
+        Py_RETURN_FALSE;
+    }
+    else if (x == 1) {
+        Py_RETURN_TRUE;
+    }
+    return NULL;
+}
+
+static PyObject *
+ms_maybe_decode_bool_from_pyint(PyObject *obj) {
+    uint64_t scale;
+    bool neg, overflow;
+    overflow = fast_long_extract_parts(obj, &neg, &scale);
+    if (overflow || neg) return NULL;
+    return ms_maybe_decode_bool_from_uint64(scale);
+}
+
 static MS_NOINLINE PyObject *
 ms_decode_str_enum_or_literal(const char *name, Py_ssize_t size, TypeNode *type, PathNode *path) {
     StrLookup *lookup = TypeNode_get_str_enum_or_literal(type);
@@ -10419,6 +10450,63 @@ ms_decode_str_lax(
     *invalid = true;
     return NULL;
 }
+
+/*************************************************************************
+ * Shared Post-Decode Handlers                                           *
+ *************************************************************************/
+
+static PyObject *
+ms_post_decode_int64(int64_t x, TypeNode *type, PathNode *path, bool strict) {
+    if (MS_LIKELY(type->types & (MS_TYPE_ANY | MS_TYPE_INT))) {
+        return ms_decode_int(x, type, path);
+    }
+    else if (type->types & (MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {
+        return ms_decode_int_enum_or_literal_int64(x, type, path);
+    }
+    else if (type->types & MS_TYPE_FLOAT) {
+        return ms_decode_float(x, type, path);
+    }
+    else if (type->types & MS_TYPE_DECIMAL) {
+        return ms_decode_decimal_from_int64(x, path);
+    }
+    else if (!strict) {
+        if (type->types & MS_TYPE_BOOL) {
+            PyObject *out = ms_maybe_decode_bool_from_int64(x);
+            if (out != NULL) return out;
+        }
+        if (type->types & MS_TYPE_DATETIME) {
+            return ms_decode_datetime_from_int64(x, type, path);
+        }
+    }
+    return ms_validation_error("int", type, path);
+}
+
+static PyObject *
+ms_post_decode_uint64(uint64_t x, TypeNode *type, PathNode *path, bool strict) {
+    if (MS_LIKELY(type->types & (MS_TYPE_ANY | MS_TYPE_INT))) {
+        return ms_decode_uint(x, type, path);
+    }
+    else if (type->types & (MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {
+        return ms_decode_int_enum_or_literal_uint64(x, type, path);
+    }
+    else if (type->types & MS_TYPE_FLOAT) {
+        return ms_decode_float(x, type, path);
+    }
+    else if (type->types & MS_TYPE_DECIMAL) {
+        return ms_decode_decimal_from_uint64(x, path);
+    }
+    else if (!strict) {
+        if (type->types & MS_TYPE_BOOL) {
+            PyObject *out = ms_maybe_decode_bool_from_uint64(x);
+            if (out != NULL) return out;
+        }
+        if (type->types & MS_TYPE_DATETIME) {
+            return ms_decode_datetime_from_uint64(x, type, path);
+        }
+    }
+    return ms_validation_error("int", type, path);
+}
+
 
 /*************************************************************************
  * MessagePack Encoder                                                   *
@@ -12849,46 +12937,6 @@ static PyObject * mpack_decode(
 );
 
 static PyObject *
-mpack_decode_int(DecoderState *self, int64_t x, TypeNode *type, PathNode *path) {
-    if (type->types & (MS_TYPE_ANY | MS_TYPE_INT)) {
-        return ms_decode_int(x, type, path);
-    }
-    else if (type->types & (MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {
-        return ms_decode_int_enum_or_literal_int64(x, type, path);
-    }
-    else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(x, type, path);
-    }
-    else if (type->types & MS_TYPE_DECIMAL) {
-        return ms_decode_decimal_from_int64(x, path);
-    }
-    else if (!self->strict && (type->types & MS_TYPE_DATETIME)) {
-        return ms_decode_datetime_from_int64(x, type, path);
-    }
-    return ms_validation_error("int", type, path);
-}
-
-static PyObject *
-mpack_decode_uint(DecoderState *self, uint64_t x, TypeNode *type, PathNode *path) {
-    if (type->types & (MS_TYPE_ANY | MS_TYPE_INT)) {
-        return ms_decode_uint(x, type, path);
-    }
-    else if (type->types & (MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {
-        return ms_decode_int_enum_or_literal_uint64(x, type, path);
-    }
-    else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(x, type, path);
-    }
-    else if (type->types & MS_TYPE_DECIMAL) {
-        return ms_decode_decimal_from_uint64(x, path);
-    }
-    else if (!self->strict && (type->types & MS_TYPE_DATETIME)) {
-        return ms_decode_datetime_from_uint64(x, type, path);
-    }
-    return ms_validation_error("int", type, path);
-}
-
-static PyObject *
 mpack_decode_none(DecoderState *self, TypeNode *type, PathNode *path) {
     if (type->types & (MS_TYPE_ANY | MS_TYPE_NONE)) {
         Py_INCREF(Py_None);
@@ -13859,7 +13907,7 @@ mpack_decode_nocustom(
     }
 
     if (('\x00' <= op && op <= '\x7f') || ('\xe0' <= op && op <= '\xff')) {
-        return mpack_decode_int(self, *((int8_t *)(&op)), type, path);
+        return ms_post_decode_int64(*((int8_t *)(&op)), type, path, self->strict);
     }
     else if ('\xa0' <= op && op <= '\xbf') {
         return mpack_decode_str(self, op & 0x1f, type, path);
@@ -13879,28 +13927,28 @@ mpack_decode_nocustom(
             return mpack_decode_bool(self, Py_False, type, path);
         case MP_UINT8:
             if (MS_UNLIKELY(mpack_read(self, &s, 1) < 0)) return NULL;
-            return mpack_decode_uint(self, *(uint8_t *)s, type, path);
+            return ms_post_decode_uint64(*(uint8_t *)s, type, path, self->strict);
         case MP_UINT16:
             if (MS_UNLIKELY(mpack_read(self, &s, 2) < 0)) return NULL;
-            return mpack_decode_uint(self, _msgspec_load16(uint16_t, s), type, path);
+            return ms_post_decode_uint64(_msgspec_load16(uint16_t, s), type, path, self->strict);
         case MP_UINT32:
             if (MS_UNLIKELY(mpack_read(self, &s, 4) < 0)) return NULL;
-            return mpack_decode_uint(self, _msgspec_load32(uint32_t, s), type, path);
+            return ms_post_decode_uint64(_msgspec_load32(uint32_t, s), type, path, self->strict);
         case MP_UINT64:
             if (MS_UNLIKELY(mpack_read(self, &s, 8) < 0)) return NULL;
-            return mpack_decode_uint(self, _msgspec_load64(uint64_t, s), type, path);
+            return ms_post_decode_uint64(_msgspec_load64(uint64_t, s), type, path, self->strict);
         case MP_INT8:
             if (MS_UNLIKELY(mpack_read(self, &s, 1) < 0)) return NULL;
-            return mpack_decode_int(self, *(int8_t *)s, type, path);
+            return ms_post_decode_int64(*(int8_t *)s, type, path, self->strict);
         case MP_INT16:
             if (MS_UNLIKELY(mpack_read(self, &s, 2) < 0)) return NULL;
-            return mpack_decode_int(self, _msgspec_load16(int16_t, s), type, path);
+            return ms_post_decode_int64(_msgspec_load16(int16_t, s), type, path, self->strict);
         case MP_INT32:
             if (MS_UNLIKELY(mpack_read(self, &s, 4) < 0)) return NULL;
-            return mpack_decode_int(self, _msgspec_load32(int32_t, s), type, path);
+            return ms_post_decode_int64(_msgspec_load32(int32_t, s), type, path, self->strict);
         case MP_INT64:
             if (MS_UNLIKELY(mpack_read(self, &s, 8) < 0)) return NULL;
-            return mpack_decode_int(self, _msgspec_load64(int64_t, s), type, path);
+            return ms_post_decode_int64(_msgspec_load64(int64_t, s), type, path, self->strict);
         case MP_FLOAT32: {
             float f = 0;
             uint32_t uf;
@@ -16367,46 +16415,6 @@ json_decode_object(
 }
 
 static PyObject *
-json_decode_int(JSONDecoderState *self, int64_t x, TypeNode *type, PathNode *path) {
-    if (type->types & (MS_TYPE_ANY | MS_TYPE_INT)) {
-        return ms_decode_int(x, type, path);
-    }
-    else if (type->types & (MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {
-        return ms_decode_int_enum_or_literal_int64(x, type, path);
-    }
-    else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(x, type, path);
-    }
-    else if (type->types & MS_TYPE_DECIMAL) {
-        return ms_decode_decimal_from_int64(x, path);
-    }
-    else if (!self->strict && (type->types & MS_TYPE_DATETIME)) {
-        return ms_decode_datetime_from_int64(x, type, path);
-    }
-    return ms_validation_error("int", type, path);
-}
-
-static PyObject *
-json_decode_uint(JSONDecoderState *self, uint64_t x, TypeNode *type, PathNode *path) {
-    if (type->types & (MS_TYPE_ANY | MS_TYPE_INT)) {
-        return ms_decode_uint(x, type, path);
-    }
-    else if (type->types & (MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {
-        return ms_decode_int_enum_or_literal_uint64(x, type, path);
-    }
-    else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(x, type, path);
-    }
-    else if (type->types & MS_TYPE_DECIMAL) {
-        return ms_decode_decimal_from_uint64(x, path);
-    }
-    else if (!self->strict && (type->types & MS_TYPE_DATETIME)) {
-        return ms_decode_datetime_from_uint64(x, type, path);
-    }
-    return ms_validation_error("int", type, path);
-}
-
-static PyObject *
 json_decode_float(JSONDecoderState *self, double x, TypeNode *type, PathNode *path) {
     if (type->types & (MS_TYPE_ANY | MS_TYPE_FLOAT)) {
         return ms_decode_float(x, type, path);
@@ -16690,9 +16698,9 @@ end_integer:
     if (!is_float) {
         if (is_negative) {
             if (MS_UNLIKELY(mantissa > 1ull << 63)) goto fallback_extended;
-            return json_decode_int(self, -1 * (int64_t)mantissa, type, path);
+            return ms_post_decode_int64(-1 * (int64_t)mantissa, type, path, self->strict);
         }
-        return json_decode_uint(self, mantissa, type, path);
+        return ms_post_decode_uint64(mantissa, type, path, self->strict);
     }
     else if (
         MS_UNLIKELY(
@@ -18073,7 +18081,7 @@ static PyObject *
 convert_int(
     ConvertState *self, PyObject *obj, TypeNode *type, PathNode *path
 ) {
-    if (type->types & MS_TYPE_INT) {
+    if (MS_LIKELY(type->types & MS_TYPE_INT)) {
         return ms_decode_pyint(obj, type, path);
     }
     else if (type->types & (MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {
@@ -18088,8 +18096,15 @@ convert_int(
     ) {
         return ms_decode_decimal_from_pyobj(obj, path, self->mod);
     }
-    else if (!self->strict && (type->types & MS_TYPE_DATETIME)) {
-        return ms_decode_datetime_from_pyint(obj, type, path);
+
+    if (!self->strict) {
+        if (type->types & MS_TYPE_BOOL) {
+            PyObject *out = ms_maybe_decode_bool_from_pyint(obj);
+            if (out != NULL) return out;
+        }
+        if (type->types & MS_TYPE_DATETIME) {
+            return ms_decode_datetime_from_pyint(obj, type, path);
+        }
     }
     return ms_validation_error("int", type, path);
 }

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3426,23 +3426,25 @@ class TestLax:
                 proto.decode(msg, type=None, strict=False)
 
     def test_lax_bool_true(self, proto):
-        for x in ["1", "true", "True", "tRue", "trUe", "truE"]:
+        for x in [1, "1", "true", "True", "tRue", "trUe", "truE"]:
             msg = proto.encode(x)
             assert proto.decode(msg, type=bool, strict=False) is True
 
-        for x in ["x", "xx", "xrue", "txue", "trxe", "trux"]:
+        for x in [-1, 3, "x", "xx", "xrue", "txue", "trxe", "trux"]:
             msg = proto.encode(x)
-            with pytest.raises(ValidationError, match="Expected `bool`, got `str`"):
+            typ = type(x).__name__
+            with pytest.raises(ValidationError, match=f"Expected `bool`, got `{typ}`"):
                 assert proto.decode(msg, type=bool, strict=False)
 
     def test_lax_bool_false(self, proto):
-        for x in ["0", "false", "False", "fAlse", "faLse", "falSe", "falsE"]:
+        for x in [0, "0", "false", "False", "fAlse", "faLse", "falSe", "falsE"]:
             msg = proto.encode(x)
             assert proto.decode(msg, type=bool, strict=False) is False
 
-        for x in ["x", "xx", "xalse", "fxlse", "faxse", "falxe", "falsx"]:
+        for x in [-1, 3, "x", "xx", "xalse", "fxlse", "faxse", "falxe", "falsx"]:
             msg = proto.encode(x)
-            with pytest.raises(ValidationError, match="Expected `bool`, got `str`"):
+            typ = type(x).__name__
+            with pytest.raises(ValidationError, match=f"Expected `bool`, got `{typ}`"):
                 assert proto.decode(msg, type=bool, strict=False)
 
     def test_lax_int(self, proto):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2091,21 +2091,23 @@ class TestLax:
                 convert(x, None, strict=False)
 
     def test_lax_bool_true(self):
-        for x in ["1", "true", "True", "tRue", "trUe", "truE"]:
+        for x in [1, "1", "true", "True", "tRue", "trUe", "truE"]:
             assert convert(x, bool, strict=False) is True
 
     def test_lax_bool_false(self):
-        for x in ["0", "false", "False", "fAlse", "faLse", "falSe", "falsE"]:
+        for x in [0, "0", "false", "False", "fAlse", "faLse", "falSe", "falsE"]:
             assert convert(x, bool, strict=False) is False
 
     def test_lax_bool_true_invalid(self):
-        for x in ["x", "xx", "xrue", "txue", "trxe", "trux"]:
-            with pytest.raises(ValidationError, match="Expected `bool`, got `str`"):
+        for x in [-1, 3, "x", "xx", "xrue", "txue", "trxe", "trux"]:
+            typ = type(x).__name__
+            with pytest.raises(ValidationError, match=f"Expected `bool`, got `{typ}`"):
                 assert convert(x, bool, strict=False)
 
     def test_lax_bool_false_invalid(self):
-        for x in ["x", "xx", "xalse", "fxlse", "faxse", "falxe", "falsx"]:
-            with pytest.raises(ValidationError, match="Expected `bool`, got `str`"):
+        for x in [-1, 3, "x", "xx", "xalse", "fxlse", "faxse", "falxe", "falsx"]:
+            typ = type(x).__name__
+            with pytest.raises(ValidationError, match=f"Expected `bool`, got `{typ}`"):
                 assert convert(x, bool, strict=False)
 
     def test_lax_int(self):


### PR DESCRIPTION
Previously we only supported mapping *string* versions of `1`/`0` to `True`/`False` in lax mode. This adds support for mapping the integer values as well.