### PR TITLE
Handle where `Annotated` has unhashable metadata.

### DIFF
--- a/msgspec/inspect.py
+++ b/msgspec/inspect.py
@@ -619,7 +619,12 @@ def _origin_args_metadata(t):
     # Strip wrappers (Annotated, NewType, Final) until we hit a concrete type
     metadata = []
     while True:
-        origin = _CONCRETE_TYPES.get(t)
+        try:
+            origin = _CONCRETE_TYPES.get(t)
+        except TypeError:
+            # t is not hashable
+            origin = None
+
         if origin is not None:
             args = None
             break

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -765,6 +765,13 @@ def test_metadata():
     )
 
 
+def test_inspect_with_unhashable_metadata():
+
+    typ = Annotated[int, {"unhashable"}]
+
+    assert mi.type_info(typ) == mi.IntType()
+
+
 def test_multi_type_info():
     class Example(msgspec.Struct):
         x: int


### PR DESCRIPTION
This PR handles the case where `t` in the call to  `_CONCRETE_TYPES.get(t)` is not hashable, such as when an `Annotated` instance contains unhashable metadata.

Closes #565