### PR TITLE
Add tests for encoding/decoding highly recursive messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.16.1
+        uses: pypa/cibuildwheel@v2.16.5
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This adds a test case [found in the `orjson` repo](https://github.com/ijl/orjson/issues/458) to ensure that we properly respect recursion limits when encoding or decoding deeply recursive messages.

No code change is needed at this time, we properly manage recursion limits already.