### PR TITLE
Support coercing float to int if `strict=False`

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -151,12 +151,16 @@ Support for large integers varies by protocol:
     123
 
 If ``strict=False`` is specified, string values may also be coerced to
-integers, following the same restrictions as above. See :ref:`strict-vs-lax`
-for more information.
+integers, following the same restrictions as above. Likewise floats that have
+an exact integer representation (i.e. no decimal component) may also be coerced
+as integers. See :ref:`strict-vs-lax` for more information.
 
 .. code-block:: python
 
    >>> msgspec.json.decode(b'"123"', type=int, strict=False)
+   123
+
+   >>> msgspec.json.decode(b'123.0', type=int, strict=False)
    123
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4066,9 +4066,20 @@ class TestLax:
             msg = proto.encode(x)
             assert proto.decode(msg, type=int, strict=False) == int(x)
 
-        for x in ["a", "1a", "1.0", "1.."]:
+        for x in ["a", "1a", "1.5", "1..", "nan", "inf"]:
             msg = proto.encode(x)
             with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
+                proto.decode(msg, type=int, strict=False)
+
+    def test_lax_int_from_float(self, proto):
+        bound = float(1 << 53)
+        for x in [-bound, -1.0, -0.0, 0.0, 1.0, bound]:
+            msg = proto.encode(x)
+            assert proto.decode(msg, type=int, strict=False) == int(x)
+
+        for x in [-bound - 2, -1.5, 0.001, 1.5, bound + 2]:
+            msg = proto.encode(x)
+            with pytest.raises(ValidationError, match="Expected `int`, got `float`"):
                 proto.decode(msg, type=int, strict=False)
 
     def test_lax_int_constr(self, proto, Annotated):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2316,12 +2316,21 @@ class TestLax:
             with pytest.raises(ValidationError, match=f"Expected `bool`, got `{typ}`"):
                 assert convert(x, bool, strict=False)
 
-    def test_lax_int(self):
-        for x in ["1", "-1", "123456"]:
+    def test_lax_int_from_str(self):
+        for x in ["1", "-1", "123456", "1.0"]:
+            assert convert(x, int, strict=False) == int(float(x))
+
+        for x in ["a", "1a", "1.5", "1..", "nan", "inf"]:
+            with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
+                convert(x, int, strict=False)
+
+    def test_lax_int_from_float(self):
+        bound = float(1 << 53)
+        for x in [-bound, -1.0, -0.0, 0.0, 1.0, bound]:
             assert convert(x, int, strict=False) == int(x)
 
-        for x in ["a", "1a", "1.0", "1.."]:
-            with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
+        for x in [-bound - 2, -1.5, 0.001, 1.5, bound + 2, float("inf"), float("nan")]:
+            with pytest.raises(ValidationError, match="Expected `int`, got `float`"):
                 convert(x, int, strict=False)
 
     @uses_annotated


### PR DESCRIPTION
This adds a path for coercing floats to ints if `strict=False`, provided the float has an exact integral representation.

```python
>>> import msgspec

>>> msgspec.convert(1.0, int, strict=False)
1

>>> msgspec.convert(1.5, int, strict=False)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
msgspec.ValidationError: Expected `int`, got `float`
```

Fixes #613.