### PR TITLE
Call `__eq__` from `__ne__` for user defined `__eq__`

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1562,6 +1562,21 @@ class TestOrderAndEq:
         self.assert_neq(x, Test(2, 2))
         self.assert_neq(x, Test2(1, 2))
 
+    def test_struct_override_eq(self):
+        class Ex(Struct):
+            a: int
+            b: int
+
+            def __eq__(self, other):
+                return self.a == other.a
+
+        x = Ex(1, 2)
+        y = Ex(1, 3)
+        z = Ex(2, 3)
+
+        self.assert_eq(x, y)
+        self.assert_neq(x, z)
+
     def test_struct_eq_identity_fastpath(self):
         class Bad:
             def __eq__(self, other):


### PR DESCRIPTION
If a user manually defines an `__eq__` for a `Struct` class, the default `__ne__` implementation will now call the user-defined `__eq__` and invert the result, rather than applying the standard `__ne__` logic. This makes it easier for users to manually override `__eq__`, and matches the behavior of standard python classes.

Fixes #585.