### PR TITLE
Support UUID subclasses in `convert`

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -20608,7 +20608,7 @@ convert(
     else if (pytype == PyDateTimeAPI->DeltaType) {
         return convert_immutable(self, MS_TYPE_TIMEDELTA, "duration", obj, type, path);
     }
-    else if (pytype == (PyTypeObject *)self->mod->UUIDType) {
+    else if (PyType_IsSubtype(pytype, (PyTypeObject *)(self->mod->UUIDType))) {
         return convert_immutable(self, MS_TYPE_UUID, "uuid", obj, type, path);
     }
     else if (pytype == (PyTypeObject *)self->mod->DecimalType) {

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -756,6 +756,14 @@ class TestUUID:
             with pytest.raises(ValidationError, match="Expected `uuid`, got `bytes`"):
                 convert(typ(u.bytes), uuid.UUID, builtin_types=(uuid.UUID,))
 
+    def test_convert_uuid_subclass(self):
+        class UUID2(uuid.UUID):
+            ...
+
+        u1 = uuid.uuid4()
+        u2 = UUID2(str(u1))
+        assert convert(u2, uuid.UUID) is u2
+
 
 class TestDecimal:
     def test_decimal_wrong_type(self):


### PR DESCRIPTION
This fixes a bug where UUID subclasses weren't supported as inputs to `msgspec.convert`.