### PR TITLE
Draft: feat: allow converting subclasses of tagged structs

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -164,6 +164,7 @@ def convert(
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
     builtin_types: Union[Iterable[type], None] = None,
     str_keys: bool = False,
+    allow_tagged_struct_subtypes: bool = False,
 ) -> T: ...
 @overload
 def convert(
@@ -175,6 +176,7 @@ def convert(
     dec_hook: Optional[Callable[[type, Any], Any]] = None,
     builtin_types: Union[Iterable[type], None] = None,
     str_keys: bool = False,
+    allow_tagged_struct_subtypes: bool = False,
 ) -> Any: ...
 
 # TODO: deprecated

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1867,6 +1867,22 @@ class TestStruct:
         assert f"Invalid value {bad!r}" in str(rec.value)
         assert "`$.type`" in str(rec.value)
 
+    def test_tagged_struct_subclass(self):
+        class Base(Struct, tag=True):
+            pass
+
+        class A(Base):
+            pass
+
+        class C(Base):
+            other: Base
+
+        assert convert(
+            {"type": "C", "other": {"type": "C", "other": {"type": "A"}}},
+            type=C,
+            allow_tagged_struct_subtypes=True,
+        ) == C(other=C(other=A()))
+
     @pytest.mark.parametrize("tag_val", [2**64 - 1, 2**64, -(2**63) - 1])
     @mapcls_and_from_attributes
     def test_tagged_struct_int_tag_not_int64_always_invalid(


### PR DESCRIPTION
Hi,

This is a very rough draft, opening to see if @jcrist will be open for this feature/approach.

It addresses #656 and my own #541 - allowing to decode data representing a tagged struct subclass in place of the super class.

This feature prevents me from switching to msgspec in my [ast library](https://github.com/mishamsk/pyoak), but should be generally very usable for any tree-like structure/messages.

As of time of writing, in order for this PR to be complete, at least the following has to be handled:

- [ ] Wire the new `allow_tagged_struct_subtypes` kwarg into json, msg pack decoders
- [ ] Properly handle type node / struct info caching. As of now, cache doesn't account for `allow_tagged_struct_subtypes`, so it will not honor the flag after decoder (type node) is cached for the first time
- [ ] Add more tests