### PR TITLE
Fixed recompilation in mashumaro

### DIFF
--- a/benchmarks/bench_validation.py
+++ b/benchmarks/bench_validation.py
@@ -130,6 +130,9 @@ class FileMashumaro(DataClassORJSONMixin):
     nbytes: int
     type: Literal["file"] = "file"
 
+    class Config:
+        lazy_compilation = True
+
 
 @dataclasses.dataclass
 class DirectoryMashumaro(DataClassORJSONMixin):
@@ -140,13 +143,16 @@ class DirectoryMashumaro(DataClassORJSONMixin):
     contents: List[Union[FileMashumaro, DirectoryMashumaro]]
     type: Literal["directory"] = "directory"
 
+    class Config:
+        lazy_compilation = True
+
 
 def bench_mashumaro(n):
     return bench(
-        lambda x: x.to_jsonb(),
-        DirectoryMashumaro.from_json,
+        lambda x: x.to_json(),
+        lambda x: DirectoryMashumaro.from_json(x),
         n,
-        DirectoryMashumaro.from_dict,
+        lambda x: DirectoryMashumaro.from_dict(x),
     )
 
 


### PR DESCRIPTION
Hi, author of mashumaro here 👋

I appreciate your work and I don't think anyone could outrun msgspec in speed but I found a bug in how mashumaro is benchmarked. Due to [how mashumaro works](https://github.com/Fatal1ty/mashumaro#how-does-it-work), it tries to compile methods `from_*` / `to_*` at import time by default but if it fails because of forward references, then these methods will consist of the code that will compile the real methods and replace with them on demand. In the original benchmark there were forward references due to `from __future__ import annotations` which were leading to expensive compilation on each call of `from_*` / `to_*`.

I fixed this with lambda functions and added ~[discriminated unions](https://github.com/Fatal1ty/mashumaro#discriminator) and~ [explicit lazy compilation](https://github.com/Fatal1ty/mashumaro#lazy_compilation-config-option) to reduce import time and speed it up slightly.

mashumaro + orjson is still slower that msgspec but not by an order of magnitude. I'm leaving the numbers to you because my environment is different from the one used to run the benchmark for the documentation.  I also encourage you to update benchmark results with the new version of mashumaro that has some new optimizations. Just for reference, I got this:

```
Benchmark - 1000 objects with validation
msgspec
  dumps: 133.01 us
  loads: 277.36 us
  total: 410.37 us
pydantic
  dumps: 13646.91 us
  loads: 14558.10 us
  total: 28205.02 us
cattrs
  dumps: 1801.90 us
  loads: 1976.82 us
  total: 3778.72 us
mashumaro
  dumps: 675.22 us
  loads: 1277.56 us
  total: 1952.78 us
```

P.S. With only two variants in Union I don't see performance boost with using `Discriminator` feature but if there were more variants, it would take place. It's up to you whether to use it, you might want to alter your benchmarks in the future. Anyway, it will look like this:
```python
contents: List[
    Annotated[
        Union[FileMashumaro, DirectoryMashumaro],
        Discriminator(field="type", include_supertypes=True),
    ]
]
```
