### PR TITLE
Add `float_hook` to json decoder

### DIFF
--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -18,6 +18,7 @@ T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
 dec_hook_sig = Optional[Callable[[type, Any], Any]]
+float_hook_sig = Optional[Callable[[str], Any]]
 
 class Encoder:
     enc_hook: enc_hook_sig
@@ -41,6 +42,7 @@ class Decoder(Generic[T]):
     type: Type[T]
     strict: bool
     dec_hook: dec_hook_sig
+    float_hook: float_hook_sig
 
     @overload
     def __init__(
@@ -48,6 +50,7 @@ class Decoder(Generic[T]):
         *,
         strict: bool = True,
         dec_hook: dec_hook_sig = None,
+        float_hook: float_hook_sig = None,
     ) -> None: ...
     @overload
     def __init__(
@@ -56,6 +59,7 @@ class Decoder(Generic[T]):
         *,
         strict: bool = True,
         dec_hook: dec_hook_sig = None,
+        float_hook: float_hook_sig = None,
     ) -> None: ...
     @overload
     def __init__(
@@ -64,6 +68,7 @@ class Decoder(Generic[T]):
         *,
         strict: bool = True,
         dec_hook: dec_hook_sig = None,
+        float_hook: float_hook_sig = None,
     ) -> None: ...
     def decode(self, data: Union[bytes, str]) -> T: ...
     def decode_lines(self, data: Union[bytes, str]) -> list[T]: ...

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+import decimal
 import pickle
 from typing import Any, Dict, Final, List, Type, Union
 
@@ -824,6 +825,14 @@ def check_json_decode_dec_hook() -> None:
 
     msgspec.json.decode(b"test", dec_hook=dec_hook)
     msgspec.json.Decoder(dec_hook=dec_hook)
+
+
+def check_json_Decoder_float_hook() -> None:
+    msgspec.json.Decoder(float_hook=None)
+    msgspec.json.Decoder(float_hook=float)
+    dec = msgspec.json.Decoder(float_hook=decimal.Decimal)
+    if dec.float_hook is not None:
+        dec.float_hook("1.5")
 
 
 def check_json_Decoder_strict() -> None:


### PR DESCRIPTION
This adds support for a `float_hook` to the json decoder. If set, this hook will be called to decode any untyped JSON float values from their raw string representations. This may be used to change the default float parsing from returning ``float`` values to return ``decimal.Decimal`` values again.

Since this is an uncommon option, it's only available on the Decoder, rather than the top-level ``msgspec.json.decode`` function.

Fixes #507.