### PR TITLE
Pass key constraints as `propertyNames` in JSON Schema

### DIFF
--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -271,6 +271,17 @@ def _to_schema(
             schema["items"] = False
     elif isinstance(t, mi.DictType):
         schema["type"] = "object"
+        # If there are restrictions on the keys, specify them as propertyNames
+        if isinstance(key_type := t.key_type, mi.StrType):
+            property_names = {}
+            if key_type.min_length is not None:
+                property_names["minLength"] = key_type.min_length
+            if key_type.max_length is not None:
+                property_names["maxLength"] = key_type.max_length
+            if key_type.pattern is not None:
+                property_names["pattern"] = key_type.pattern
+            if property_names:
+                schema["propertyNames"] = property_names
         if not isinstance(t.value_type, mi.AnyType):
             schema["additionalProperties"] = _to_schema(
                 t.value_type, name_map, ref_template

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1073,6 +1073,23 @@ def test_string_metadata(field, val, constraint):
     assert msgspec.json.schema(typ) == {"type": "string", constraint: val}
 
 
+@pytest.mark.parametrize(
+    "field, val, constraint",
+    [
+        ("pattern", "[a-z]*", "pattern"),
+        ("min_length", 0, "minLength"),
+        ("max_length", 3, "maxLength"),
+    ],
+)
+def test_dict_key_metadata(field, val, constraint):
+    typ = Annotated[str, Meta(**{field: val})]
+    assert msgspec.json.schema(Dict[typ, int]) == {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+        "propertyNames": {constraint: val},
+    }
+
+
 @pytest.mark.parametrize("typ", [bytes, bytearray])
 @pytest.mark.parametrize(
     "field, n, constraint",


### PR DESCRIPTION
This adds support for publicizing constraints on dict keys using the `propertyNames` field when generating a JSON Schema. For now this is only done for dicts with string keys; constraints on other key types are trickier to specify.

Supersedes #576.