### PR TITLE
Build Python 3.13 wheels (not free-threaded)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Environment
         if: github.event_name != 'release'
         run: |
-            echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*" >> $GITHUB_ENV
+            echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
         uses: pypa/cibuildwheel@v2.19.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     env:
       CIBW_TEST_REQUIRES: "pytest msgpack pyyaml tomli tomli_w"
       CIBW_TEST_COMMAND: "pytest {project}/tests"
-      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp13-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
       CIBW_SKIP: "*-win32 *_i686 *_s390x *_ppc64le"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "x86_64 aarch64"
@@ -100,6 +100,7 @@ jobs:
       - name: Set up Environment
         if: github.event_name != 'release'
         run: |
+            echo "CIBW_BUILD=${CIBW_BUILD} cp313-*" >> $GITHUB_ENV
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,6 @@ jobs:
       - name: Set up Environment
         if: github.event_name != 'release'
         run: |
-            echo "CIBW_BUILD=${CIBW_BUILD}" >> $GITHUB_ENV
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.21.2
+        uses: pypa/cibuildwheel@v2.21.3
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.21.1
+        uses: pypa/cibuildwheel@v2.21.2
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,12 @@ jobs:
     env:
       CIBW_TEST_REQUIRES: "pytest msgpack pyyaml tomli tomli_w"
       CIBW_TEST_COMMAND: "pytest {project}/tests"
-      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
       CIBW_SKIP: "*-win32 *_i686 *_s390x *_ppc64le"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "x86_64 aarch64"
       CIBW_TEST_SKIP: "*_arm64 *-musllinux_*"
       CIBW_ENVIRONMENT: "CFLAGS=-g0"
-      CIBW_PRERELEASE_PYTHONS: "true"
 
     steps:
       - uses: actions/checkout@v4
@@ -100,11 +99,11 @@ jobs:
       - name: Set up Environment
         if: github.event_name != 'release'
         run: |
-            echo "CIBW_BUILD=${CIBW_BUILD} cp313-*" >> $GITHUB_ENV
+            echo "CIBW_BUILD=${CIBW_BUILD}" >> $GITHUB_ENV
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v2.20.0
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: github.event_name == 'release' && github.event.action == 'published'
         with:
+          name: artifact-wheels
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -129,6 +130,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
+          name: artifact-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -138,8 +140,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          merge-multiple: true
           path: dist
+          pattern: artifact-*
 
       - uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,13 @@ jobs:
     env:
       CIBW_TEST_REQUIRES: "pytest msgpack pyyaml tomli tomli_w"
       CIBW_TEST_COMMAND: "pytest {project}/tests"
-      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp13-*"
       CIBW_SKIP: "*-win32 *_i686 *_s390x *_ppc64le"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "x86_64 aarch64"
       CIBW_TEST_SKIP: "*_arm64 *-musllinux_*"
       CIBW_ENVIRONMENT: "CFLAGS=-g0"
+      CIBW_PRERELEASE_PYTHONS: "true"
 
     steps:
       - uses: actions/checkout@v4
@@ -99,10 +100,10 @@ jobs:
       - name: Set up Environment
         if: github.event_name != 'release'
         run: |
-            echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64" >> $GITHUB_ENV
+            echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.19.2
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp38-*_aarch64 cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*_aarch64" >> $GITHUB_ENV
 
       - name: Build & Test Wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.21.1
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -11265,7 +11265,12 @@ ms_uuid_to_16_bytes(MsgspecState *mod, PyObject *obj, unsigned char *buf) {
         return -1;
     }
 #if PY313_PLUS
