### PR TITLE
Plug leak of "match_args" in StructMeta.

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -6810,6 +6810,7 @@ StructMeta_clear(StructMetaObject *self)
     Py_CLEAR(self->rename);
     Py_CLEAR(self->post_init);
     Py_CLEAR(self->struct_info);
+    Py_CLEAR(self->match_args);
     if (self->struct_offsets != NULL) {
         PyMem_Free(self->struct_offsets);
         self->struct_offsets = NULL;


### PR DESCRIPTION
"match_args" is set in StructMetaInfo and eventually StructMeta via -

```
 info->match_args = PyTuple_GetSlice(info->fields, 0, nfields - nkwonly);
```

This is incref'd before copying to StructMeta, and decref'd when cleaning up StructMetaInfo. There's no corresponding decref for StructMeta itself. This causes a leak that valgrind readily detects:

```
env PYTHONMALLOC=malloc valgrind python3 -c 'import msgspec'
...
==576283== LEAK SUMMARY:
==576283==    definitely lost: 1,608 bytes in 26 blocks
```

With the fix in place, we get:

```
==576086== LEAK SUMMARY:
==576086==    definitely lost: 0 bytes in 0 blocks
```