### PR TITLE
Fix JSON encoding of datetimes with zoneinfo tzinfos

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3164,6 +3164,18 @@ class TestTime:
         sol = proto.encode(t_str)
         assert res == sol
 
+    @py39_plus
+    def test_encode_time_zoneinfo(self):
+        import zoneinfo
+
+        try:
+            x = datetime.time(1, 2, 3, 456789, zoneinfo.ZoneInfo("America/Chicago"))
+        except zoneinfo.ZoneInfoNotFoundError:
+            pytest.skip(reason="Failed to load timezone")
+        sol = msgspec.json.encode(x.isoformat())
+        res = msgspec.json.encode(x)
+        assert res == sol
+
     @pytest.mark.parametrize(
         "dt",
         [

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -33,6 +33,9 @@ import msgspec
 
 UTC = datetime.timezone.utc
 
+PY39 = sys.version_info[:2] >= (3, 9)
+py39_plus = pytest.mark.skipif(not PY39, reason="3.9+ only")
+
 
 class FruitInt(enum.IntEnum):
     APPLE = -1
@@ -837,6 +840,20 @@ class TestDatetime:
         x = datetime.datetime(1234, 12, 31, 14, 56, 27, 123456, tz)
         s = msgspec.json.encode(x)
         assert s == expected
+
+    @py39_plus
+    def test_encode_datetime_zoneinfo(self):
+        import zoneinfo
+
+        try:
+            x = datetime.datetime(
+                2023, 1, 2, 3, 4, 5, 678, zoneinfo.ZoneInfo("America/Chicago")
+            )
+        except zoneinfo.ZoneInfoNotFoundError:
+            pytest.skip(reason="Failed to load timezone")
+        sol = msgspec.json.encode(x.isoformat())
+        res = msgspec.json.encode(x)
+        assert res == sol
 
     @pytest.mark.parametrize(
         "dt",


### PR DESCRIPTION
This fixes a bug where datetime objects with `zoneinfo.ZoneInfo` instances set for `tzinfo` would encode as UTC, ignoring the zoneinfo. This issue was due to `datetime.utcoffset` being called with `None` instead of the `datetime` instance. This worked fine for other `tzinfo` types (like `datetime.timezone`) since those use fixed offsets that aren't date aware.

This also fixes a bug where `datetime.time` instances with a `tzinfo` that returns `None` from `datetime.time.utcoffset` were treated as UTC rather than naive. Quoting from the [standard library docs](https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive):

> A datetime object d is aware if both of the following hold:
>
> 1. d.tzinfo is not None
> 2. d.tzinfo.utcoffset(d) does not return None
>
> Otherwise, d is naive.
>
> A time object t is aware if both of the following hold:
>
> 1. t.tzinfo is not None
> 2. t.tzinfo.utcoffset(None) does not return None.
>
> Otherwise, t is naive.

Both bugs fixed above were due to incorrect behavior around the 2nd condition using `utcoffset`.

Fixes #533.