### PR TITLE
Support alternative UUID formats.

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -487,10 +487,9 @@ as total seconds. See :ref:`strict-vs-lax` for more information.
 ``uuid``
 --------
 
-`uuid.UUID` values are serialized as RFC4122_ encoded strings in all protocols.
-Subclasses of `uuid.UUID` are also supported for encoding only.
-
-When decoding, both hyphenated and unhyphenated forms are supported.
+`uuid.UUID` values are serialized as RFC4122_ encoded canonical strings in all
+protocols by default. Subclasses of `uuid.UUID` are also supported for encoding
+only.
 
 .. code-block:: python
 
@@ -504,13 +503,59 @@ When decoding, both hyphenated and unhyphenated forms are supported.
     >>> msgspec.json.decode(b'"c4524ac0-e81e-4aa8-a595-0aec605a659a"', type=uuid.UUID)
     UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
 
-    >>> msgspec.json.decode(b'"c4524ac0e81e4aa8a5950aec605a659a"', type=uuid.UUID)
-    UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
-
     >>> msgspec.json.decode(b'"oops"', type=uuid.UUID)
     Traceback (most recent call last):
         File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Invalid UUID
+
+Alternative formats are also supported by the JSON and MessagePack encoders.
+The format may be selected by passing it to ``uuid_format`` when creating an
+``Encoder``. The following options are supported:
+
+- ``canonical``: UUIDs are encoded as RFC4122_ canonical strings (same as
+  ``str(uuid)``). This is the default.
+- ``hex``: UUIDs are encoded as RFC4122_ hex strings (same as ``uuid.hex``).
+- ``bytes``: UUIDs are encoded as binary values of the uuid's big-endian
+  128-bit integer representation (same as ``uuid.bytes``). This is only supported
+  by the MessagePack encoder.
+
+When decoding, both ``canonical`` and ``hex`` formats are supported by all
+protocols.
+
+.. code-block:: python
+
+    >>> enc = msgspec.json.Encoder(uuid_format="hex")
+
+    >>> enc.encode(u)
+    b'"c4524ac0e81e4aa8a5950aec605a659a"'
+
+    >>> u.hex
+    "c4524ac0e81e4aa8a5950aec605a659a"
+
+    >>> msgspec.json.decode(b'"c4524ac0e81e4aa8a5950aec605a659a"', type=uuid.UUID)
+    UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
+
+Additionally, if ``strict=False`` is specified, the ``bytes`` format may be
+decoded by the MessagePack decoder. See :ref:`strict-vs-lax` for more
+information.
+
+.. code-block:: python
+
+    >>> enc = msgspec.msgpack.Encoder(uuid_format="bytes")
+
+    >>> msg = enc.encode(u)
+
+    >>> msg
+    b'\xc4\x10\xc4RJ\xc0\xe8\x1eJ\xa8\xa5\x95\n\xec`Ze\x9a'
+
+    >>> msgspec.msgpack.decode(msg, type=uuid.UUID)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    msgspec.ValidationError: Expected `uuid`, got `bytes`
+
+    >>> msgspec.msgpack.decode(msg, type=uuid.UUID, strict=False)
+    UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
+
 
 ``decimal``
 -----------

--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -519,41 +519,25 @@ The format may be selected by passing it to ``uuid_format`` when creating an
   128-bit integer representation (same as ``uuid.bytes``). This is only supported
   by the MessagePack encoder.
 
-When decoding, both ``canonical`` and ``hex`` formats are supported by all
-protocols.
+When decoding, any of the above formats are accepted.
 
 .. code-block:: python
 
     >>> enc = msgspec.json.Encoder(uuid_format="hex")
 
-    >>> enc.encode(u)
+    >>> uuid_hex = enc.encode(u)
+
+    >>> uuid_hex
     b'"c4524ac0e81e4aa8a5950aec605a659a"'
 
