### PR TITLE
Refactor float parsing

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -696,9 +696,9 @@ Dict subclasses (`collections.OrderedDict`, for example) are also supported for
 encoding only. To decode into a ``dict`` subclass you'll need to implement a
 ``dec_hook`` (see :doc:`extending`).
 
-JSON and TOML only support key types that encode as strings or integers (for
-example `str`, `int`, `enum.Enum`, `datetime.datetime`, `uuid.UUID`, ...).
-MessagePack and YAML support any hashable for the key type.
+JSON and TOML only support key types that encode as strings or numbers (for
+example `str`, `int`, `float`, `enum.Enum`, `datetime.datetime`, `uuid.UUID`,
+...). MessagePack and YAML support any hashable for the key type.
 
 An error is raised during decoding if the keys or values don't match their
 respective types (if specified).

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4014,13 +4014,10 @@ class TestLax:
             ("true", True),
             ("false", False),
             ("null", None),
-            ("1a", "1a"),
-            ("falsx", "falsx"),
-            ("nulx", "nulx"),
         ],
     )
     def test_lax_union_valid(self, x, sol, proto):
-        typ = Union[int, float, bool, None, str]
+        typ = Union[int, float, bool, None]
         msg = proto.encode(x)
         assert_eq(proto.decode(msg, type=typ, strict=False), sol)
 
@@ -4041,7 +4038,6 @@ class TestLax:
             ("18446744073709551616", "`int` <= 1000"),
             ("-9223372036854775809", "`int` >= 0"),
             ("100.5", "`float` <= 100.0"),
-            ("x" * 11, "length <= 10"),
         ],
     )
     def test_lax_union_invalid_constr(self, x, err, proto, Annotated):
@@ -4051,7 +4047,6 @@ class TestLax:
         typ = Union[
             Annotated[int, Meta(ge=0), Meta(le=1000)],
             Annotated[float, Meta(le=100)],
-            Annotated[str, Meta(max_length=10)],
         ]
         with pytest.raises(ValidationError, match=err):
             proto.decode(msg, type=typ, strict=False)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3608,12 +3608,15 @@ class TestDecimal:
         s = str(d)
         assert proto.encode(d) == proto.encode(s)
 
-    def test_decode_decimal_str(self, proto):
-        d = decimal.Decimal("1.5")
-        msg = proto.encode(d)
+    @pytest.mark.parametrize(
+        "val", ["1.5", "InF", "-iNf", "iNfInItY", "-InFiNiTy", "NaN"]
+    )
+    def test_decode_decimal_str(self, val, proto):
+        sol = decimal.Decimal(val)
+        msg = proto.encode(sol)
         res = proto.decode(msg, type=decimal.Decimal)
+        assert str(res) == str(sol)
         assert type(res) is decimal.Decimal
-        assert res == d
 
     def test_decode_decimal_str_invalid(self, proto):
         msg = proto.encode("1..5")

--- a/tests/test_to_builtins.py
+++ b/tests/test_to_builtins.py
@@ -296,17 +296,13 @@ class TestToBuiltins:
         assert to_builtins({FruitInt.BANANA: 1}, str_keys=True) == {"2": 1}
         assert to_builtins({2: 1}, str_keys=True) == {"2": 1}
 
-        with pytest.raises(
-            TypeError, match="Only dicts with `str` or `int` keys are supported"
-        ):
-            to_builtins({(1, 2): 3}, str_keys=True)
-
     def test_dict_sequence_keys(self):
         msg = {frozenset([1, 2]): 1}
         assert to_builtins(msg) == {(1, 2): 1}
 
         with pytest.raises(
-            TypeError, match="Only dicts with `str` or `int` keys are supported"
+            TypeError,
+            match="Only dicts with str-like or number-like keys are supported",
         ):
             to_builtins(msg, str_keys=True)
 


### PR DESCRIPTION
This refactors the number parsing routine (str -> int/float), with the following results:

- Improved performance, up to 20% faster, dependent on message. This is most prominent for floats or long ints.
- Ability to reuse the same routine for converting strings to ints or floats (or int/float-like things). Previously we had a duplicate `str -> int` routine, and relied on cpython's float parser for the `str -> float` conversions. With this change we're able to delete a bunch of code.
- Expanded features. In particular, we can now support float-like strings as dict keys in JSON.
- Improved maintainability. The reorganized code should provide a better base to build new features off of.

This also adds support for encoding dicts with floats as keys (the keys are encoded as strings).