### PR TITLE
Preserve typing args when inspecting custom types

### DIFF
--- a/msgspec/inspect.py
+++ b/msgspec/inspect.py
@@ -1002,4 +1002,4 @@ class _Translator:
             )
             return out
         else:
-            return CustomType(t)
+            return CustomType(t[args] if args else t)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -245,6 +245,13 @@ def test_custom():
     assert mi.type_info(complex) == mi.CustomType(complex)
 
 
+def test_custom_with_args():
+    class MyGeneric(Generic[T]):
+        value: T
+
+    assert mi.type_info(MyGeneric[int]) == mi.CustomType(MyGeneric[int])
+
+
 @pytest.mark.parametrize(
     "kw",
     [{}, dict(min_length=0), dict(max_length=3)],


### PR DESCRIPTION
The other inspected types carry through the typing args, seems like custom types should as well. My specific use-case is wanting to use `msgspec.inspect.type_info` on `Struct`s which may have custom `Generic` members, without having to augment it with a separate call to `msgspec.structs.fields` and parsing out the type info myself.