### PR TITLE
Fix JSON decoding of > 64 bit integers

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -11649,6 +11649,7 @@ ms_post_decode_float(
  *************************************************************************/
 
 #define ONE_E18 1000000000000000000ULL
+#define ONE_E19_MINUS_ONE 9999999999999999999ULL
 
 static MS_NOINLINE PyObject *
 parse_number_fallback(
@@ -11948,7 +11949,7 @@ end_parsing:
                 (is_float) ||
                 ((integer_end - integer_start) != 20) ||
                 (*integer_start != '1') ||
-                (mantissa <= ONE_E18)
+                (mantissa <= ONE_E19_MINUS_ONE)
             )
         ) {
             /* We overflowed. Redo parsing, truncating at 19 digits */

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1113,17 +1113,30 @@ class TestIntegers:
         assert isinstance(x2, int)
         assert x2 == x
 
-    @pytest.mark.parametrize("x", [-(2**63) - 1, 2**64])
-    def test_decode_big_int_as_any(self, x):
+    @pytest.mark.parametrize(
+        "x",
+        [
+            -(2**63) - 1,
+            2**64,
+            2**64 + 10**18,
+            2**64 + 10**18 + 1,
+            19999999999999999999,
+            20000000000000000000,
+            2**64 + 10**19,  # mantissa overflows to 20 digits
+            2**64 + 10**19 - 1,
+            -(2**64),
+            -(2**64) + 10**18,
+            -(2**64) + 10**18 + 1,
+            -19999999999999999999,
+            -20000000000000000000,
+            -(2**64 + 10**19),
+            -(2**64 + 10**19 - 1),
+        ],
+    )
+    @pytest.mark.parametrize("type", [Any, int])
+    def test_decode_big_int(self, x, type):
         s = str(x).encode()
-        x2 = msgspec.json.decode(s)
-        assert isinstance(x2, int)
-        assert x2 == x
-
-    @pytest.mark.parametrize("x", [-(2**63) - 1, 2**64])
-    def test_decode_big_int_as_int(self, x):
-        s = str(x).encode()
-        x2 = msgspec.json.decode(s, type=int)
+        x2 = msgspec.json.decode(s, type=type)
         assert isinstance(x2, int)
         assert x2 == x
 


### PR DESCRIPTION
Previously our 64 bit integer overflow detection logic was broken for a range of 65 bit integers between `(2 ** 64) + (10 ** 18) + 1` and `19999999999999999999` (inclusive). This PR fixes this overflow detection logic and improves the test coverage of certain big integers.

Fixes #701.