### PR TITLE
Call `__post_init__` when converting struct from object

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -21363,6 +21363,9 @@ convert_object_to_struct(
             should_untrack = !MS_MAYBE_TRACKED(val);
         }
     }
+
+    if (Struct_decode_post_init(struct_type, out, path) < 0) goto error;
+
     Py_LeaveRecursiveCall();
     if (is_gc && !should_untrack)
         PyObject_GC_Track(out);


### PR DESCRIPTION
Previously a struct's `__post_init__` method wouldn't be called when converting from a custom mapping or object with `from_attributes=True`. This PR fixes that and expands the tests to cover this case.

Fixes #673.