### PR TITLE
`datetime.timedelta` Support

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -151,6 +151,7 @@ Inspect
 .. autoclass:: DateTimeType
 .. autoclass:: TimeType
 .. autoclass:: DateType
+.. autoclass:: TimeDeltaType
 .. autoclass:: UUIDType
 .. autoclass:: DecimalType
 .. autoclass:: ExtType

--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -405,7 +405,6 @@ The duration format used here is as follows:
 
    [+/-]P[#D][T[#H][#M][#S]]
 
-
 - The format starts with an optional sign (``-`` or ``+``). If negative, the
   whole duration is negated.
 
@@ -450,7 +449,6 @@ The implementation in ``msgspec`` is compatible with the ones in:
 Duration strings produced by msgspec should be interchangeable with these
 libraries, as well as similar ones in other language ecosystems.
 
-
 .. code-block:: python
 
     >>> from datetime import timedelta
@@ -472,6 +470,19 @@ libraries, as well as similar ones in other language ecosystems.
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Invalid ISO8601 duration
 
+Additionally, if ``strict=False`` is specified, all protocols will decode ints,
+floats, or strings containing ints/floats as timedeltas, interpreting the value
+as total seconds. See :ref:`strict-vs-lax` for more information.
+
+.. code-block:: python
+
+    >>> msgspec.json.decode(b"123.4", type=datetime.timedelta)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Expected `duration`, got `float`
+
+    >>> msgspec.json.decode(b"123.4", type=datetime.timedelta, strict=False)
+    datetime.timedelta(seconds=123, microseconds=400000)
 
 ``uuid``
 --------

--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -31,6 +31,7 @@ Most combinations of the following types are supported (with a few restrictions)
 - `datetime.datetime`
 - `datetime.date`
 - `datetime.time`
+- `datetime.timedelta`
 - `uuid.UUID`
 - `decimal.Decimal`
 - `enum.Enum` types
@@ -387,6 +388,90 @@ timezone-naive by specifying a ``tz`` constraint (see
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Invalid RFC3339 encoded time
+
+``timedelta``
+-------------
+
+`datetime.timedelta` values map to extended `ISO 8601 duration strings`_ in all
+protocols.
+
+The format as described in the ISO specification is fairly lax and a bit
+underspecified, leading most real-world implementations to implement a stricter
+subset.
+
+The duration format used here is as follows:
+
+.. code-block:: text
+
+   [+/-]P[#D][T[#H][#M][#S]]
+
+
+- The format starts with an optional sign (``-`` or ``+``). If negative, the
+  whole duration is negated.
+
+- The letter ``P`` follows (case insensitive)
+
+- There are then four segments, each consisting of a number and unit. The units
+  are ``D``, ``H``, ``M``, ``S`` (case insensitive) for days, hours, minutes,
+  and seconds respectively. These segments must occur in this order.
+
+  - If a segment would have a 0 value it may be omitted, with the caveat that at
+    least one segment must be present.
+
+  - If a time (hour, minute, or second) segment is present then the letter ``T``
+    (case insensitive) must precede the first time segment. Likewise if a ``T``
+    is present, there must be at least 1 segment after the ``T``.
+
+  - Each segment is composed of 1 or more digits, followed by the unit. Leading
+    0s are accepted. The *final* segment may include a decimal component if
+    needed.
+
+A few examples:
+
+.. code-block:: python
+
+   "P0D"                # 0 days
+   "P1D"                # 1 Day
+   "PT1H30S"            # 1 Hour and 30 minutes
+   "PT1.5H"             # 1 Hour and 30 minutes
+   "-PT1M30S"           # -90 seconds
+   "PT1H30M25.5S"       # 1 Hour, 30 minutes, and 25.5 seconds
+
+While msgspec will decode duration strings making use of the ``H`` (hour) or
+``M`` (minute) units, durations encoded by msgspec will only consist of ``D``
+(day) and ``S`` (second) segments.
+
+The implementation in ``msgspec`` is compatible with the ones in:
+
+- Java's ``time.Duration.parse`` (`docs <https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)>`__)
+- Javascript's proposed ``Temporal.Duration`` standard API (`docs <https://tc39.es/proposal-temporal/docs/duration.html>`__)
+- Python libraries like pendulum_ or pydantic_.
+
+Duration strings produced by msgspec should be interchangeable with these
+libraries, as well as similar ones in other language ecosystems.
+
+
+.. code-block:: python
+
+    >>> from datetime import timedelta
+
+    >>> msgspec.json.encode(timedelta(seconds=123))
+    b'"PT123S"'
+
+    >>> msgspec.json.encode(timedelta(days=1, seconds=30, microseconds=123))
+    b'"P1DT30.000123S"'
+
+    >>> msgspec.json.decode(b'"PT123S"', type=timedelta)
+    datetime.timedelta(seconds=123)
+
+    >>> msgspec.json.decode(b'"PT1.5M"', type=timedelta)
+    datetime.timedelta(seconds=90)
+
+    >>> msgspec.json.decode(b'"oops"', type=datetime.timedelta)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Invalid ISO8601 duration
+
 
 ``uuid``
 --------
@@ -1339,6 +1424,7 @@ TOML_ types are decoded to Python types as follows:
 .. _YAML: https://yaml.org
 .. _TOML: https://toml.io
 .. _pydantic: https://pydantic-docs.helpmanual.io/
+.. _pendulum: https://pendulum.eustace.io/
 .. _RFC8259: https://datatracker.ietf.org/doc/html/rfc8259
 .. _RFC3339: https://datatracker.ietf.org/doc/html/rfc3339
 .. _RFC4122: https://datatracker.ietf.org/doc/html/rfc4122
@@ -1352,3 +1438,4 @@ TOML_ types are decoded to Python types as follows:
 .. _generic types:
 .. _user-defined generic types: https://docs.python.org/3/library/typing.html#user-defined-generic-types
 .. _open an issue: https://github.com/jcrist/msgspec/issues>
+.. _ISO 8601 duration strings: https://en.wikipedia.org/wiki/ISO_8601#Durations

--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -244,6 +244,9 @@ def _to_schema(
     elif isinstance(t, mi.DateType):
         schema["type"] = "string"
         schema["format"] = "date"
+    elif isinstance(t, mi.TimeDeltaType):
+        schema["type"] = "string"
+        schema["format"] = "duration"
     elif isinstance(t, mi.UUIDType):
         schema["type"] = "string"
         schema["format"] = "uuid"

--- a/msgspec/inspect.py
+++ b/msgspec/inspect.py
@@ -51,6 +51,7 @@ __all__ = (
     "DateTimeType",
     "TimeType",
     "DateType",
+    "TimeDeltaType",
     "UUIDType",
     "DecimalType",
     "ExtType",
@@ -248,6 +249,10 @@ class TimeType(Type):
 
 class DateType(Type):
     """A type corresponding to `datetime.date`."""
+
+
+class TimeDeltaType(Type):
+    """A type corresponding to `datetime.timedelta`."""
 
 
 class UUIDType(Type):
@@ -798,6 +803,8 @@ class _Translator:
             return TimeType(tz=tz)
         elif t is datetime.date:
             return DateType()
+        elif t is datetime.timedelta:
+            return TimeDeltaType()
         elif t is uuid.UUID:
             return UUIDType()
         elif t is decimal.Decimal:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -671,6 +671,25 @@ class TestDate:
             convert("2022-01-02", datetime.date, builtin_types=(datetime.date,))
 
 
+class TestTimeDelta:
+    def test_timedelta_wrong_type(self):
+        with pytest.raises(ValidationError, match="Expected `duration`, got `array`"):
+            convert([], datetime.timedelta)
+
+    def test_timedelta_builtin(self):
+        td = datetime.timedelta(1)
+        assert convert(td, datetime.timedelta) is td
+
+    def test_timedelta_str(self):
+        sol = datetime.timedelta(1, 2)
+        res = convert("P1DT2S", datetime.timedelta)
+        assert res == sol
+
+    def test_timedelta_str_disabled(self):
+        with pytest.raises(ValidationError, match="Expected `duration`, got `str`"):
+            convert("P1DT2S", datetime.timedelta, builtin_types=(datetime.timedelta,))
+
+
 class TestUUID:
     def test_uuid_wrong_type(self):
         with pytest.raises(ValidationError, match="Expected `uuid`, got `int`"):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -162,6 +162,10 @@ def test_date():
     assert mi.type_info(datetime.date) == mi.DateType()
 
 
+def test_timedelta():
+    assert mi.type_info(datetime.timedelta) == mi.TimeDeltaType()
+
+
 def test_uuid():
     assert mi.type_info(uuid.UUID) == mi.UUIDType()
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -139,6 +139,13 @@ def test_date():
     }
 
 
+def test_timedelta():
+    assert msgspec.json.schema(datetime.timedelta) == {
+        "type": "string",
+        "format": "duration",
+    }
+
+
 def test_uuid():
     assert msgspec.json.schema(uuid.UUID) == {
         "type": "string",

--- a/tests/test_to_builtins.py
+++ b/tests/test_to_builtins.py
@@ -168,6 +168,16 @@ class TestToBuiltins:
         res = to_builtins(msg, builtin_types=(datetime.time,))
         assert res is msg
 
+    def test_timedelta(self):
+        msg = datetime.timedelta(1, 2, 300)
+        res = to_builtins(msg)
+        assert res == "P1DT2.0003S"
+
+    def test_timedelta_builtin_types(self):
+        msg = datetime.timedelta(1, 2, 300)
+        res = to_builtins(msg, builtin_types=(datetime.timedelta,))
+        assert res is msg
+
     def test_uuid(self):
         msg = uuid.uuid4()
         assert to_builtins(msg) == str(msg)


### PR DESCRIPTION
This adds builtin timedelta support.

By default, we encode-to/decode-from a subset of [ISO 8601 duration strings](https://en.wikipedia.org/wiki/ISO_8601#Durations).

This subset matches the intersection between the one used by [java's duration](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)), and the proposed javascript `Temporal.Duration` api ([docs here](https://tc39.es/proposal-temporal/docs/duration.html)). Duration strings produced by msgspec should be compatible with either of these libraries (and most other ISO 8601 compatible systems). Likewise, durations produced by those libraries should be readable by msgspec. See the included docs update for a complete spec of what ISO8601 subset is supported.

- [x] A remaining TODO is adding support for parsing int/float inputs as timedeltas (interpreted as total seconds) when in lax-mode (`strict=False`).

We _might_ want to also add a `timedelta_format` option to the encoders so users can also encode `timedelta` objects in this format as well. I'm less certain this is necessary. A `double` can only represent a timedelta of ~270 years down to microsecond precision, deltas larger than this will start to lose precision when serialized as floats. Whether that matters is use case dependent.

Fixes #260.