### PR TITLE
Add support for Python 3.12's `type` aliases

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -49,6 +49,8 @@ Most combinations of the following types are supported (with a few restrictions)
 - `typing.Literal`
 - `typing.NewType`
 - `typing.Final`
+- `typing.TypeAliasType`
+- `typing.TypeAlias`
 - `typing.NamedTuple` / `collections.namedtuple`
 - `typing.TypedDict`
 - `typing.Generic`
@@ -1169,6 +1171,36 @@ support here is purely to aid static analysis tools like mypy_ or pyright_.
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `int`, got `str`
+
+Type Aliases
+------------
+
+For complex types, sometimes it can be nice to write the type once so you can
+reuse it later.
+
+.. code-block:: python
+
+    Point = tuple[float, float]
+
+Here ``Point`` is a "type alias" for ``tuple[float, float]`` - ``msgspec``
+will substitute in ``tuple[float, float]`` whenever the ``Point`` type
+is used in an annotation.
+
+``msgspec`` supports the following equivalent forms:
+
+.. code-block:: python
+
+    # Using variable assignment
+    Point = tuple[float, float]
+
+    # Using variable assignment, annotated as a `TypeAlias`
+    Point: TypeAlias = tuple[float, float]
+
+    # Using Python 3.12's new `type` statement. This only works on Python 3.12+
+    type Point = tuple[float, float]
+
+To learn more about Type Aliases, see Python's `Type Alias docs here
+<https://docs.python.org/3/library/typing.html#type-aliases>`__.
 
 Generic Types
 -------------

--- a/msgspec/inspect.py
+++ b/msgspec/inspect.py
@@ -20,6 +20,11 @@ try:
 except Exception:
     _types_UnionType = type("UnionType", (), {})  # type: ignore
 
+try:
+    from typing import TypeAliasType as _TypeAliasType  # type: ignore
+except Exception:
+    _TypeAliasType = type("TypeAliasType", (), {})  # type: ignore
+
 import msgspec
 from msgspec import NODEFAULT, UNSET, UnsetType as _UnsetType
 
@@ -628,6 +633,8 @@ def _origin_args_metadata(t):
                 t = origin
             elif origin == Final:
                 t = t.__args__[0]
+            elif type(origin) is _TypeAliasType:
+                t = origin.__value__[t.__args__]
             else:
                 args = getattr(t, "__args__", None)
                 origin = _CONCRETE_TYPES.get(origin, origin)
@@ -636,6 +643,8 @@ def _origin_args_metadata(t):
             supertype = getattr(t, "__supertype__", None)
             if supertype is not None:
                 t = supertype
+            elif type(t) is _TypeAliasType:
+                t = t.__value__
             else:
                 origin = t
                 args = None

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1032,11 +1032,17 @@ class TestSequences:
             for _ in range(depth):
                 typ = FrozenSet[typ]
 
-        msg = []
-        msg.append(msg)
+        class Cache(Struct):
+            value: typ
+
+        msgspec.json.Decoder(Cache)
+
+        arr = []
+        arr.append(arr)
+        msg = {"value": arr}
         with pytest.raises(RecursionError):
             with max_call_depth(5):
-                assert convert(msg, typ)
+                convert(msg, Cache)
 
     @pytest.mark.parametrize("out_type", [list, tuple, set, frozenset])
     @uses_annotated
@@ -1246,11 +1252,19 @@ class TestDict:
         typ = Dict[str, int]
         for _ in range(depth):
             typ = Dict[str, typ]
-        msg = dictcls()
-        msg["x"] = msg
+
+        class Cache(Struct):
+            value: typ
+
+        msgspec.json.Decoder(Cache)
+
+        map = dictcls()
+        map["x"] = map
+        msg = {"value": map}
+
         with pytest.raises(RecursionError):
             with max_call_depth(5):
-                assert convert(msg, typ)
+                convert(msg, Cache)
 
     @uses_annotated
     def test_dict_constrs(self, dictcls):


### PR DESCRIPTION
This adds support for the new syntactic type aliases added in Python 3.12. A few examples:

```
type NullableStr = str | None

type Pair[T] = tuple[T, T]

type NullableStrPair = Pair[NullableStr]
```

msgspec now supports these type aliases, *except* in cases where the type alias is recursive. For example, the following type isn't supported:

```
type Link[T] = tuple[T, Link[T] | None]
```

The internal datastructure we use to store type information was not designed to handle recursive types like these; supporting them will require a larger refactor.

Fixes #579.