### PR TITLE
Investigate constrained mapping keys, JSON Schema patternProperties

### DIFF
--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -272,9 +272,14 @@ def _to_schema(
     elif isinstance(t, mi.DictType):
         schema["type"] = "object"
         if not isinstance(t.value_type, mi.AnyType):
-            schema["additionalProperties"] = _to_schema(
-                t.value_type, name_map, ref_template
-            )
+            if isinstance(t.key_type, mi.StrType) and t.key_type.pattern:
+                schema["patternProperties"] = {
+                    t.key_type.pattern: _to_schema(t.value_type, name_map, ref_template)
+                }
+            else:
+                schema["additionalProperties"] = _to_schema(
+                    t.value_type, name_map, ref_template
+                )
         if t.max_length is not None:
             schema["maxProperties"] = t.max_length
         if t.min_length is not None:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -754,6 +754,22 @@ class TestMapConstraints:
             with pytest.raises(msgspec.ValidationError, match=err_msg):
                 dec.decode(proto.encode(Ex(x)))
 
+    def test_key_pattern(self, proto):
+        class Ex(msgspec.Struct):
+            x: Dict[Annotated[str, Meta(pattern="[a-z]+")], int]
+
+        dec = proto.Decoder(Ex)
+
+        x = {"a": 1}
+        assert dec.decode(proto.encode(Ex(x))).x == {"a": 1}
+
+        x = {"1": 0}
+        err_msg = re.escape(
+            r"Expected `str` matching regex '[a-z]+' - at `key` in `$.x`"
+        )
+        with pytest.raises(msgspec.ValidationError, match=err_msg):
+            dec.decode(proto.encode(Ex(x)))
+
     def test_max_length(self, proto):
         class Ex(msgspec.Struct):
             x: Annotated[Dict[str, int], Meta(max_length=2)]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1107,6 +1107,17 @@ def test_object_metadata(field, constraint):
     assert msgspec.json.schema(typ) == {"type": "object", constraint: 2}
 
 
+def test_object_key_pattern_properties():
+    re_uuid = r"^[\da-fA-F]{4}([\da-fA-F]{4}-){4}[\da-fA-F]{12}$"
+    UUIDString = Annotated[str, Meta(pattern=re_uuid)]
+    typ = typing.MutableMapping[UUIDString, int]
+
+    assert msgspec.json.schema(typ) == {
+        "type": "object",
+        "patternProperties": {re_uuid: {"type": "integer"}},
+    }
+
+
 def test_generic_metadata():
     typ = Annotated[
         int,


### PR DESCRIPTION
## Elevator Pitch

This PR explores the current support for constraining the keys of `dict`-like objects, where the key enables some level of "uniqueness" across a single attribute, used as the key of a mapping.

## Changes

- [x] add simplest `patternProperties` to JSON Schema generation
- [x] update tests
  - [x] JSON schema
    - [x] handle `patternProperties`
    - [ ] handle `patternProperties` + `additionalProperties`?
  - [ ] decode/validate
    - [x] `.json.decode` already Just Worked :tada: 
    - [ ] the `.msgpack.decode` decoder does not raise the validation warning
- [ ] update docs
  - [ ] determine correct places for docs
    - [ ] _Mapping Constraints_? New section?
    - [ ] _JSON Schema_? Just include in example?

## Motivation

This mostly revolves around the following kind of extension to the JSON schema example:

```py
#: A string constrained to a Global Trade Item Number (GTIN) 
GTINString = Annotated[str, Meta(pattern=r"^\d{14}$")]

class Catalog(Struct):
    """A catalog of products"""
    skus: dict[GTINString, Product]
```

Which yields something like:

```
b'{"$ref":"#/$defs/Catalog","$defs":{"Catalog":{"title":"Catalog","description":"A catalog of products","type":"object","properties":{"skus":{"type":"object","patternProperties":{"^\\\\d{14}$":{"$ref":"#/$defs/Product"}}}},"required":["skus"]},"Product":{"title":"Product","description":"A product in a catalog","type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"},"price":{"type":"number","exclusiveMinimum":0},"tags":{"type":"array","items":{"type":"string"},"default":[]},"dimensions":{"anyOf":[{"type":"null"},{"$ref":"#/$defs/Dimensions"}],"default":null}},"required":["id","name","price"]},"Dimensions":{"title":"Dimensions","description":"Dimensions for a product, all measurements in centimeters","type":"object","properties":{"length":{"type":"number","exclusiveMinimum":0},"width":{"type":"number","exclusiveMinimum":0},"height":{"type":"number","exclusiveMinimum":0}},"required":["length","width","height"]}}}'
```

I've been looking into applying `msgspec` to e.g. the Jupyter notebook format. It makes use of a number of patterns, such as MIME types, etc. as the keys of mappings for constrained, but extensible metadata. I'm not entirely certain what this pattern (ha!) looks like yet, from an `annotated-types`(+/-`msgspec.Meta`) perspective.

```yaml
      "mimebundle": {
        "description": "A mime-type keyed dictionary of data",
        "type": "object",
        "additionalProperties": {
          "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
          "$ref": "#/definitions/misc/multiline_string"
        },
        "patternProperties": {
          "^application/(.*\\+)?json$": {
            "description": "Mimetypes with JSON output, can be any type"
          }
        }
      },
```


