### PR TITLE
Support custom dict key types in JSON

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -16529,6 +16529,9 @@ json_decode_dict_key_fallback(
         else {
             out = PyUnicode_DecodeUTF8(view, size, NULL);
         }
+        if (MS_UNLIKELY(type->types & (MS_TYPE_CUSTOM | MS_TYPE_CUSTOM_GENERIC))) {
+            return ms_decode_custom(out, self->dec_hook, type, path);
+        }
         return ms_check_str_constraints(out, type, path);
     }
     if (type->types & (

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2096,6 +2096,25 @@ class TestDict:
         msg = msgspec.json.encode({mystr("test"): 1})
         assert msg == b'{"test":1}'
 
+    def test_encode_dict_custom_key(self):
+        class Custom:
+            def __init__(self, value):
+                self.value = value
+
+        msg = msgspec.json.encode(
+            {Custom("a"): 1, Custom("b"): 2}, enc_hook=lambda x: x.value
+        )
+        assert msg == b'{"a":1,"b":2}'
+
+        def enc_hook(x):
+            raise TypeError("Oh no!")
+
+        with pytest.raises(TypeError):
+            msgspec.json.encode({Custom("x"): 1}, enc_hook=enc_hook)
+
+        with pytest.raises(RecursionError):
+            msgspec.json.encode({Custom("x"): 1}, enc_hook=lambda x: x)
+
     @pytest.mark.parametrize(
         "s, error",
         [

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2115,6 +2115,27 @@ class TestDict:
         with pytest.raises(RecursionError):
             msgspec.json.encode({Custom("x"): 1}, enc_hook=lambda x: x)
 
+    def test_decode_dict_custom_key(self):
+        class Custom:
+            def __init__(self, value):
+                self.value = value
+
+            def __hash__(self):
+                return hash(self.value)
+
+            def __eq__(self, other):
+                return self.value == other.value
+
+        def dec_hook(typ, obj):
+            if typ == Custom:
+                return Custom(obj)
+            raise NotImplementedError
+
+        msg = b'{"a":1,"b":2}'
+
+        obj = msgspec.json.decode(msg, type=Dict[Custom, int], dec_hook=dec_hook)
+        assert obj == {Custom("a"): 1, Custom("b"): 2}
+
     @pytest.mark.parametrize(
         "s, error",
         [


### PR DESCRIPTION
This adds support for encoding/decoding custom types when used as dict keys in the JSON encoder/decoder. Previously the JSON implementation failed to fallback to `enc_hook`/`dec_hook` for custom dict keys.

Fixes #568.