### PR TITLE
Use `PyType_GetDict` in Python 3.12+

### DIFF
--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -246,6 +246,12 @@ class TestMixins:
             class Test(Struct, Mixin):
                 pass
 
+    def test_mixin_builtin_type_errors(self):
+        with pytest.raises(TypeError):
+
+            class Test(Struct, Exception):
+                pass
+
 
 def test_struct_subclass_forbids_non_types():
     # Currently this failcase is handled by CPython's internals, but it's good


### PR DESCRIPTION
Previously we were incorrectly accessing `tp_dict` in mixin classes when defining a `Struct` class on Python 3.12+. This could result in a segfault if a user tried to create a `Struct` class that also subclassed from an interpreter builtin type (like `Exception`). Now we error nicely instead.

Fixes #727.