### PR TITLE
Wrap errors in dataclass/attrs post-init methods

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -4746,7 +4746,6 @@ ms_error_with_path(const char *msg, PathNode *path) {
     return NULL;
 }
 
-/* TODO */
 static MS_NOINLINE void
 ms_maybe_wrap_validation_error(PathNode *path) {
     PyObject *exc_type, *exc, *tb;
@@ -7972,7 +7971,10 @@ DataclassInfo_post_decode(DataclassInfo *self, PyObject *obj, PathNode *path) {
     }
     if (self->post_init != NULL) {
         PyObject *res = CALL_ONE_ARG(self->post_init, obj);
-        if (res == NULL) return -1;
+        if (res == NULL) {
+            ms_maybe_wrap_validation_error(path);
+            return -1;
+        }
         Py_DECREF(res);
     }
     return 0;
@@ -19260,7 +19262,10 @@ convert_object_to_dataclass(
     }
     if (info->post_init != NULL) {
         PyObject *res = CALL_ONE_ARG(info->post_init, out);
-        if (res == NULL) goto error;
+        if (res == NULL) {
+            ms_maybe_wrap_validation_error(path);
+            goto error;
+        }
         Py_DECREF(res);
     }
     Py_LeaveRecursiveCall();

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1344,7 +1344,7 @@ class TestDataclass:
 
         msg = mapcls(a=1)
 
-        with pytest.raises(ValueError, match="Oh no!"):
+        with pytest.raises(ValidationError, match="Oh no!"):
             convert(msg, Example, from_attributes=from_attributes)
 
     @mapcls_and_from_attributes
@@ -1529,7 +1529,7 @@ class TestAttrs:
             def __attrs_post_init__(self):
                 raise ValueError("Oh no!")
 
-        with pytest.raises(ValueError, match="Oh no!"):
+        with pytest.raises(ValidationError, match="Oh no!"):
             convert(mapcls(a=1), Example, from_attributes=from_attributes)
 
     def test_attrs_to_attrs(self):


### PR DESCRIPTION
When decoding/converting to a dataclass/attrs type with a `__post_init__`/`__attrs_post_init__` method, we now wrap all `ValueError`/`TypeError` exceptions in a `ValidationError`. This mirrors the behavior used in the new `Struct.__post_init__` support, and helps provide more uniform error handling support.