### PR TITLE
Include the struct type in frozen hash implementation

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1460,6 +1460,16 @@ class TestSetAttr:
         with pytest.raises(TypeError, match="unhashable type"):
             hash(p)
 
+    def test_hash_includes_type(self):
+        Ex1 = defstruct("Ex1", ["x"], frozen=True)
+        Ex2 = defstruct("Ex2", ["x"], frozen=True)
+        Ex3 = defstruct("Ex3", [], frozen=True)
+        Ex4 = defstruct("Ex4", [], frozen=True)
+        assert hash(Ex1(1)) == hash(Ex1(1))
+        assert hash(Ex1(1)) != hash(Ex2(1))
+        assert hash(Ex3()) == hash(Ex3())
+        assert hash(Ex3()) != hash(Ex4())
+
     @pytest.mark.parametrize("base_gc", [True, None, False])
     @pytest.mark.parametrize("base_frozen", [True, False])
     @pytest.mark.parametrize("has_gc", [True, None, False])


### PR DESCRIPTION
This modifies the provided hash method to also include the struct type. This improves hash quality for mappings or sets that contain multiple different struct types as keys, as structs of different types with the same data will now hash differently, better matching the `__eq__` implementation.

As an implementation detail, structs should now hash as a tuple of the type and all following elements.

```python
from msgspec import Struct

class Point(Struct, frozen=True):
    x: int
    y: int

assert hash(Point(1, 2)) == hash((Point, 1, 2))
```

Addresses part of #591.