-    >>> u.hex
-    "c4524ac0e81e4aa8a5950aec605a659a"
-
-    >>> msgspec.json.decode(b'"c4524ac0e81e4aa8a5950aec605a659a"', type=uuid.UUID)
+    >>> msgspec.json.decode(uuid_hex, type=uuid.UUID)
     UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
-
-Additionally, if ``strict=False`` is specified, the ``bytes`` format may be
-decoded by the MessagePack decoder. See :ref:`strict-vs-lax` for more
-information.
-
-.. code-block:: python
 
     >>> enc = msgspec.msgpack.Encoder(uuid_format="bytes")
 
-    >>> msg = enc.encode(u)
+    >>> uuid_bytes = enc.encode(u)
 
-    >>> msg
-    b'\xc4\x10\xc4RJ\xc0\xe8\x1eJ\xa8\xa5\x95\n\xec`Ze\x9a'
-
-    >>> msgspec.msgpack.decode(msg, type=uuid.UUID)
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    msgspec.ValidationError: Expected `uuid`, got `bytes`
-
-    >>> msgspec.msgpack.decode(msg, type=uuid.UUID, strict=False)
+    >>> msgspec.msgpack.decode(uuid_bytes, type=uuid.UUID)
     UUID('c4524ac0-e81e-4aa8-a595-0aec605a659a')
 
 

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -13585,7 +13585,7 @@ mpack_decode_bin(
     else if (type->types & MS_TYPE_BYTEARRAY) {
         return PyByteArray_FromStringAndSize(s, size);
     }
-    else if (!self->strict && (type->types & MS_TYPE_UUID)) {
+    else if (type->types & MS_TYPE_UUID) {
         return ms_decode_uuid_from_bytes(s, size, path);
     }
 
@@ -18992,7 +18992,10 @@ convert_bytes(
         }
         return PyByteArray_FromObject(obj);
     }
-    if (!self->strict && (type->types & MS_TYPE_UUID)) {
+    if (
+            (type->types & MS_TYPE_UUID) &&
+            !(self->builtin_types & MS_BUILTIN_UUID)
+    ) {
         return ms_decode_uuid_from_bytes(
             PyBytes_AS_STRING(obj), PyBytes_GET_SIZE(obj), path
         );
@@ -19014,7 +19017,10 @@ convert_bytearray(
         }
         return PyBytes_FromObject(obj);
     }
-    if (!self->strict && (type->types & MS_TYPE_UUID)) {
+    if (
+            (type->types & MS_TYPE_UUID) &&
+            !(self->builtin_types & MS_BUILTIN_UUID)
+    ) {
         return ms_decode_uuid_from_bytes(
             PyByteArray_AS_STRING(obj), PyByteArray_GET_SIZE(obj), path
         );

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -22,12 +22,14 @@ dec_hook_sig = Optional[Callable[[type, Any], Any]]
 class Encoder:
     enc_hook: enc_hook_sig
     decimal_format: Literal["string", "number"]
+    uuid_format: Literal["canonical", "hex"]
 
     def __init__(
         self,
         *,
         enc_hook: enc_hook_sig = None,
         decimal_format: Literal["string", "number"] = "string",
+        uuid_format: Literal["canonical", "hex"] = "canonical",
     ): ...
     def encode(self, obj: Any) -> bytes: ...
     def encode_lines(self, items: Iterable) -> bytes: ...

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -59,11 +59,13 @@ class Decoder(Generic[T]):
 class Encoder:
     enc_hook: enc_hook_sig
     decimal_format: Literal["string", "number"]
+    uuid_format: Literal["canonical", "hex", "bytes"]
     def __init__(
         self,
         *,
         enc_hook: enc_hook_sig = None,
         decimal_format: Literal["string", "number"] = "string",
+        uuid_format: Literal["canonical", "hex", "bytes"] = "canonical",
     ): ...
     def encode(self, obj: Any) -> bytes: ...
     def encode_into(

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -647,6 +647,13 @@ def check_msgpack_Encoder_decimal_format() -> None:
     reveal_type(enc.decimal_format)  # assert "string" in typ.lower() and "number" in typ.lower()
 
 
+def check_msgpack_Encoder_uuid_format() -> None:
+    enc = msgspec.msgpack.Encoder(uuid_format="canonical")
+    msgspec.msgpack.Encoder(uuid_format="hex")
+    msgspec.msgpack.Encoder(uuid_format="bytes")
+    reveal_type(enc.uuid_format)  # assert all(s in typ.lower() for s in ("canonical", "hex", "bytes"))
+
+
 def check_msgpack_decode_dec_hook() -> None:
     def dec_hook(typ: Type, obj: Any) -> Any:
         return typ(obj)
@@ -803,6 +810,12 @@ def check_json_Encoder_decimal_format() -> None:
     enc = msgspec.json.Encoder(decimal_format="string")
     msgspec.json.Encoder(decimal_format="number")
     reveal_type(enc.decimal_format)  # assert "string" in typ.lower() and "number" in typ.lower()
+
+
+def check_json_Encoder_uuid_format() -> None:
+    enc = msgspec.json.Encoder(uuid_format="canonical")
+    msgspec.json.Encoder(uuid_format="hex")
+    reveal_type(enc.uuid_format)  # assert all(s in typ.lower() for s in ("canonical", "hex"))
 
 
 def check_json_decode_dec_hook() -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3402,20 +3402,15 @@ class TestUUID:
         assert res == u
         assert res.is_safe == u.is_safe
 
-    def test_decode_uuid_from_bytes_lax(self):
+    def test_decode_uuid_from_bytes(self):
         sol = uuid.uuid4()
         msg = msgspec.msgpack.encode(sol.bytes)
-        res = msgspec.msgpack.decode(msg, type=uuid.UUID, strict=False)
+        res = msgspec.msgpack.decode(msg, type=uuid.UUID)
         assert res == sol
 
         bad_msg = msgspec.msgpack.encode(b"x" * 8)
         with pytest.raises(msgspec.ValidationError, match="Invalid UUID bytes"):
-            msgspec.msgpack.decode(bad_msg, type=uuid.UUID, strict=False)
-
-        with pytest.raises(
-            msgspec.ValidationError, match="Expected `uuid`, got `bytes`"
-        ):
-            msgspec.msgpack.decode(msg, type=uuid.UUID)
+            msgspec.msgpack.decode(bad_msg, type=uuid.UUID)
 
     @pytest.mark.parametrize(
         "uuid_str",

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2348,6 +2348,20 @@ class TestLax:
             with pytest.raises(ValidationError, match="Invalid"):
                 convert(msg, type=datetime.timedelta, strict=False)
 
+    @pytest.mark.parametrize("input_type", [bytes, bytearray])
+    def test_lax_uuid(self, input_type):
+        sol = uuid.uuid4()
+        msg = input_type(sol.bytes)
+        res = convert(msg, uuid.UUID, strict=False)
+        assert res == sol
+
+        bad_msg = input_type(b"x" * 8)
+        with pytest.raises(msgspec.ValidationError, match="Invalid UUID bytes"):
+            convert(bad_msg, type=uuid.UUID, strict=False)
+
+        with pytest.raises(ValidationError, match="Expected `uuid`, got `bytes`"):
+            convert(msg, uuid.UUID)
+
     @pytest.mark.parametrize(
         "msg, sol",
         [

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -8,6 +8,7 @@ import math
 import pickle
 import struct
 import sys
+import uuid
 from typing import (
     Any,
     Dict,
@@ -1980,3 +1981,20 @@ class TestRaw:
         s = msgspec.msgpack.encode({"x": [1, 2]})
         res = msgspec.msgpack.decode(s, type=Test, dec_hook=dec_hook)
         assert res == Test(Custom(1, 2))
+
+
+class TestUUID:
+    def test_lax_uuid(self):
+        sol = uuid.uuid4()
+        msg = msgspec.msgpack.encode(sol.bytes)
+        res = msgspec.msgpack.decode(msg, type=uuid.UUID, strict=False)
+        assert res == sol
+
+        bad_msg = msgspec.msgpack.encode(b"x" * 8)
+        with pytest.raises(msgspec.ValidationError, match="Invalid UUID bytes"):
+            msgspec.msgpack.decode(bad_msg, type=uuid.UUID, strict=False)
+
+        with pytest.raises(
+            msgspec.ValidationError, match="Expected `uuid`, got `bytes`"
+        ):
+            msgspec.msgpack.decode(msg, type=uuid.UUID)

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -8,7 +8,6 @@ import math
 import pickle
 import struct
 import sys
-import uuid
 from typing import (
     Any,
     Dict,
@@ -1981,20 +1980,3 @@ class TestRaw:
         s = msgspec.msgpack.encode({"x": [1, 2]})
         res = msgspec.msgpack.decode(s, type=Test, dec_hook=dec_hook)
         assert res == Test(Custom(1, 2))
-
-
-class TestUUID:
-    def test_lax_uuid(self):
-        sol = uuid.uuid4()
-        msg = msgspec.msgpack.encode(sol.bytes)
-        res = msgspec.msgpack.decode(msg, type=uuid.UUID, strict=False)
-        assert res == sol
-
-        bad_msg = msgspec.msgpack.encode(b"x" * 8)
-        with pytest.raises(msgspec.ValidationError, match="Invalid UUID bytes"):
-            msgspec.msgpack.decode(bad_msg, type=uuid.UUID, strict=False)
-
-        with pytest.raises(
-            msgspec.ValidationError, match="Expected `uuid`, got `bytes`"
-        ):
-            msgspec.msgpack.decode(msg, type=uuid.UUID)


### PR DESCRIPTION
This adds a new `uuid_format` to the json and msgpack encoders, configuring how msgspec will handle uuids. This may be one of:

- `canonical`: UUIDs are encoded as canonical strings (same as `str(uuid)`). This is the default.
- `hex`: UUIDs are encoded as strings without hyphens (same as `uuid.hex`).
- `bytes`: UUIDs are encoded as binary values representing big-endian 128-bit integers (same as `uuid.bytes`).

All protocols support decoding from any of these formats by default. Note that only msgpack supports encoding/decoding the `'bytes'` value, as JSON lacks a native binary type.

```python
In [1]: import msgspec

In [2]: import uuid

In [3]: u = uuid.uuid4()

In [4]: u
Out[4]: UUID('827ba710-601d-421c-bdaf-632d2db2620c')

In [5]: msgspec.json.encode(u)  # defaults to canonical
Out[5]: b'"827ba710-601d-421c-bdaf-632d2db2620c"'

In [6]: hex_enc = msgspec.json.Encoder(uuid_format="hex")  # use the hex format

In [7]: hex_enc.encode(u)
Out[7]: b'"827ba710601d421cbdaf632d2db2620c"'

In [8]: msgspec.json.decode(_, type=uuid.UUID)  # decode supports all formats
Out[8]: UUID('827ba710-601d-421c-bdaf-632d2db2620c')

In [9]: bytes_enc = msgspec.msgpack.Encoder(uuid_format="bytes")  # use the bytes format

In [10]: bytes_enc.encode(u)
Out[10]: b'\xc4\x10\x82{\xa7\x10`\x1dB\x1c\xbd\xafc--\xb2b\x0c'

In [11]: u.bytes  # this ^^ is the msgpack encoded version of u.bytes
Out[11]: b'\x82{\xa7\x10`\x1dB\x1c\xbd\xafc--\xb2b\x0c'

In [12]: msgspec.msgpack.decode(bytes_enc.encode(u), type=uuid.UUID)  # roundtrips fine
Out[12]: UUID('827ba710-601d-421c-bdaf-632d2db2620c')
```

Fixes #493.

