### PR TITLE
Change behavior of `encode_into` with `offset` > `len(buf)`

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -9401,8 +9401,10 @@ encoder_encode_into_common(
             PyErr_SetString(PyExc_ValueError, "offset must be >= -1");
             return NULL;
         }
-        if (offset > buf_size) {
-            offset = buf_size;
+
+        if (offset < buf_size) {
+            buf_size = Py_MAX(8, 1.5 * offset);
+            if (PyByteArray_Resize(buf, buf_size) < 0) return NULL;
         }
     }
 
@@ -9419,9 +9421,11 @@ encoder_encode_into_common(
         .max_output_len = buf_size,
         .resize_buffer = ms_resize_bytearray
     };
+
     if (encode(&state, obj) < 0) {
         return NULL;
     }
+
     FAST_BYTEARRAY_SHRINK(buf, state.output_len);
     Py_RETURN_NONE;
 }

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -298,10 +298,11 @@ class TestEncoderMisc:
         enc.encode_into(msg, buf, 2)
         assert buf == b"01" + encoded
 
-        # Offset out of bounds appends to end
+        # Offset out of bounds extends
         buf = bytearray(b"01234")
-        enc.encode_into(msg, buf, 1000)
-        assert buf == b"01234" + encoded
+        enc.encode_into(msg, buf, 10)
+        assert buf[:5] == b"01234"
+        assert buf[10:] == encoded
 
         # Offset -1 means append at end
         buf = bytearray(b"01234")

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -432,10 +432,11 @@ class TestEncoderMisc:
         enc.encode_into(msg, buf, 2)
         assert buf == b"01" + encoded
 
-        # Offset out of bounds appends to end
+        # Offset out of bounds extends
         buf = bytearray(b"01234")
-        enc.encode_into(msg, buf, 1000)
-        assert buf == b"01234" + encoded
+        enc.encode_into(msg, buf, 10)
+        assert buf[:5] == b"01234"
+        assert buf[10:] == encoded
 
         # Offset -1 means append at end
         buf = bytearray(b"01234")


### PR DESCRIPTION
Previously we'd truncate `offset = len(buf)` if `offset > len(buf)` when calling `encode_into(msg, buf, offset)`. We now expand the size of `buf` to `offset`, providing a more consistent and expected behavior.

Fixes #697.