### PR TITLE
Fix caching of dataclass subclass info

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -3706,7 +3706,7 @@ error:
 
 static bool
 get_msgspec_cache(MsgspecState *mod, PyObject *obj, PyTypeObject *type, PyObject **out) {
-    PyObject *cached = PyObject_GetAttr(obj, mod->str___msgspec_cache__);
+    PyObject *cached = PyObject_GenericGetAttr(obj, mod->str___msgspec_cache__);
     if (cached != NULL) {
         if (Py_TYPE(cached) != type) {
             Py_DECREF(cached);

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2582,6 +2582,20 @@ class TestDataclass:
         assert dec.decode(proto.encode(msg)) == msg
         assert dec2.decode(proto.encode(msg)) == msg
 
+    def test_decode_dataclass_subclasses(self, proto):
+        @dataclass
+        class Base:
+            x: int
+
+        @dataclass
+        class Sub(Base):
+            y: int
+
+        msg = proto.encode({"x": 1, "y": 2})
+
+        assert proto.decode(msg, type=Base) == Base(1)
+        assert proto.decode(msg, type=Sub) == Sub(1, 2)
+
     def test_multiple_dataclasses_errors(self, proto):
         @dataclass
         class Ex1:


### PR DESCRIPTION
Previously our caching mechanism would do the wrong thing when accessing type info on a dataclass subclass when the base class info was already cached. This fixes that so that decoding dataclass subclasses always works properly.

Fixes #598.