### PR TITLE
Fix bug with multiple generic inheritence

### DIFF
--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -74,13 +74,12 @@ def _get_class_mro_and_typevar_mappings(obj):
             new_scope = {}
         else:
             cls = getattr(c, "__origin__", None)
-            if cls in (None, object, typing.Generic):
+            if cls in (None, object, typing.Generic) or cls in mapping:
                 return
-            if cls not in mapping:
-                params = cls.__parameters__
-                args = tuple(_apply_params(a, scope) for a in c.__args__)
-                assert len(params) == len(args)
-                mapping[cls] = new_scope = dict(zip(params, args))
+            params = cls.__parameters__
+            args = tuple(_apply_params(a, scope) for a in c.__args__)
+            assert len(params) == len(args)
+            mapping[cls] = new_scope = dict(zip(params, args))
 
         if issubclass(cls, typing.Generic):
             bases = getattr(cls, "__orig_bases__", cls.__bases__)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -181,3 +181,12 @@ class TestGetClassAnnotations:
             "a": List[List[int]],
             "b": List[int],
         }
+
+    def test_generic_sub11(self):
+        class Sub(Base[int]):
+            y: float
+
+        class Sub2(Sub, Base[int]):
+            z: str
+
+        assert get_class_annotations(Sub2) == {"x": int, "y": float, "z": str}


### PR DESCRIPTION
Previously if the same generic base class appeared multiple times in a classes inheritence graph msgspec would error when trying to analyze the class. This PR fixes the bug and adds a test for the behavior.

Fixes #625.