### PR TITLE
Add a `schema_hook` for generating JSON schemas

### DIFF
--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import re
 import textwrap
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Optional, Callable
 
 from . import inspect as mi, to_builtins
 
 __all__ = ("schema", "schema_components")
 
 
-def schema(type: Any) -> dict[str, Any]:
+def schema(
+    type: Any, *, schema_hook: Optional[Callable[[type], dict[str, Any]]] = None
+) -> dict[str, Any]:
     """Generate a JSON Schema for a given type.
 
     Any schemas for (potentially) shared components are extracted and stored in
@@ -23,6 +25,10 @@ def schema(type: Any) -> dict[str, Any]:
     ----------
     type : type
         The type to generate the schema for.
+    schema_hook : callable, optional
+        An optional callback to use for generating JSON schemas of custom
+        types. Will be called with the custom type, and should return a dict
+        representation of the JSON schema for that type.
 
     Returns
     -------
@@ -33,14 +39,17 @@ def schema(type: Any) -> dict[str, Any]:
     --------
     schema_components
     """
-    (out,), components = schema_components((type,))
+    (out,), components = schema_components((type,), schema_hook=schema_hook)
     if components:
         out["$defs"] = components
     return out
 
 
 def schema_components(
-    types: Iterable[Any], ref_template: str = "#/$defs/{name}"
+    types: Iterable[Any],
+    *,
+    schema_hook: Optional[Callable[[type], dict[str, Any]]] = None,
+    ref_template: str = "#/$defs/{name}",
 ) -> tuple[tuple[dict[str, Any], ...], dict[str, Any]]:
     """Generate JSON Schemas for one or more types.
 
@@ -51,6 +60,10 @@ def schema_components(
     ----------
     types : Iterable[type]
         An iterable of one or more types to generate schemas for.
+    schema_hook : callable, optional
+        An optional callback to use for generating JSON schemas of custom
+        types. Will be called with the custom type, and should return a dict
+        representation of the JSON schema for that type.
     ref_template : str, optional
         A template to use when generating ``"$ref"`` fields. This template is
         formatted with the type name as ``template.format(name=name)``. This
@@ -77,11 +90,12 @@ def schema_components(
 
     name_map = _build_name_map(component_types)
 
-    schemas = tuple(_to_schema(t, name_map, ref_template) for t in type_infos)
+    gen = _SchemaGenerator(name_map, schema_hook, ref_template)
+
+    schemas = tuple(gen.to_schema(t) for t in type_infos)
 
     components = {
-        name_map[cls]: _to_schema(t, name_map, ref_template, check_ref=False)
-        for cls, t in component_types.items()
+        name_map[cls]: gen.to_schema(t, False) for cls, t in component_types.items()
     }
     return schemas, components
 
@@ -183,232 +197,243 @@ def _build_name_map(component_types: dict[Any, mi.Type]) -> dict[Any, str]:
     return {v: k for k, v in names.items()}
 
 
-def _to_schema(
-    t: mi.Type, name_map: dict[Any, str], ref_template: str, check_ref: bool = True
-) -> dict[str, Any]:
-    """Converts a Type to a json-schema."""
-    schema: dict[str, Any] = {}
+class _SchemaGenerator:
+    def __init__(
+        self,
+        name_map: dict[Any, str],
+        schema_hook: Optional[Callable[[type], dict[str, Any]]] = None,
+        ref_template: str = "#/$defs/{name}",
+    ):
+        self.name_map = name_map
+        self.schema_hook = schema_hook
+        self.ref_template = ref_template
 
-    while isinstance(t, mi.Metadata):
-        schema = mi._merge_json(schema, t.extra_json_schema)
-        t = t.type
+    def to_schema(self, t: mi.Type, check_ref: bool = True) -> dict[str, Any]:
+        """Converts a Type to a json-schema."""
+        schema: dict[str, Any] = {}
 
-    if check_ref and hasattr(t, "cls"):
-        if name := name_map.get(t.cls):
-            schema["$ref"] = ref_template.format(name=name)
-            return schema
+        while isinstance(t, mi.Metadata):
+            schema = mi._merge_json(schema, t.extra_json_schema)
+            t = t.type
 
-    if isinstance(t, (mi.AnyType, mi.RawType)):
-        pass
-    elif isinstance(t, mi.NoneType):
-        schema["type"] = "null"
-    elif isinstance(t, mi.BoolType):
-        schema["type"] = "boolean"
-    elif isinstance(t, (mi.IntType, mi.FloatType)):
-        schema["type"] = "integer" if isinstance(t, mi.IntType) else "number"
-        if t.ge is not None:
-            schema["minimum"] = t.ge
-        if t.gt is not None:
-            schema["exclusiveMinimum"] = t.gt
-        if t.le is not None:
-            schema["maximum"] = t.le
-        if t.lt is not None:
-            schema["exclusiveMaximum"] = t.lt
-        if t.multiple_of is not None:
-            schema["multipleOf"] = t.multiple_of
-    elif isinstance(t, mi.StrType):
-        schema["type"] = "string"
-        if t.max_length is not None:
-            schema["maxLength"] = t.max_length
-        if t.min_length is not None:
-            schema["minLength"] = t.min_length
-        if t.pattern is not None:
-            schema["pattern"] = t.pattern
-    elif isinstance(t, (mi.BytesType, mi.ByteArrayType)):
-        schema["type"] = "string"
-        schema["contentEncoding"] = "base64"
-        if t.max_length is not None:
-            schema["maxLength"] = 4 * ((t.max_length + 2) // 3)
-        if t.min_length is not None:
-            schema["minLength"] = 4 * ((t.min_length + 2) // 3)
-    elif isinstance(t, mi.DateTimeType):
-        schema["type"] = "string"
-        if t.tz is True:
-            schema["format"] = "date-time"
-    elif isinstance(t, mi.TimeType):
-        schema["type"] = "string"
-        if t.tz is True:
-            schema["format"] = "time"
-        elif t.tz is False:
-            schema["format"] = "partial-time"
-    elif isinstance(t, mi.DateType):
-        schema["type"] = "string"
-        schema["format"] = "date"
-    elif isinstance(t, mi.TimeDeltaType):
-        schema["type"] = "string"
-        schema["format"] = "duration"
-    elif isinstance(t, mi.UUIDType):
-        schema["type"] = "string"
-        schema["format"] = "uuid"
-    elif isinstance(t, mi.DecimalType):
-        schema["type"] = "string"
-        schema["format"] = "decimal"
-    elif isinstance(t, mi.CollectionType):
-        schema["type"] = "array"
-        if not isinstance(t.item_type, mi.AnyType):
-            schema["items"] = _to_schema(t.item_type, name_map, ref_template)
-        if t.max_length is not None:
-            schema["maxItems"] = t.max_length
-        if t.min_length is not None:
-            schema["minItems"] = t.min_length
-    elif isinstance(t, mi.TupleType):
-        schema["type"] = "array"
-        schema["minItems"] = schema["maxItems"] = len(t.item_types)
-        if t.item_types:
-            schema["prefixItems"] = [
-                _to_schema(i, name_map, ref_template) for i in t.item_types
-            ]
-            schema["items"] = False
-    elif isinstance(t, mi.DictType):
-        schema["type"] = "object"
-        # If there are restrictions on the keys, specify them as propertyNames
-        if isinstance(key_type := t.key_type, mi.StrType):
-            property_names = {}
-            if key_type.min_length is not None:
-                property_names["minLength"] = key_type.min_length
-            if key_type.max_length is not None:
-                property_names["maxLength"] = key_type.max_length
-            if key_type.pattern is not None:
-                property_names["pattern"] = key_type.pattern
-            if property_names:
-                schema["propertyNames"] = property_names
-        if not isinstance(t.value_type, mi.AnyType):
-            schema["additionalProperties"] = _to_schema(
-                t.value_type, name_map, ref_template
-            )
-        if t.max_length is not None:
-            schema["maxProperties"] = t.max_length
-        if t.min_length is not None:
-            schema["minProperties"] = t.min_length
-    elif isinstance(t, mi.UnionType):
-        structs = {}
-        other = []
-        tag_field = None
-        for subtype in t.types:
-            real_type = subtype
-            while isinstance(real_type, mi.Metadata):
-                real_type = real_type.type
-            if isinstance(real_type, mi.StructType) and not real_type.array_like:
-                tag_field = real_type.tag_field
-                structs[real_type.tag] = real_type
-            else:
-                other.append(subtype)
+        if check_ref and hasattr(t, "cls"):
+            if name := self.name_map.get(t.cls):
+                schema["$ref"] = self.ref_template.format(name=name)
+                return schema
 
-        options = [_to_schema(a, name_map, ref_template) for a in other]
+        if isinstance(t, (mi.AnyType, mi.RawType)):
+            pass
+        elif isinstance(t, mi.NoneType):
+            schema["type"] = "null"
+        elif isinstance(t, mi.BoolType):
+            schema["type"] = "boolean"
+        elif isinstance(t, (mi.IntType, mi.FloatType)):
+            schema["type"] = "integer" if isinstance(t, mi.IntType) else "number"
+            if t.ge is not None:
+                schema["minimum"] = t.ge
+            if t.gt is not None:
+                schema["exclusiveMinimum"] = t.gt
+            if t.le is not None:
+                schema["maximum"] = t.le
+            if t.lt is not None:
+                schema["exclusiveMaximum"] = t.lt
+            if t.multiple_of is not None:
+                schema["multipleOf"] = t.multiple_of
+        elif isinstance(t, mi.StrType):
+            schema["type"] = "string"
+            if t.max_length is not None:
+                schema["maxLength"] = t.max_length
+            if t.min_length is not None:
+                schema["minLength"] = t.min_length
+            if t.pattern is not None:
+                schema["pattern"] = t.pattern
+        elif isinstance(t, (mi.BytesType, mi.ByteArrayType)):
+            schema["type"] = "string"
+            schema["contentEncoding"] = "base64"
+            if t.max_length is not None:
+                schema["maxLength"] = 4 * ((t.max_length + 2) // 3)
+            if t.min_length is not None:
+                schema["minLength"] = 4 * ((t.min_length + 2) // 3)
+        elif isinstance(t, mi.DateTimeType):
+            schema["type"] = "string"
+            if t.tz is True:
+                schema["format"] = "date-time"
+        elif isinstance(t, mi.TimeType):
+            schema["type"] = "string"
+            if t.tz is True:
+                schema["format"] = "time"
+            elif t.tz is False:
+                schema["format"] = "partial-time"
+        elif isinstance(t, mi.DateType):
+            schema["type"] = "string"
+            schema["format"] = "date"
+        elif isinstance(t, mi.TimeDeltaType):
+            schema["type"] = "string"
+            schema["format"] = "duration"
+        elif isinstance(t, mi.UUIDType):
+            schema["type"] = "string"
+            schema["format"] = "uuid"
+        elif isinstance(t, mi.DecimalType):
+            schema["type"] = "string"
+            schema["format"] = "decimal"
+        elif isinstance(t, mi.CollectionType):
+            schema["type"] = "array"
+            if not isinstance(t.item_type, mi.AnyType):
+                schema["items"] = self.to_schema(t.item_type)
+            if t.max_length is not None:
+                schema["maxItems"] = t.max_length
+            if t.min_length is not None:
+                schema["minItems"] = t.min_length
+        elif isinstance(t, mi.TupleType):
+            schema["type"] = "array"
+            schema["minItems"] = schema["maxItems"] = len(t.item_types)
+            if t.item_types:
+                schema["prefixItems"] = [self.to_schema(i) for i in t.item_types]
+                schema["items"] = False
+        elif isinstance(t, mi.DictType):
+            schema["type"] = "object"
+            # If there are restrictions on the keys, specify them as propertyNames
+            if isinstance(key_type := t.key_type, mi.StrType):
+                property_names: dict[str, Any] = {}
+                if key_type.min_length is not None:
+                    property_names["minLength"] = key_type.min_length
+                if key_type.max_length is not None:
+                    property_names["maxLength"] = key_type.max_length
+                if key_type.pattern is not None:
+                    property_names["pattern"] = key_type.pattern
+                if property_names:
+                    schema["propertyNames"] = property_names
+            if not isinstance(t.value_type, mi.AnyType):
+                schema["additionalProperties"] = self.to_schema(t.value_type)
+            if t.max_length is not None:
+                schema["maxProperties"] = t.max_length
+            if t.min_length is not None:
+                schema["minProperties"] = t.min_length
+        elif isinstance(t, mi.UnionType):
+            structs = {}
+            other = []
+            tag_field = None
+            for subtype in t.types:
+                real_type = subtype
+                while isinstance(real_type, mi.Metadata):
+                    real_type = real_type.type
+                if isinstance(real_type, mi.StructType) and not real_type.array_like:
+                    tag_field = real_type.tag_field
+                    structs[real_type.tag] = real_type
+                else:
+                    other.append(subtype)
 
-        if len(structs) >= 2:
-            mapping = {
-                k: ref_template.format(name=name_map[v.cls]) for k, v in structs.items()
-            }
-            struct_schema = {
-                "anyOf": [
-                    _to_schema(v, name_map, ref_template) for v in structs.values()
-                ],
-                "discriminator": {"propertyName": tag_field, "mapping": mapping},
-            }
-            if options:
-                options.append(struct_schema)
+            options = [self.to_schema(a) for a in other]
+
+            if len(structs) >= 2:
+                mapping = {
+                    k: self.ref_template.format(name=self.name_map[v.cls])
+                    for k, v in structs.items()
+                }
+                struct_schema = {
+                    "anyOf": [self.to_schema(v) for v in structs.values()],
+                    "discriminator": {"propertyName": tag_field, "mapping": mapping},
+                }
+                if options:
+                    options.append(struct_schema)
+                    schema["anyOf"] = options
+                else:
+                    schema.update(struct_schema)
+            elif len(structs) == 1:
+                _, subtype = structs.popitem()
+                options.append(self.to_schema(subtype))
                 schema["anyOf"] = options
             else:
-                schema.update(struct_schema)
-        elif len(structs) == 1:
-            _, subtype = structs.popitem()
-            options.append(_to_schema(subtype, name_map, ref_template))
-            schema["anyOf"] = options
-        else:
-            schema["anyOf"] = options
-    elif isinstance(t, mi.LiteralType):
-        schema["enum"] = sorted(t.values)
-    elif isinstance(t, mi.EnumType):
-        schema.setdefault("title", t.cls.__name__)
-        if doc := _get_doc(t):
-            schema.setdefault("description", doc)
-        schema["enum"] = sorted(e.value for e in t.cls)
-    elif isinstance(t, mi.StructType):
-        schema.setdefault("title", _get_class_name(t.cls))
-        if doc := _get_doc(t):
-            schema.setdefault("description", doc)
-        required = []
-        names = []
-        fields = []
+                schema["anyOf"] = options
+        elif isinstance(t, mi.LiteralType):
+            schema["enum"] = sorted(t.values)
+        elif isinstance(t, mi.EnumType):
+            schema.setdefault("title", t.cls.__name__)
+            if doc := _get_doc(t):
+                schema.setdefault("description", doc)
+            schema["enum"] = sorted(e.value for e in t.cls)
+        elif isinstance(t, mi.StructType):
+            schema.setdefault("title", _get_class_name(t.cls))
+            if doc := _get_doc(t):
+                schema.setdefault("description", doc)
+            required = []
+            names = []
+            fields = []
 
-        if t.tag_field is not None:
-            required.append(t.tag_field)
-            names.append(t.tag_field)
-            fields.append({"enum": [t.tag]})
+            if t.tag_field is not None:
+                required.append(t.tag_field)
+                names.append(t.tag_field)
+                fields.append({"enum": [t.tag]})
 
-        for field in t.fields:
-            field_schema = _to_schema(field.type, name_map, ref_template)
-            if field.required:
-                required.append(field.encode_name)
-            elif field.default is not mi.NODEFAULT:
-                field_schema["default"] = to_builtins(field.default, str_keys=True)
-            elif field.default_factory in (list, dict, set, bytearray):
-                field_schema["default"] = field.default_factory()
-            names.append(field.encode_name)
-            fields.append(field_schema)
+            for field in t.fields:
+                field_schema = self.to_schema(field.type)
+                if field.required:
+                    required.append(field.encode_name)
+                elif field.default is not mi.NODEFAULT:
+                    field_schema["default"] = to_builtins(field.default, str_keys=True)
+                elif field.default_factory in (list, dict, set, bytearray):
+                    field_schema["default"] = field.default_factory()
+                names.append(field.encode_name)
+                fields.append(field_schema)
 
-        if t.array_like:
-            n_trailing_defaults = 0
-            for n_trailing_defaults, f in enumerate(reversed(t.fields)):
-                if f.required:
-                    break
-            schema["type"] = "array"
-            schema["prefixItems"] = fields
-            schema["minItems"] = len(fields) - n_trailing_defaults
-            if t.forbid_unknown_fields:
+            if t.array_like:
+                n_trailing_defaults = 0
+                for n_trailing_defaults, f in enumerate(reversed(t.fields)):
+                    if f.required:
+                        break
+                schema["type"] = "array"
+                schema["prefixItems"] = fields
+                schema["minItems"] = len(fields) - n_trailing_defaults
+                if t.forbid_unknown_fields:
+                    schema["maxItems"] = len(fields)
+            else:
+                schema["type"] = "object"
+                schema["properties"] = dict(zip(names, fields))
+                schema["required"] = required
+                if t.forbid_unknown_fields:
+                    schema["additionalProperties"] = False
+        elif isinstance(t, (mi.TypedDictType, mi.DataclassType, mi.NamedTupleType)):
+            schema.setdefault("title", _get_class_name(t.cls))
+            if doc := _get_doc(t):
+                schema.setdefault("description", doc)
+            names = []
+            fields = []
+            required = []
+            for field in t.fields:
+                field_schema = self.to_schema(field.type)
+                if field.required:
+                    required.append(field.encode_name)
+                elif field.default is not mi.NODEFAULT:
+                    field_schema["default"] = to_builtins(field.default, str_keys=True)
+                names.append(field.encode_name)
+                fields.append(field_schema)
+            if isinstance(t, mi.NamedTupleType):
+                schema["type"] = "array"
+                schema["prefixItems"] = fields
+                schema["minItems"] = len(required)
                 schema["maxItems"] = len(fields)
+            else:
+                schema["type"] = "object"
+                schema["properties"] = dict(zip(names, fields))
+                schema["required"] = required
+        elif isinstance(t, mi.ExtType):
+            raise TypeError("json-schema doesn't support msgpack Ext types")
+        elif isinstance(t, mi.CustomType):
+            if self.schema_hook:
+                try:
+                    schema = mi._merge_json(self.schema_hook(t.cls), schema)
+                except NotImplementedError:
+                    pass
+            if not schema:
+                raise TypeError(
+                    "Generating JSON schema for custom types requires either:\n"
+                    "- specifying a `schema_hook`\n"
+                    "- annotating the type with `Meta(extra_json_schema=...)`\n"
+                    "\n"
+                    f"type {t.cls!r} is not supported"
+                )
         else:
-            schema["type"] = "object"
-            schema["properties"] = dict(zip(names, fields))
-            schema["required"] = required
-            if t.forbid_unknown_fields:
-                schema["additionalProperties"] = False
-    elif isinstance(t, (mi.TypedDictType, mi.DataclassType, mi.NamedTupleType)):
-        schema.setdefault("title", _get_class_name(t.cls))
-        if doc := _get_doc(t):
-            schema.setdefault("description", doc)
-        names = []
-        fields = []
-        required = []
-        for field in t.fields:
-            field_schema = _to_schema(field.type, name_map, ref_template)
-            if field.required:
-                required.append(field.encode_name)
-            elif field.default is not mi.NODEFAULT:
-                field_schema["default"] = to_builtins(field.default, str_keys=True)
-            names.append(field.encode_name)
-            fields.append(field_schema)
-        if isinstance(t, mi.NamedTupleType):
-            schema["type"] = "array"
-            schema["prefixItems"] = fields
-            schema["minItems"] = len(required)
-            schema["maxItems"] = len(fields)
-        else:
-            schema["type"] = "object"
-            schema["properties"] = dict(zip(names, fields))
-            schema["required"] = required
-    elif isinstance(t, mi.ExtType):
-        raise TypeError("json-schema doesn't support msgpack Ext types")
-    elif isinstance(t, mi.CustomType):
-        if not schema:
-            raise TypeError(
-                "Custom types currently require a schema be explicitly provided "
-                "by annotating the type with `Meta(extra_json_schema=...)` - type "
-                f"{t.cls!r} is not supported"
-            )
-    else:
-        # This should be unreachable
-        raise TypeError(f"json-schema doesn't support type {t!r}")
+            # This should be unreachable
+            raise TypeError(f"json-schema doesn't support type {t!r}")
 
-    return schema
+        return schema

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -19,6 +19,7 @@ T = TypeVar("T")
 enc_hook_sig = Optional[Callable[[Any], Any]]
 dec_hook_sig = Optional[Callable[[type, Any], Any]]
 float_hook_sig = Optional[Callable[[str], Any]]
+schema_hook_sig = Optional[Callable[[type], dict[str, Any]]]
 
 class Encoder:
     enc_hook: enc_hook_sig
@@ -97,9 +98,12 @@ def decode(
     dec_hook: dec_hook_sig = None,
 ) -> Any: ...
 def encode(obj: Any, *, enc_hook: enc_hook_sig = None) -> bytes: ...
-def schema(type: Any) -> Dict[str, Any]: ...
+def schema(type: Any, *, schema_hook: schema_hook_sig = None) -> Dict[str, Any]: ...
 def schema_components(
-    types: Iterable[Any], ref_template: str = "#/$defs/{name}"
+    types: Iterable[Any],
+    *,
+    schema_hook: schema_hook_sig = None,
+    ref_template: str = "#/$defs/{name}"
 ) -> Tuple[Tuple[Dict[str, Any], ...], Dict[str, Any]]: ...
 @overload
 def format(buf: str, *, indent: int = 2) -> str: ...

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -1025,20 +1025,27 @@ def check_consume_inspect_types() -> None:
 
 
 def check_json_schema() -> None:
-    o = msgspec.json.schema(List[int])
-    reveal_type(o)  # assert ("Dict" in typ or "dict" in typ)
+    o1 = msgspec.json.schema(List[int])
+    reveal_type(o1)  # assert ("Dict" in typ or "dict" in typ)
+
+    o2 = msgspec.json.schema(List[int], schema_hook=lambda t: {"type": "object"})
+    reveal_type(o2)  # assert ("Dict" in typ or "dict" in typ)
 
 
 def check_json_schema_components() -> None:
-    s, c = msgspec.json.schema_components([List[int]])
-    reveal_type(s)  # assert ("dict" in typ.lower()) and ("tuple" in typ.lower())
-    reveal_type(c)  # assert ("dict" in typ.lower())
+    s1, c1 = msgspec.json.schema_components([List[int]])
+    reveal_type(s1)  # assert ("dict" in typ.lower()) and ("tuple" in typ.lower())
+    reveal_type(c1)  # assert ("dict" in typ.lower())
 
+    s2, c2 = msgspec.json.schema_components([List[int]], ref_template="#/definitions/{name}")
+    reveal_type(s2)  # assert ("dict" in typ.lower()) and ("tuple" in typ.lower())
+    reveal_type(c2)  # assert ("dict" in typ.lower())
 
-def check_json_schema_components_full() -> None:
-    s, c = msgspec.json.schema_components([List[int]], ref_template="#/definitions/{name}")
-    reveal_type(s)  # assert ("dict" in typ.lower()) and ("tuple" in typ.lower())
-    reveal_type(c)  # assert ("dict" in typ.lower())
+    s3, c3 = msgspec.json.schema_components(
+        [List[int]], schema_hook=lambda t: {"type": "object"}
+    )
+    reveal_type(s3)  # assert ("dict" in typ.lower()) and ("tuple" in typ.lower())
+    reveal_type(c3)  # assert ("dict" in typ.lower())
 
 
 ##########################################################


### PR DESCRIPTION
Previously custom types needed to be annotated with `Meta(extra_json_schema=...)` to be supported in `msgspec.json.schema`. This adds a new `schema_hook` which supports generating json schemas for custom types without requiring an extra annotation.