### PR TITLE
feat: support deserializing to memoryview

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -150,6 +150,7 @@ Inspect
 .. autoclass:: StrType
 .. autoclass:: BytesType
 .. autoclass:: ByteArrayType
+.. autoclass:: MemoryViewType
 .. autoclass:: DateTimeType
 .. autoclass:: TimeType
 .. autoclass:: DateType

--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -244,6 +244,23 @@ Bytes-like objects map to base64-encoded strings in JSON, YAML, and TOML. The
     >>> msgspec.json.decode(msg, type=bytearray)
     bytearray(b'\xf0\x9d\x84\x9e')
 
+
+.. note::
+
+    For the ``msgpack`` protocol, `memoryview` objects will be decoded as
+    direct views into the larger buffer containing the input message being
+    decoded. This may be useful for implementing efficient zero-copy handling
+    of large binary messages, but is also a potential footgun. As long as a
+    decoded ``memoryview`` remains in memory, the input message buffer will
+    also be persisted, potentially resulting in unnecessarily large memory
+    usage. The usage of ``memoryview`` types in this manner is considered an
+    advanced topic, and should only be used when you know their usage will
+    result in a performance benefit.
+
+    For all other protocols `memoryview` objects will still result in a copy,
+    and will likely be slightly slower than decoding into a `bytes` object
+
+
 ``datetime``
 ------------
 

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -2525,6 +2525,7 @@ static PyTypeObject Field_Type = {
 #define MS_TYPE_TYPEDDICT           (1ull << 32)
 #define MS_TYPE_DATACLASS           (1ull << 33)
 #define MS_TYPE_NAMEDTUPLE          (1ull << 34)
+#define MS_TYPE_MEMORYVIEW          (1ull << 35)
 /* Constraints */
 #define MS_CONSTR_INT_MIN           (1ull << 42)
 #define MS_CONSTR_INT_MAX           (1ull << 43)
@@ -4621,6 +4622,10 @@ typenode_collect_type(TypeNodeCollectState *state, PyObject *obj) {
     }
     else if (t == (PyObject *)(&PyByteArray_Type)) {
         state->types |= MS_TYPE_BYTEARRAY;
+        kind = CK_BYTES;
+    }
+    else if (t == (PyObject *)(&PyMemoryView_Type)) {
+        state->types |= MS_TYPE_MEMORYVIEW;
         kind = CK_BYTES;
     }
     else if (t == (PyObject *)(PyDateTimeAPI->DateTimeType)) {
@@ -14463,6 +14468,9 @@ mpack_decode_bin(
     }
     else if (type->types & MS_TYPE_UUID) {
         return ms_decode_uuid_from_bytes(s, size, path);
+    }
+    else if (type->types & MS_TYPE_MEMORYVIEW) {
+        return PyMemoryView_FromMemory(s, size, PyBUF_READ);
     }
 
     return ms_validation_error("bytes", type, path);

--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -247,7 +247,7 @@ class _SchemaGenerator:
                 schema["minLength"] = t.min_length
             if t.pattern is not None:
                 schema["pattern"] = t.pattern
-        elif isinstance(t, (mi.BytesType, mi.ByteArrayType)):
+        elif isinstance(t, (mi.BytesType, mi.ByteArrayType, mi.MemoryViewType)):
             schema["type"] = "string"
             schema["contentEncoding"] = "base64"
             if t.max_length is not None:

--- a/msgspec/inspect.py
+++ b/msgspec/inspect.py
@@ -53,6 +53,7 @@ __all__ = (
     "StrType",
     "BytesType",
     "ByteArrayType",
+    "MemoryViewType",
     "DateTimeType",
     "TimeType",
     "DateType",
@@ -207,6 +208,23 @@ class BytesType(Type):
 
 class ByteArrayType(Type):
     """A type corresponding to `bytearray`.
+
+    Parameters
+    ----------
+    min_length: int, optional
+        If set, an instance of this type must have length greater than or equal
+        to ``min_length``.
+    max_length: int, optional
+        If set, an instance of this type must have length less than or equal
+        to ``max_length``.
+    """
+
+    min_length: Union[int, None] = None
+    max_length: Union[int, None] = None
+
+
+class MemoryViewType(Type):
+    """A type corresponding to `memoryview`.
 
     Parameters
     ----------
@@ -803,6 +821,8 @@ class _Translator:
             return BytesType(min_length=min_length, max_length=max_length)
         elif t is bytearray:
             return ByteArrayType(min_length=min_length, max_length=max_length)
+        elif t is memoryview:
+            return MemoryViewType(min_length=min_length, max_length=max_length)
         elif t is datetime.datetime:
             return DateTimeType(tz=tz)
         elif t is datetime.time:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -660,7 +660,7 @@ class TestTimeConstraints:
 
 
 class TestBytesConstraints:
-    @pytest.mark.parametrize("typ", [bytes, bytearray])
+    @pytest.mark.parametrize("typ", [bytes, bytearray, memoryview])
     def test_min_length(self, proto, typ):
         class Ex(msgspec.Struct):
             x: Annotated[typ, Meta(min_length=2)]
@@ -668,14 +668,14 @@ class TestBytesConstraints:
         dec = proto.Decoder(Ex)
 
         for x in [b"xx", b"xxx"]:
-            assert dec.decode(proto.encode(Ex(x))).x == x
+            assert bytes(dec.decode(proto.encode(Ex(x))).x) == x
 
         err_msg = r"Expected `bytes` of length >= 2 - at `\$.x`"
         for x in [b"", b"x"]:
             with pytest.raises(msgspec.ValidationError, match=err_msg):
                 dec.decode(proto.encode(Ex(x)))
 
-    @pytest.mark.parametrize("typ", [bytes, bytearray])
+    @pytest.mark.parametrize("typ", [bytes, bytearray, memoryview])
     def test_max_length(self, proto, typ):
         class Ex(msgspec.Struct):
             x: Annotated[typ, Meta(max_length=2)]
@@ -683,13 +683,13 @@ class TestBytesConstraints:
         dec = proto.Decoder(Ex)
 
         for x in [b"", b"xx"]:
-            assert dec.decode(proto.encode(Ex(x))).x == x
+            assert bytes(dec.decode(proto.encode(Ex(x))).x) == x
 
         err_msg = r"Expected `bytes` of length <= 2 - at `\$.x`"
         with pytest.raises(msgspec.ValidationError, match=err_msg):
             dec.decode(proto.encode(Ex(b"xxx")))
 
-    @pytest.mark.parametrize("typ", [bytes, bytearray])
+    @pytest.mark.parametrize("typ", [bytes, bytearray, memoryview])
     def test_combinations(self, proto, typ):
         class Ex(msgspec.Struct):
             x: Annotated[typ, Meta(min_length=2, max_length=4)]
@@ -697,7 +697,7 @@ class TestBytesConstraints:
         dec = proto.Decoder(Ex)
 
         for x in [b"xx", b"xxx", b"xxxx"]:
-            assert dec.decode(proto.encode(Ex(x))).x == x
+            assert bytes(dec.decode(proto.encode(Ex(x))).x) == x
 
         for x in [b"x", b"xxxxx"]:
             with pytest.raises(msgspec.ValidationError):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -539,31 +539,31 @@ class TestStr:
 
 
 class TestBinary:
-    @pytest.mark.parametrize("out_type", [bytes, bytearray])
+    @pytest.mark.parametrize("out_type", [bytes, bytearray, memoryview])
     def test_binary_wrong_type(self, out_type):
         with pytest.raises(ValidationError, match="Expected `bytes`, got `int`"):
             convert(1, out_type)
 
-    @pytest.mark.parametrize("in_type", [bytes, bytearray])
-    @pytest.mark.parametrize("out_type", [bytes, bytearray])
+    @pytest.mark.parametrize("in_type", [bytes, bytearray, memoryview])
+    @pytest.mark.parametrize("out_type", [bytes, bytearray, memoryview])
     def test_binary_builtin(self, in_type, out_type):
         res = convert(in_type(b"test"), out_type)
         assert res == b"test"
         assert isinstance(res, out_type)
 
-    @pytest.mark.parametrize("out_type", [bytes, bytearray])
+    @pytest.mark.parametrize("out_type", [bytes, bytearray, memoryview])
     def test_binary_base64(self, out_type):
         res = convert("AQI=", out_type)
         assert res == b"\x01\x02"
         assert isinstance(res, out_type)
 
-    @pytest.mark.parametrize("out_type", [bytes, bytearray])
+    @pytest.mark.parametrize("out_type", [bytes, bytearray, memoryview])
     def test_binary_base64_disabled(self, out_type):
         with pytest.raises(ValidationError, match="Expected `bytes`, got `str`"):
-            convert("AQI=", out_type, builtin_types=(bytes, bytearray))
+            convert("AQI=", out_type, builtin_types=(bytes, bytearray, memoryview))
 
-    @pytest.mark.parametrize("in_type", [bytes, bytearray, str])
-    @pytest.mark.parametrize("out_type", [bytes, bytearray])
+    @pytest.mark.parametrize("in_type", [bytes, bytearray, memoryview, str])
+    @pytest.mark.parametrize("out_type", [bytes, bytearray, memoryview])
     @uses_annotated
     def test_binary_constraints(self, in_type, out_type):
         class Ex(Struct):
@@ -590,10 +590,12 @@ class TestBinary:
 
         msg = MyBytes(b"abc")
 
-        for typ in [bytes, bytearray]:
+        for typ in [bytes, bytearray, memoryview]:
             sol = convert(msg, typ)
             assert type(sol) is typ
             assert sol == b"abc"
+
+        del sol
 
         assert sys.getrefcount(msg) == 2  # msg + 1
         sol = convert(msg, MyBytes)
@@ -735,7 +737,7 @@ class TestUUID:
         res = convert(str(sol), uuid.UUID)
         assert res == sol
 
-    @pytest.mark.parametrize("input_type", [bytes, bytearray])
+    @pytest.mark.parametrize("input_type", [bytes, bytearray, memoryview])
     def test_uuid_bytes(self, input_type):
         sol = uuid.uuid4()
         msg = input_type(sol.bytes)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -131,7 +131,12 @@ def test_string(kw):
     [{}, dict(min_length=0), dict(max_length=3)],
 )
 @pytest.mark.parametrize(
-    "typ, info_type", [(bytes, mi.BytesType), (bytearray, mi.ByteArrayType)]
+    "typ, info_type",
+    [
+        (bytes, mi.BytesType),
+        (bytearray, mi.ByteArrayType),
+        (memoryview, mi.MemoryViewType),
+    ],
 )
 def test_binary(kw, typ, info_type):
     if kw:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -739,12 +739,12 @@ class TestBinary:
     @pytest.mark.parametrize(
         "x", [b"", b"a", b"ab", b"abc", b"abcd", b"abcde", b"abcdef", b"\x00\xff"]
     )
-    @pytest.mark.parametrize("type", [bytes, bytearray])
+    @pytest.mark.parametrize("type", [bytes, bytearray, memoryview])
     def test_decode_binary(self, x, type):
         s = b'"' + base64.b64encode(x) + b'"'
-        x2 = msgspec.json.decode(s, type=type)
-        assert x == x2
-        assert isinstance(x2, type)
+        res = msgspec.json.decode(s, type=type)
+        assert res == bytes(x)
+        assert isinstance(res, type)
 
     @pytest.mark.parametrize("n", [1023, 1024, 1025])
     def test_roundtrip_random(self, n, rand):

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -466,6 +466,13 @@ class TestEncoderMisc:
         res = msgspec.msgpack.decode(msg)
         assert buf == res
 
+    @pytest.mark.parametrize("size", SIZES)
+    def test_decode_memoryview(self, size):
+        buf = bytearray(size)
+        msg = msgspec.msgpack.encode(memoryview(buf))
+        res = msgspec.msgpack.decode(msg, type=memoryview)
+        assert buf == res.tobytes()
+
     @pytest.mark.parametrize(
         "dt, dt_str",
         [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -110,7 +110,7 @@ def test_string():
     assert msgspec.json.schema(str) == {"type": "string"}
 
 
-@pytest.mark.parametrize("typ", [bytes, bytearray])
+@pytest.mark.parametrize("typ", [bytes, bytearray, memoryview])
 def test_binary(typ):
     assert msgspec.json.schema(typ) == {
         "type": "string",
@@ -1108,7 +1108,7 @@ def test_dict_key_metadata(field, val, constraint):
     }
 
 
-@pytest.mark.parametrize("typ", [bytes, bytearray])
+@pytest.mark.parametrize("typ", [bytes, bytearray, memoryview])
 @pytest.mark.parametrize(
     "field, n, constraint",
     [("min_length", 2, "minLength"), ("max_length", 7, "maxLength")],


### PR DESCRIPTION
The implementation enables zero-copy functionality when decoding msgpack by supporting deserialization directly to a memoryview. This is very useful for decoding large numpy array.