### PR TITLE
Add struct `cache_hash` option

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -67,6 +67,7 @@ class Struct:
         gc: bool = True,
         weakref: bool = False,
         dict: bool = False,
+        cache_hash: bool = False,
     ) -> None: ...
     def __rich_repr__(
         self,
@@ -98,6 +99,7 @@ def defstruct(
     gc: bool = True,
     weakref: bool = False,
     dict: bool = False,
+    cache_hash: bool = False,
 ) -> Type[Struct]: ...
 
 # Lie and say `Raw` is a subclass of `bytes`, so mypy will accept it in most

--- a/msgspec/structs.pyi
+++ b/msgspec/structs.pyi
@@ -19,6 +19,7 @@ class StructConfig:
     forbid_unknown_fields: bool
     weakref: bool
     dict: bool
+    cache_hash: bool
     tag: Union[str, int, None]
     tag_field: Union[str, None]
 

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -269,6 +269,15 @@ def check_struct_dict() -> None:
     reveal_type(t)  # assert "Test" in typ
 
 
+def check_struct_cache_hash() -> None:
+    class Test(msgspec.Struct, cache_hash=True):
+        x: int
+        y: str
+
+    t = Test(1, "foo")
+    reveal_type(t)  # assert "Test" in typ
+
+
 def check_struct_tag_tag_field() -> None:
     class Test1(msgspec.Struct, tag=None):
         pass
@@ -353,6 +362,7 @@ def check_struct_config() -> None:
     reveal_type(config.forbid_unknown_fields)  # assert "bool" in typ
     reveal_type(config.weakref)  # assert "bool" in typ
     reveal_type(config.dict)  # assert "bool" in typ
+    reveal_type(config.cache_hash)  # assert "bool" in typ
     reveal_type(config.tag)  # assert "str" in typ and "int" in typ
     reveal_type(config.tag_field)  # assert "str" in typ
 
@@ -406,6 +416,9 @@ def check_defstruct_config_options() -> None:
         kw_only=True,
         repr_omit_defaults=True,
         array_like=True,
+        dict=True,
+        weakref=True,
+        cache_hash=True,
         gc=False,
         tag="mytag",
         tag_field="mytagfield",

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -159,6 +159,13 @@ def test_struct_subclass_forbidden_field_names():
         class Test2(Struct):
             __dict__: int
 
+    with pytest.raises(
+        TypeError, match="Cannot have a struct field named '__msgspec_cached_hash__'"
+    ):
+
+        class Test3(Struct):
+            __msgspec_cached_hash__: int
+
 
 class TestMixins:
     def test_mixin_no_slots(self):
@@ -1423,6 +1430,56 @@ def test_dict_option():
             pass
 
 
+def test_cache_hash_option():
+    with pytest.raises(
+        ValueError, match="Cannot set cache_hash=True without frozen=True"
+    ):
+
+        class Invalid(Struct, cache_hash=True):
+            pass
+
+    class Default(Struct, frozen=True):
+        pass
+
+    assert "__msgspec_cached_hash__" not in Default.__slots__
+    assert not Default.__struct_config__.cache_hash
+
+    class Enabled(Struct, cache_hash=True, frozen=True):
+        pass
+
+    assert "__msgspec_cached_hash__" in Enabled.__slots__
+    assert Enabled.__struct_config__.cache_hash
+
+    class Disabled(Struct, cache_hash=False, frozen=True):
+        pass
+
+    assert "__msgspec_cached_hash__" not in Disabled.__slots__
+    assert not Disabled.__struct_config__.cache_hash
+
+    class T(Enabled):
+        pass
+
+    assert "__msgspec_cached_hash__" not in T.__slots__
+    assert T.__struct_config__.cache_hash
+
+    class T(Enabled, Default):
+        pass
+
+    assert "__msgspec_cached_hash__" not in T.__slots__
+    assert T.__struct_config__.cache_hash
+
+    class T(Default, Disabled, Enabled):
+        pass
+
+    assert "__msgspec_cached_hash__" not in T.__slots__
+    assert T.__struct_config__.cache_hash
+
+    with pytest.raises(ValueError, match="Cannot set `cache_hash=False`"):
+
+        class T(Enabled, cache_hash=False):
+            pass
+
+
 def test_invalid_option_raises():
     with pytest.raises(TypeError):
 
@@ -1435,12 +1492,7 @@ class FrozenPoint(Struct, frozen=True):
     y: int
 
 
-class TestSetAttr:
-    def test_frozen_objects_no_setattr(self):
-        p = FrozenPoint(1, 2)
-        with pytest.raises(AttributeError, match="immutable type: 'FrozenPoint'"):
-            p.x = 3
-
+class TestHash:
     def test_frozen_objects_hashable(self):
         p1 = FrozenPoint(1, 2)
         p2 = FrozenPoint(1, 2)
@@ -1469,6 +1521,33 @@ class TestSetAttr:
         assert hash(Ex1(1)) != hash(Ex2(1))
         assert hash(Ex3()) == hash(Ex3())
         assert hash(Ex3()) != hash(Ex4())
+
+    def test_cache_hash(self):
+        class Inner:
+            def __init__(self):
+                self.hash_calls = 0
+
+            def __hash__(self):
+                self.hash_calls += 1
+                return 123
+
+        class Cached(Struct, frozen=True, cache_hash=True):
+            x: int
+            y: Inner
+
+        assert "__msgspec_cached_hash__" in Cached.__slots__
+        obj = Cached(1, Inner())
+        assert not hasattr(obj, "__msgspec_cached_hash__")
+        assert hash(obj) == hash(obj)
+        assert obj.__msgspec_cached_hash__ == hash(obj)
+        assert obj.y.hash_calls == 1
+
+
+class TestSetAttr:
+    def test_frozen_objects_no_setattr(self):
+        p = FrozenPoint(1, 2)
+        with pytest.raises(AttributeError, match="immutable type: 'FrozenPoint'"):
+            p.x = 3
 
     @pytest.mark.parametrize("base_gc", [True, None, False])
     @pytest.mark.parametrize("base_frozen", [True, False])
@@ -2119,6 +2198,16 @@ class TestDefStruct:
         Test = defstruct("Test", [], dict=True)
         assert hasattr(Test(), "__dict__")
         assert Test.__struct_config__.dict
+
+    def test_defstruct_cache_hash(self):
+        Test = defstruct("Test", [], frozen=True)
+        assert not Test.__struct_config__.cache_hash
+
+        Test = defstruct("Test", [], frozen=True, cache_hash=False)
+        assert not Test.__struct_config__.cache_hash
+
+        Test = defstruct("Test", [], frozen=True, cache_hash=True)
+        assert Test.__struct_config__.cache_hash
 
     def test_defstruct_tag_and_tag_field(self):
         Test = defstruct("Test", [], tag=True)


### PR DESCRIPTION
If enabled, the hash value for a frozen struct instance will be computed at most once, and then stored on the instance for further reuse. For expensive hash computations this can result in improved performance at the cost of a small amount of memory use.

Fixes #591.