### PR TITLE
Support attrs validators

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -860,7 +860,13 @@ During decoding, any extra fields are ignored. An error is raised if a field's
 type doesn't match or if any required fields are missing.
 
 If the ``__attrs_pre_init__`` or ``__attrs_post_init__`` methods are defined on
-the class, they are called as part of the decoding process.
+the class, they are called as part of the decoding process. Likewise, if a
+class makes use of attrs' `validators
+<https://www.attrs.org/en/stable/examples.html#validators>`__, the validators
+will be called, and a `msgspec.ValidationError` raised on error. Note that
+attrs' `converters
+<https://www.attrs.org/en/stable/examples.html#conversion>`__ are not currently
+supported.
 
 When possible we recommend using `msgspec.Struct` instead of attrs_ types for
 specifying schemas - :doc:`structs` are faster, more ergonomic, and support

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3005,6 +3005,24 @@ class TestAttrs:
         with pytest.raises(ValueError, match="Oh no!"):
             proto.decode(proto.encode({"a": 1}), type=Example)
 
+    def test_decode_attrs_validators(self, proto):
+        def not2(self, attr, value):
+            if value == 2:
+                raise ValueError("Oh no!")
+
+        @attrs.define
+        class Example:
+            a: int = attrs.field(validator=[attrs.validators.gt(0), not2])
+
+        res = proto.decode(proto.encode({"a": 1}), type=Example)
+        assert res.a == 1
+
+        with pytest.raises(ValidationError):
+            res = proto.decode(proto.encode({"a": -1}), type=Example)
+
+        with pytest.raises(ValidationError, match="Oh no!"):
+            res = proto.decode(proto.encode({"a": 2}), type=Example)
+
     def test_decode_attrs_not_object(self, proto):
         @attrs.define
         class Example:


### PR DESCRIPTION
This adds support for attrs validators. Validators are run after decoding the instance has completed, but before calling `__attrs_post_init__`. Since the builtin attrs validators include the attribute name in the error message, we don't add the field to the error path. This feels *a bit* weird, but is way easier since all of this can be done in pure python.

When possible, it'd be better to use msgspec's builtin constraints for handling validation. These will be much more performant, and integrate better with the rest of the system.

Fixes #535.