### PR TITLE
Support encoding more dataclass-like things

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -721,7 +721,7 @@ respective types (if specified).
     msgspec.ValidationError: Expected `int`, got `str` - at `$[...]`
 
 ``TypedDict``
---------------------
+-------------
 
 `typing.TypedDict` provides a way to specify different types for different
 values in a ``dict``, rather than a single value type (the ``int`` in
@@ -766,9 +766,6 @@ already using them elsewhere, or if you have downstream code that requires a
 ---------------
 
 `dataclasses` map to objects/maps in all protocols.
-
-During encoding, all attributes without a leading underscore (``"_"``) are
-encoded.
 
 During decoding, any extra fields are ignored. An error is raised if a field's
 type doesn't match or if any required fields are missing.

--- a/tests/test_to_builtins.py
+++ b/tests/test_to_builtins.py
@@ -419,18 +419,6 @@ class TestToBuiltins:
         assert res == {"x": 1, "y": 2}
 
     @pytest.mark.parametrize("slots", slots_params)
-    def test_dataclass_skip_leading_underscore(self, slots):
-        @dataclass(**({"slots": True} if slots else {}))
-        class Ex:
-            x: int
-            y: int
-            _z: int
-
-        x = Ex(1, 2, 3)
-        res = to_builtins(x)
-        assert res == {"x": 1, "y": 2}
-
-    @pytest.mark.parametrize("slots", slots_params)
     def test_dataclass_unsupported_value(self, slots):
         @dataclass(**({"slots": True} if slots else {}))
         class Ex:
@@ -452,6 +440,20 @@ class TestToBuiltins:
 
         msg = Ex(1, FruitInt.APPLE)
         assert to_builtins(msg) == {"x": 1, "y": -1}
+
+    @pytest.mark.parametrize("slots", [True, False])
+    def test_attrs_skip_leading_underscore(self, slots):
+        attrs = pytest.importorskip("attrs")
+
+        @attrs.define(slots=slots)
+        class Ex:
+            x: int
+            y: int
+            _z: int
+
+        x = Ex(1, 2, 3)
+        res = to_builtins(x)
+        assert res == {"x": 1, "y": 2}
 
     @pytest.mark.parametrize("kind", ["struct", "dataclass", "attrs"])
     def test_unset_fields(self, kind):


### PR DESCRIPTION
Previously we supported encoding dataclasses (determined as any object with a `__dataclass_fields__` attribute), provided those objects were implemented in a way similar-enough to how they were implemented in the standard library. The intent was to support stdlib dataclasses, and if alternative implementations (e.g. `pydantic.dataclasses`) happened to work then all the better.

However, due to how we were detecting if an object was a dataclass, there was no way to override our builtin support if an alternative implementation (in this case `edgedb.Object`) didn't work.

To fix this, we now make fewer assumptions about how the backing dataclass object is implemented.

Pros:

- We can now natively encode objects implemented using `dataclasses`, `pydantic.dataclasses`, and `edgedb.Object`.
- We now only encode fields as declared on the dataclass object. Previously we encoded any attribute lacking a leading underscore, which was efficient and worked well in practice (it's also what `orjson` does). However, this can lead to weird behavior if some fields intentionally start with an `_` (like `_id` in mongodb) or if the object makes use of `functools.cached_property`.

Cons:

- This flexibility and correctness comes at a performance cost. The fast path is the common case (dataclass uses `__dict__`, doesn't override `__getattribute__`), but encoding is now ~20% slower than before. Before we encoded `__dict__` based dataclasses 20% faster than orjson; now we're faster for small classes and slower for larger numbers of fields (on my machine 12 fields is the crossover point). For `__slots__` based classes we're still around 2x faster than `orjson`.

Fixes #495.

TODO:

- [x] `msgspec.json.encode`
- [x] `msgspec.msgpack.encode`
- [x] `msgspec.to_builtins`
- [x] tests
- [x] update docs