### PR TITLE
Add `order` option to encoders

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -152,6 +152,7 @@ def to_builtins(
     str_keys: bool = False,
     builtin_types: Union[Iterable[type], None] = None,
     enc_hook: Optional[Callable[[Any], Any]] = None,
+    order: Literal[None, "deterministic", "sorted"] = None,
 ) -> Any: ...
 @overload
 def convert(

--- a/msgspec/json.pyi
+++ b/msgspec/json.pyi
@@ -25,6 +25,7 @@ class Encoder:
     enc_hook: enc_hook_sig
     decimal_format: Literal["string", "number"]
     uuid_format: Literal["canonical", "hex"]
+    order: Literal[None, "deterministic", "sorted"]
 
     def __init__(
         self,
@@ -32,6 +33,7 @@ class Encoder:
         enc_hook: enc_hook_sig = None,
         decimal_format: Literal["string", "number"] = "string",
         uuid_format: Literal["canonical", "hex"] = "canonical",
+        order: Literal[None, "deterministic", "sorted"] = None,
     ): ...
     def encode(self, obj: Any) -> bytes: ...
     def encode_lines(self, items: Iterable) -> bytes: ...
@@ -97,7 +99,7 @@ def decode(
     strict: bool = True,
     dec_hook: dec_hook_sig = None,
 ) -> Any: ...
-def encode(obj: Any, *, enc_hook: enc_hook_sig = None) -> bytes: ...
+def encode(obj: Any, *, enc_hook: enc_hook_sig = None, order: Literal[None, "deterministic", "sorted"] = None) -> bytes: ...
 def schema(type: Any, *, schema_hook: schema_hook_sig = None) -> Dict[str, Any]: ...
 def schema_components(
     types: Iterable[Any],

--- a/msgspec/msgpack.pyi
+++ b/msgspec/msgpack.pyi
@@ -60,12 +60,14 @@ class Encoder:
     enc_hook: enc_hook_sig
     decimal_format: Literal["string", "number"]
     uuid_format: Literal["canonical", "hex", "bytes"]
+    order: Literal[None, "deterministic", "sorted"]
     def __init__(
         self,
         *,
         enc_hook: enc_hook_sig = None,
         decimal_format: Literal["string", "number"] = "string",
         uuid_format: Literal["canonical", "hex", "bytes"] = "canonical",
+        order: Literal[None, "deterministic", "sorted"] = None,
     ): ...
     def encode(self, obj: Any) -> bytes: ...
     def encode_into(
@@ -98,4 +100,4 @@ def decode(
     dec_hook: dec_hook_sig = None,
     ext_hook: ext_hook_sig = None,
 ) -> Any: ...
-def encode(obj: Any, *, enc_hook: enc_hook_sig = None) -> bytes: ...
+def encode(obj: Any, *, enc_hook: enc_hook_sig = None, order: Literal[None, "deterministic", "sorted"] = None) -> bytes: ...

--- a/msgspec/yaml.py
+++ b/msgspec/yaml.py
@@ -1,5 +1,5 @@
 import datetime as _datetime
-from typing import Any, Callable, Optional, Type, TypeVar, Union, overload
+from typing import Any, Callable, Optional, Type, TypeVar, Union, overload, Literal
 
 from . import (
     DecodeError as _DecodeError,
@@ -28,7 +28,12 @@ def _import_pyyaml(name):
         return yaml
 
 
-def encode(obj: Any, *, enc_hook: Optional[Callable[[Any], Any]] = None) -> bytes:
+def encode(
+    obj: Any,
+    *,
+    enc_hook: Optional[Callable[[Any], Any]] = None,
+    order: Literal[None, "deterministic", "sorted"] = None,
+) -> bytes:
     """Serialize an object as YAML.
 
     Parameters
@@ -39,6 +44,18 @@ def encode(obj: Any, *, enc_hook: Optional[Callable[[Any], Any]] = None) -> byte
         A callable to call for objects that aren't supported msgspec types.
         Takes the unsupported object and should return a supported object, or
         raise a ``NotImplementedError`` if unsupported.
+    order : {None, 'deterministic', 'sorted'}, optional
+        The ordering to use when encoding unordered compound types.
+
+        - ``None``: All objects are encoded in the most efficient manner
+          matching their in-memory representations. The default.
+        - `'deterministic'`: Unordered collections (sets, dicts) are sorted to
+          ensure a consistent output between runs. Useful when
+          comparison/hashing of the encoded binary output is necessary.
+        - `'sorted'`: Like `'deterministic'`, but *all* object-like types
+          (structs, dataclasses, ...) are also sorted by field name before
+          encoding. This is slower than `'deterministic'`, but may produce more
+          human-readable output.
 
     Returns
     -------
@@ -64,6 +81,7 @@ def encode(obj: Any, *, enc_hook: Optional[Callable[[Any], Any]] = None) -> byte
                 obj,
                 builtin_types=(_datetime.datetime, _datetime.date),
                 enc_hook=enc_hook,
+                order=order,
             )
         ],
         encoding="utf-8",

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -667,6 +667,17 @@ def check_msgpack_Encoder_enc_hook() -> None:
     msgspec.msgpack.Encoder(enc_hook=lambda x: None)
 
 
+def check_msgpack_order() -> None:
+    enc = msgspec.msgpack.Encoder(order=None)
+    msgspec.msgpack.Encoder(order='deterministic')
+    msgspec.msgpack.Encoder(order='sorted')
+    reveal_type(enc.order)  # assert "deterministic" in typ
+
+    msgspec.msgpack.encode({"a": 1}, order=None)
+    msgspec.msgpack.encode({"a": 1}, order='deterministic')
+    msgspec.msgpack.encode({"a": 1}, order='sorted')
+
+
 def check_msgpack_Encoder_decimal_format() -> None:
     enc = msgspec.msgpack.Encoder(decimal_format="string")
     msgspec.msgpack.Encoder(decimal_format="number")
@@ -832,6 +843,17 @@ def check_json_Encoder_enc_hook() -> None:
     msgspec.json.Encoder(enc_hook=lambda x: None)
 
 
+def check_json_order() -> None:
+    enc = msgspec.json.Encoder(order=None)
+    msgspec.json.Encoder(order='deterministic')
+    msgspec.json.Encoder(order='sorted')
+    reveal_type(enc.order)  # assert "deterministic" in typ
+
+    msgspec.json.encode({"a": 1}, order=None)
+    msgspec.json.encode({"a": 1}, order='deterministic')
+    msgspec.json.encode({"a": 1}, order='sorted')
+
+
 def check_json_Encoder_decimal_format() -> None:
     enc = msgspec.json.Encoder(decimal_format="string")
     msgspec.json.Encoder(decimal_format="number")
@@ -911,6 +933,12 @@ def check_yaml_encode_enc_hook() -> None:
     msgspec.yaml.encode(object(), enc_hook=lambda x: None)
 
 
+def check_yaml_encode_order() -> None:
+    msgspec.yaml.encode(object(), order=None)
+    msgspec.yaml.encode(object(), order="deterministic")
+    msgspec.yaml.encode(object(), order="sorted")
+
+
 def check_yaml_decode_dec_hook() -> None:
     def dec_hook(typ: Type, obj: Any) -> Any:
         return typ(obj)
@@ -951,6 +979,12 @@ def check_toml_decode_from_str() -> None:
 
 def check_toml_encode_enc_hook() -> None:
     msgspec.toml.encode(object(), enc_hook=lambda x: None)
+
+
+def check_toml_encode_order() -> None:
+    msgspec.toml.encode(object(), order=None)
+    msgspec.toml.encode(object(), order="deterministic")
+    msgspec.toml.encode(object(), order="sorted")
 
 
 def check_toml_decode_dec_hook() -> None:
@@ -1057,6 +1091,9 @@ def check_to_builtins() -> None:
     msgspec.to_builtins({1: 2}, str_keys=False)
     msgspec.to_builtins(b"test", builtin_types=(bytes, bytearray, memoryview))
     msgspec.to_builtins([1, 2, 3], enc_hook=lambda x: None)
+    msgspec.to_builtins([1, 2, 3], order=None)
+    msgspec.to_builtins([1, 2, 3], order="deterministic")
+    msgspec.to_builtins([1, 2, 3], order="sorted")
 
 
 def check_convert() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,10 @@ class Rand:
             if math.isfinite(x):
                 return x
 
+    def shuffle(self, obj):
+        """random shuffle"""
+        self.rand.shuffle(obj)
+
 
 @pytest.fixture
 def rand():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2154,6 +2154,12 @@ class TestDict:
         with pytest.raises(msgspec.DecodeError, match=error):
             msgspec.json.decode(s, type=type)
 
+    def test_encode_dict_order_escape(self):
+        msg = {"test\nkey": 1, "another\t\rkey": 2}
+        res = msgspec.json.encode(msg, order="deterministic")
+        sol = b'{"another\\t\\rkey":2,"test\\nkey":1}'
+        assert res == sol
+
 
 class TestTypedDict:
     """Most tests are in `test_common`, this just tests some JSON peculiarities"""

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -156,6 +156,19 @@ def test_encode_enc_hook():
     assert msgspec.toml.decode(msg) == {"x": "1.5"}
 
 
+@needs_encode
+@pytest.mark.parametrize("order", [None, "deterministic"])
+def test_encode_order(order):
+    msg = {"y": 1, "x": ({"n": 1, "m": 2},), "z": [{"b": 1, "a": 2}]}
+    res = msgspec.toml.encode(msg, order=order)
+    if order:
+        sol_msg = {"x": ({"m": 2, "n": 1},), "y": 1, "z": [{"a": 2, "b": 1}]}
+    else:
+        sol_msg = msg
+    sol = tomli_w.dumps(sol_msg).encode("utf-8")
+    assert res == sol
+
+
 @needs_decode
 def test_decode_str_or_bytes_like():
     assert msgspec.toml.decode("a = 1") == {"a": 1}

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -125,6 +125,14 @@ def test_encode_enc_hook():
     assert msgspec.yaml.decode(msg) == "1.5"
 
 
+@pytest.mark.parametrize("order", [None, "deterministic"])
+def test_encode_order(order):
+    msg = {"y": 1, "x": 2, "z": 3}
+    res = msgspec.yaml.encode(msg, order=order)
+    sol = yaml.safe_dump(msg, sort_keys=bool(order)).encode("utf-8")
+    assert res == sol
+
+
 def test_decode_str_or_bytes_like():
     assert msgspec.yaml.decode("[1, 2]") == [1, 2]
     assert msgspec.yaml.decode(b"[1, 2]") == [1, 2]


### PR DESCRIPTION
Add `order` kwarg to encoders

This adds an `order` kwarg to all encoders for configuring how unordered
collections/objects are encoded. Options are:

- `None`: the default. All objects are encoded in the most efficient
  manner corresponding to their in-memory representation.
- `'deterministic'`: Unordered collections (sets, dicts) are sorted
  before encoding. This ensures a consistent output between runs, which
  may be useful when comparing/hashing the encoded binary
  representation.
- `'sorted'`: same as `'deterministic'`, but *all* objet-like objects
  will have their fields encoded in alphabetical order by name. This is
  more expensive than `'deterministic'`, but may be useful for making
  the output more human readable.

The `'deterministic'` output has been heavily optimized - given the work
required to accomplish this feature, I wouldn't expect we can speed up
this operation much more. The `'sorted'` option has not been fully
optimized (the assumption being a human-readable output is rarely perf
sensitive). If needed, there are some rather simple optimizations we can
add here to speed this up further.

In general, `msgspec.json.encode(obj, order="deterministic")` should be
as fast or faster than `orjson.dumps(obj, option=orjson.OPT_SORT_KEYS)`.
For common small object sizes we average a ~20% speedup over `orjson`
for key sorting.

```python
In [1]: import msgspec, orjson, random

In [2]: enc = msgspec.json.Encoder(order="deterministic")

In [3]: keys = [f'field_{i}' for i in range(6)]

In [4]: random.shuffle(keys)

In [5]: msg = dict(zip(keys, range(len(keys))))

In [6]: %timeit enc.encode(msg)
305 ns ± 2.99 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [7]: %timeit orjson.dumps(msg, option=orjson.OPT_SORT_KEYS)
377 ns ± 2.04 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

Fixes #609.