### PR TITLE
Fix memory leak in Raw.copy().

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -1513,7 +1513,9 @@ Raw_copy(Raw *self, PyObject *unused)
     }
     PyObject *buf = PyBytes_FromStringAndSize(self->buf, self->len);
     if (buf == NULL) return NULL;
-    return Raw_New(buf);
+    PyObject *out = Raw_New(buf);
+    Py_DECREF(buf);
+    return out;
 }
 
 static PyMethodDef Raw_methods[] = {


### PR DESCRIPTION
Raw_New borrows a reference to its PyBytesObject argument, so Raw_Copy must still dispose of it.

The following is a minimal repro for this issue:

```
import msgspec

DECODER = msgspec.msgpack.Decoder(type=msgspec.Raw)
PAYLOAD = b"\xda\xff\xff" + (65535 * b"\0") # array of 65535 zeros

for _ in range(1000000):
  raw = DECODER.decode(PAYLOAD)
  raw.copy()
```