-    int out = _PyLong_AsByteArray((PyLongObject *)int128, buf, 16, 0, 0, 1);
+    int out = (int)PyLong_AsNativeBytes(
+        int128,
+        buf,
+        16,
+        Py_ASNATIVEBYTES_BIG_ENDIAN | Py_ASNATIVEBYTES_UNSIGNED_BUFFER
+    );
 #else
     int out = _PyLong_AsByteArray((PyLongObject *)int128, buf, 16, 0, 0);
 #endif

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -57,6 +57,12 @@ ms_popcount(uint64_t i) {                            \
 #define SET_SIZE(obj, size) (((PyVarObject *)obj)->ob_size = size)
 #endif
 
+#if PY313_PLUS
+#define MS_UNICODE_EQ(a, b) (PyUnicode_Compare(a, b) == 0)
+#else
+#define MS_UNICODE_EQ(a, b) _PyUnicode_EQ(a, b)
+#endif
+
 #define DIV_ROUND_CLOSEST(n, d) ((((n) < 0) == ((d) < 0)) ? (((n) + (d)/2)/(d)) : (((n) - (d)/2)/(d)))
 
 /* These macros are used to manually unroll some loops */
@@ -498,7 +504,7 @@ find_keyword(PyObject *kwnames, PyObject *const *kwstack, PyObject *key)
     for (i = 0; i < nkwargs; i++) {
         PyObject *kwname = PyTuple_GET_ITEM(kwnames, i);
         assert(PyUnicode_Check(kwname));
-        if (PyUnicode_Compare(kwname, key) == 0) {
+        if (MS_UNICODE_EQ(kwname, key)) {
             return kwstack[i];
         }
     }
@@ -7330,7 +7336,7 @@ Struct_vectorcall(PyTypeObject *cls, PyObject *const *args, size_t nargsf, PyObj
          * check for parameters passed both as arg and kwarg */
         for (field_index = 0; field_index < nfields; field_index++) {
             PyObject *field = PyTuple_GET_ITEM(fields, field_index);
-            if (PyUnicode_Compare(kwname, field) == 0) {
+            if (MS_UNICODE_EQ(kwname, field)) {
                 if (MS_UNLIKELY(field_index < nargs)) {
                     PyErr_Format(
                         PyExc_TypeError,
@@ -7737,7 +7743,7 @@ struct_replace(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject
         }
         for (field_index = 0; field_index < nfields; field_index++) {
             PyObject *field = PyTuple_GET_ITEM(fields, field_index);
-            if (PyUnicode_Compare(kwname, field) == 0) goto kw_found;
+            if (MS_UNICODE_EQ(kwname, field)) goto kw_found;
         }
 
         /* Unknown keyword */

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -4621,10 +4621,14 @@ typenode_origin_args_metadata(
          * abstract -> concrete mapping. If present, this is an unparametrized
          * collection of some form. This helps avoid compatibility issues in
          * Python 3.8, where unparametrized collections still have __args__. */
-        origin = PyDict_GetItem(state->mod->concrete_types, t);
+        origin = PyDict_GetItemWithError(state->mod->concrete_types, t);
         if (origin != NULL) {
             Py_INCREF(origin);
             break;
+        }
+        else {
+            /* Ignore all errors in this initial check */
+            PyErr_Clear();
         }
 
         /* If `t` is a type instance, no need to inspect further */

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -127,6 +127,7 @@ def get_class_annotations(obj):
                 value = type(None)
             elif isinstance(value, str):
                 value = _forward_ref(value)
+            # TODO: Pass `type_params` to `_eval_type` to fix deprecation warning
             value = typing._eval_type(value, cls_locals, cls_globals)
             if mapping is not None:
                 value = _apply_params(value, mapping)

--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -51,6 +51,15 @@ else:
         return typing.ForwardRef(value, is_argument=False, is_class=True)
 
 
+# Python 3.13 adds a new mandatory type_params kwarg to _eval_type
+if sys.version_info >= (3, 13):
+
+    def _eval_type(t, globalns, localns):
+        return typing._eval_type(t, globalns, localns, ())
+else:
+    _eval_type = typing._eval_type
+
+
 def _apply_params(obj, mapping):
     if params := getattr(obj, "__parameters__", None):
         args = tuple(mapping.get(p, p) for p in params)
@@ -127,8 +136,7 @@ def get_class_annotations(obj):
                 value = type(None)
             elif isinstance(value, str):
                 value = _forward_ref(value)
-            # TODO: Pass `type_params` to `_eval_type` to fix deprecation warning
-            value = typing._eval_type(value, cls_locals, cls_globals)
+            value = _eval_type(value, cls_locals, cls_globals)
             if mapping is not None:
                 value = _apply_params(value, mapping)
             hints[name] = value

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,8 @@ omit =
 markers =
     mypy
     pyright
+filterwarnings =
+    error
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     extras_require=extras_require,
     license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
     ],
     extras_require=extras_require,
     license="BSD",


### PR DESCRIPTION
I can close this if https://github.com/jcrist/msgspec/pull/703 gets more attention, but I've confirmed changes here allow the wheels to be built in 3.8-3.13, and all tests are passing.

This warning is currently raised, but fixing it might be beyond the scope of this PR:

```
PytestUnraisableExceptionWarning: Exception ignored in PyDict_GetItem(); consider using PyDict_GetItemRef() or PyDict_GetItemWithError(): None
```

https://github.com/python/cpython/issues/106004

- Closes #698
- Closes #741