### PR TITLE
JSON encoding speedups

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -13284,27 +13284,6 @@ PyDoc_STRVAR(JSONEncoder__doc__,
 static int json_encode_inline(EncoderState*, PyObject*);
 static int json_encode(EncoderState*, PyObject*);
 
-static MS_INLINE int
-json_encode_none(EncoderState *self)
-{
-    const char *buf = "null";
-    return ms_write(self, buf, 4);
-}
-
-static MS_INLINE int
-json_encode_true(EncoderState *self)
-{
-    const char *buf = "true";
-    return ms_write(self, buf, 4);
-}
-
-static MS_INLINE int
-json_encode_false(EncoderState *self)
-{
-    const char *buf = "false";
-    return ms_write(self, buf, 5);
-}
-
 static MS_NOINLINE int
 json_encode_long_fallback(EncoderState *self, PyObject *obj) {
     int out = -1;
@@ -14137,13 +14116,13 @@ json_encode_struct(EncoderState *self, PyObject *obj)
 static MS_NOINLINE int
 json_encode_uncommon(EncoderState *self, PyTypeObject *type, PyObject *obj) {
     if (obj == Py_None) {
-        return json_encode_none(self);
+        return ms_write(self, "null", 4);
     }
     else if (obj == Py_True) {
-        return json_encode_true(self);
+        return ms_write(self, "true", 4);
     }
     else if (obj == Py_False) {
-        return json_encode_false(self);
+        return ms_write(self, "false", 5);
     }
     else if (Py_TYPE(type) == &StructMetaType) {
         return json_encode_struct(self, obj);

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -12337,10 +12337,7 @@ static int
 mpack_encode_raw(EncoderState *self, PyObject *obj)
 {
     Raw *raw = (Raw *)obj;
-    if (ms_ensure_space(self, raw->len) < 0) return -1;
-    memcpy(self->output_buffer_raw + self->output_len, raw->buf, raw->len);
-    self->output_len += raw->len;
-    return 0;
+    return ms_write(self, raw->buf, raw->len);
 }
 
 static int
@@ -13559,10 +13556,7 @@ static int
 json_encode_raw(EncoderState *self, PyObject *obj)
 {
     Raw *raw = (Raw *)obj;
-    if (ms_ensure_space(self, raw->len) < 0) return -1;
-    memcpy(self->output_buffer_raw + self->output_len, raw->buf, raw->len);
-    self->output_len += raw->len;
-    return 0;
+    return ms_write(self, raw->buf, raw->len);
 }
 
 static int

--- a/msgspec/itoa.h
+++ b/msgspec/itoa.h
@@ -145,19 +145,19 @@ write_u64_5_to_8_digits(uint32_t x, char *buf) {
 }
 
 /* Write a uint64 to buf, requires 20 bytes of space */
-static inline int
+static inline char *
 write_u64(uint64_t x, char *buf) {
     uint64_t tmp, hgh;
     uint32_t mid, low;
 
     if (x < 100000000) {  /* 1-8 digits */
-        return write_u32_1_to_8_digits((uint32_t)x, buf) - buf;
+        return write_u32_1_to_8_digits((uint32_t)x, buf);
     } else if (x < (uint64_t)100000000 * 100000000) {  /* 9-16 digits */
         hgh = x / 100000000;                           /* (x / 100000000) */
         low = (uint32_t)(x - hgh * 100000000);         /* (x % 100000000) */
         char *cur = write_u32_1_to_8_digits((uint32_t)hgh, buf);
         write_u32_8_digits(low, cur);
-        return cur + 8 - buf;
+        return cur + 8;
     } else {                                    /* 17-20 digits */
         tmp = x / 100000000;                    /* (x / 100000000) */
         low = (uint32_t)(x - tmp * 100000000);  /* (x % 100000000) */
@@ -166,7 +166,7 @@ write_u64(uint64_t x, char *buf) {
         char *cur = write_u64_5_to_8_digits((uint32_t)hgh, buf);
         write_u32_4_digits(mid, cur);
         write_u32_8_digits(low, cur + 4);
-        return cur + 12 - buf;
+        return cur + 12;
     }
 }
 

--- a/msgspec/itoa.h
+++ b/msgspec/itoa.h
@@ -59,12 +59,29 @@ write_u32_8_digits(uint32_t x, char *buf) {
 }
 
 static MS_INLINE void
+write_u32_6_digits(uint32_t x, char *buf) {
+    uint32_t aa, bbcc, bb, cc;
+    aa = (uint32_t)(((uint64_t)x * 109951163) >> 40);  /* (x / 10000) */
+    bbcc = x - aa * 10000;                             /* (x % 10000) */
+    bb = (bbcc * 5243) >> 19;                          /* (bbcc / 100) */
+    cc = bbcc - bb * 100;                              /* (bbcc % 100) */
+    memcpy(buf + 0, DIGIT_TABLE + aa * 2, 2);
+    memcpy(buf + 2, DIGIT_TABLE + bb * 2, 2);
+    memcpy(buf + 4, DIGIT_TABLE + cc * 2, 2);
+}
+
+static MS_INLINE void
 write_u32_4_digits(uint32_t x, char *buf) {
     uint32_t aa, bb;
     aa = (x * 5243) >> 19;  /* (x / 100) */
     bb = x - aa * 100;      /* (x % 100) */
     memcpy(buf + 0, DIGIT_TABLE + aa * 2, 2);
     memcpy(buf + 2, DIGIT_TABLE + bb * 2, 2);
+}
+
+static MS_INLINE void
+write_u32_2_digits(uint32_t x, char *buf) {
+    memcpy(buf, DIGIT_TABLE + x * 2, 2);
 }
 
 static MS_INLINE char *

--- a/msgspec/ryu.h
+++ b/msgspec/ryu.h
@@ -946,38 +946,38 @@ write_f64(double f, char* buf, bool allow_nonfinite) {
     }
 
     if (sign) {
-        *buf = '-';
+        *buf++ = '-';
     }
 
     if (ieee_exponent == 0 && ieee_mantissa == 0) {
-        memcpy(buf + sign, "0.0", 3);
+        memcpy(buf, "0.0", 3);
         return sign + 3;
     }
 
     floating_decimal_64 v = d2d(ieee_mantissa, ieee_exponent);
 
-    int length = write_u64(v.mantissa, buf + sign);
+    int length = write_u64(v.mantissa, buf) - buf;
     int32_t k = v.exponent;
     int32_t kk = length + k;
 
     if (0 <= k && kk <= 16) {
         /* XYZ00.0 */
-        memset(buf + sign + length, '0', k + 2);
-        *(buf + sign + kk) = '.';
+        memset(buf + length, '0', k + 2);
+        *(buf + kk) = '.';
         return sign + kk + 2;
     }
     else if (0 < kk && kk <= 16) {
         /* XY.Z */
-        memmove(buf + sign + kk + 1, buf + sign + kk, length - kk);
-        *(buf + sign + kk) = '.';
+        memmove(buf + kk + 1, buf + kk, length - kk);
+        *(buf + kk) = '.';
         return sign + length + 1;
     }
     else if (-5 < kk && kk <= 0) {
         /* 0.0XYZ */
         int offset = 2 - kk;
-        memmove(buf + sign + offset, buf + sign, length);
-        memset(buf + sign, '0', offset);
-        *(buf + sign + 1) = '.';
+        memmove(buf + offset, buf, length);
+        memset(buf, '0', offset);
+        *(buf + 1) = '.';
         return sign + length + offset;
     }
     else {
@@ -985,11 +985,11 @@ write_f64(double f, char* buf, bool allow_nonfinite) {
         int offset = 0;
         if (length > 1) {
             offset = length;
-            memmove(buf + sign + 2, buf + sign + 1, length - 1);
-            *(buf + sign + 1) = '.';
+            memmove(buf + 2, buf + 1, length - 1);
+            *(buf + 1) = '.';
         }
-        *(buf + sign + offset + 1) = 'e';
-        return sign + offset + 2 + write_exponent(kk - 1, buf + sign + offset + 2);
+        *(buf + offset + 1) = 'e';
+        return sign + offset + 2 + write_exponent(kk - 1, buf + offset + 2);
     }
 }
 #endif // RYU_H


### PR DESCRIPTION
An assortment of micro-optimizations and cleanups around JSON encoding:

- Accelerated `int` and `float` encoding by up to ~2x for small numbers
- Accelerated `datetime`, `date`, and `time` encoding by ~30-40%
- A few code cleanups to simplify the JSON encoder handlers