### PR TITLE
Relaxed datetime/time parsing

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -10078,11 +10078,12 @@ end_decimal:
                 goto invalid;
             }
 
-            /* Explicit offset requires exactly 5 bytes left */
-            if (buf_end - buf != 5) goto invalid;
-
+            if (buf_end - buf < 3) goto invalid;
             if ((buf = ms_read_fixint(buf, 2, &offset_hour)) == NULL) goto invalid;
-            if (*buf++ != ':') goto invalid;
+            /* RFC3339 requires a ':' separator, ISO8601 doesn't. We support
+             * either */
+            if (*buf == ':') buf++;
+            if (buf_end - buf != 2) goto invalid;
             if ((buf = ms_read_fixint(buf, 2, &offset_min)) == NULL) goto invalid;
             if (offset_hour > 23 || offset_min > 59) goto invalid;
             offset *= (offset_hour * 60 + offset_min);
@@ -10178,9 +10179,10 @@ ms_decode_datetime_from_str(
     if (*buf++ != '-') goto invalid;
     if ((buf = ms_read_fixint(buf, 2, &day)) == NULL) goto invalid;
 
-    /* Date/time separator can be T or t */
+    /* RFC3339 date/time separator can be T or t. We also support ' ', which is
+     * ISO8601 compatible. */
     c = *buf++;
-    if (!(c == 'T' || c == 't')) goto invalid;
+    if (!(c == 'T' || c == 't' || c == ' ')) goto invalid;
 
     /* Parse time */
     if ((buf = ms_read_fixint(buf, 2, &hour)) == NULL) goto invalid;
@@ -10251,11 +10253,12 @@ end_decimal:
                 goto invalid;
             }
 
-            /* Explicit offset requires exactly 5 bytes left */
-            if (buf_end - buf != 5) goto invalid;
-
+            if (buf_end - buf < 3) goto invalid;
             if ((buf = ms_read_fixint(buf, 2, &offset_hour)) == NULL) goto invalid;
-            if (*buf++ != ':') goto invalid;
+            /* RFC3339 requires a ':' separator, ISO8601 doesn't. We support
+             * either */
+            if (*buf == ':') buf++;
+            if (buf_end - buf != 2) goto invalid;
             if ((buf = ms_read_fixint(buf, 2, &offset_min)) == NULL) goto invalid;
             if (offset_hour > 23 || offset_min > 59) goto invalid;
             offset *= (offset_hour * 60 + offset_min);

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3212,6 +3212,20 @@ class TestTime:
         assert res == sol
 
     @pytest.mark.parametrize(
+        "lax, strict",
+        [
+            ("03:04:05+0102", "03:04:05+01:02"),
+            ("03:04:05-0102", "03:04:05-01:02"),
+        ],
+    )
+    def test_decode_time_rfc3339_relaxed(self, lax, strict, proto):
+        """msgspec supports a few relaxations of the RFC3339 format."""
+        sol = datetime.time.fromisoformat(strict)
+        msg = proto.encode(lax)
+        res = proto.decode(msg, type=datetime.time)
+        assert res == sol
+
+    @pytest.mark.parametrize(
         "t, sol",
         [
             (
@@ -3258,6 +3272,8 @@ class TestTime:
             "01:02:3.0000004Z",
             "01:02:03.0000004+5:06",
             "01:02:03.0000004+05:6",
+            "01:02:03.0000004+056",
+            "01:02:03.0000004+05600",
             # Trailing data
             "01:02:030",
             "01:02:03a",
@@ -3265,6 +3281,7 @@ class TestTime:
             "01:02:03.0a",
             "01:02:03.0000004a",
             "01:02:03.0000004+00:000",
+            "01:02:03.0000004+00000",
             "01:02:03.0000004Z0",
             # Truncated
             "01:02:3",
@@ -3280,6 +3297,8 @@ class TestTime:
             "01:02:03.00a+05:06",
             "01:02:03.004+0a:06",
             "01:02:03.004+05:0a",
+            "01:02:03.004+0a06",
+            "01:02:03.004+050a",
             # Hour out of range
             "24:02:03.004",
             # Minute out of range

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -985,6 +985,21 @@ class TestDatetime:
         assert res == sol
 
     @pytest.mark.parametrize(
+        "lax, strict",
+        [
+            ("2022-01-02T03:04:05+0102", "2022-01-02T03:04:05+01:02"),
+            ("2022-01-02T03:04:05-0102", "2022-01-02T03:04:05-01:02"),
+            ("2022-01-02 03:04:05", "2022-01-02T03:04:05"),
+        ],
+    )
+    def test_decode_datetime_rfc3339_relaxed(self, lax, strict):
+        """msgspec supports a few relaxations of the RFC3339 format."""
+        sol = datetime.datetime.fromisoformat(strict)
+        msg = msgspec.json.encode(lax)
+        res = msgspec.json.decode(msg, type=datetime.datetime)
+        assert res == sol
+
+    @pytest.mark.parametrize(
         "s",
         [
             # Incorrect field lengths
@@ -996,8 +1011,10 @@ class TestDatetime:
             b'"0001-02-03T04:05:6.000007Z"',
             b'"0001-02-03T04:05:06.000007+0:00"',
             b'"0001-02-03T04:05:06.000007+00:0"',
+            b'"0001-02-03T04:05:06.000007+000"',
             # Trailing data
             b'"0001-02-03T04:05:06.000007+00:000"',
+            b'"0001-02-03T04:05:06.000007+00000"',
             b'"0001-02-03T04:05:06.000007Z0"',
             b'"0001-02-03T04:05:06a"',
             b'"0001-02-03T04:05:06.000007a"',
@@ -1019,6 +1036,8 @@ class TestDatetime:
             b'"0001-02-03T04:05:06.000007a"',
             b'"0001-02-03T04:05:06.000007+0a:00"',
             b'"0001-02-03T04:05:06.000007+00:0a"',
+            b'"0001-02-03T04:05:06.000007+0a00"',
+            b'"0001-02-03T04:05:06.000007+000a"',
             # Year out of range
             b'"0000-02-03T04:05:06.000007Z"',
             # Month out of range


### PR DESCRIPTION
Previously we strictly followed the RFC3339 format when parsing datetime and time objects from strings. We now support a few common ISO8601 compatible relaxations:

- A `:` isn't required as part of the timezone component in both datetime and time strings (`2022-01-02T03:04:05.678+0102` and `2022-01-02T03:04:05.678+01:02` are treated the same).

- A ` ` may be used instead of `T`/`t` as a separator between date and time components when parsing datetime strings (`2022-01-02 03:04:05.678+01:02` and `2022-01-02T03:04:05.678+01:02` are treated the same).

When encoding datetime/time objects we still strictly follow RFC3339. This eases integrating msgspec with other systems that don't strictly follow RFC3339.

Fixes #537.