### PR TITLE
Add `msgspec.json.Encoder.encode_lines`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -57,7 +57,7 @@ JSON
 .. currentmodule:: msgspec.json
 
 .. autoclass:: Encoder
-    :members: encode, encode_into
+    :members: encode, encode_lines, encode_into
 
 .. autoclass:: Decoder
     :members: decode

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -4,6 +4,7 @@ from typing import (
     Callable,
     Dict,
     Generic,
+    Iterable,
     Literal,
     Optional,
     Tuple,
@@ -29,6 +30,7 @@ class Encoder:
         decimal_format: Literal["string", "number"] = "string",
     ): ...
     def encode(self, obj: Any) -> bytes: ...
+    def encode_lines(self, items: Iterable) -> bytes: ...
     def encode_into(
         self, obj: Any, buffer: bytearray, offset: Optional[int] = 0
     ) -> None: ...

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -690,6 +690,16 @@ def check_json_Encoder_encode() -> None:
     reveal_type(b)  # assert "bytes" in typ
 
 
+def check_json_Encoder_encode_lines() -> None:
+    enc = msgspec.json.Encoder()
+    items = [{"x": 1}, 2]
+    b = enc.encode_lines(items)
+    b2 = enc.encode_lines((i for i in items))
+
+    reveal_type(b)  # assert "bytes" in typ
+    reveal_type(b2)  # assert "bytes" in typ
+
+
 def check_json_Encoder_encode_into() -> None:
     enc = msgspec.json.Encoder()
     buf = bytearray(48)


### PR DESCRIPTION
This adds a new method on the JSON `Encoder` class for encoding an iterable of items as newline delimited JSON, one item per line. This is roughly equivalent to (but up to 3x faster than):

```python
def encode_lines(items):
    return b''.join(
        msgspec.json.encode(item) + b'\n' for item in items
    )
```

We limit it to an implementation on the `Encoder` class alone for now (rather than a new top-level function) since this is a relatively niche feature.

Fixes #449.