### PR TITLE
Support encoding any enum type whose value is supported

### DIFF
--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -1059,9 +1059,13 @@ other than a field for one of these types.
 ------------------------------------
 
 Enum types (`enum.Enum`, `enum.IntEnum`, `enum.StrEnum`, ...) encode as their
-member *values* in all protocols. Only enums composed of all string or all
-integer values are supported. An error is raised during decoding if the value
-isn't the proper type, or doesn't match any valid member.
+member *values* in all protocols.
+
+Any enum whose *value* is a supported type may be encoded, but only enums
+composed of all string or all integer values may be decoded.
+
+An error is raised during decoding if the value isn't the proper type, or
+doesn't match any valid member.
 
 .. code-block:: python
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -604,20 +604,27 @@ class TestEnum:
         with pytest.raises(TypeError, match="Enum types must have at least one item"):
             proto.Decoder(Empty)
 
-    def test_unsupported_type_errors(self, proto):
-        class Bad(enum.Enum):
+    def test_encode_complex(self, proto):
+        class Complex(enum.Enum):
             A = 1.5
 
-        with pytest.raises(
-            msgspec.EncodeError, match="Only enums with int or str values are supported"
-        ):
-            proto.encode(Bad.A)
+        res = proto.encode(Complex.A)
+        sol = proto.encode(1.5)
+        assert res == sol
+
+        res = proto.encode({Complex.A: 1})
+        sol = proto.encode({1.5: 1})
+        assert res == sol
+
+    def test_decode_complex_errors(self, proto):
+        class Complex(enum.Enum):
+            A = 1.5
 
         with pytest.raises(TypeError) as rec:
-            proto.Decoder(Bad)
+            proto.Decoder(Complex)
 
         assert "Enums must contain either all str or all int values" in str(rec.value)
-        assert repr(Bad) in str(rec.value)
+        assert repr(Complex) in str(rec.value)
 
     @pytest.mark.parametrize(
         "values",

--- a/tests/test_to_builtins.py
+++ b/tests/test_to_builtins.py
@@ -11,7 +11,7 @@ from typing import Any, NamedTuple, Union
 
 import pytest
 
-from msgspec import UNSET, EncodeError, Struct, UnsetType, to_builtins, defstruct
+from msgspec import UNSET, Struct, UnsetType, to_builtins, defstruct
 
 PY310 = sys.version_info[:2] >= (3, 10)
 PY311 = sys.version_info[:2] >= (3, 11)
@@ -216,12 +216,12 @@ class TestToBuiltins:
         assert res == "apple"
         assert type(res) is str
 
-    def test_enum_invalid(self):
-        class Bad(enum.Enum):
+    def test_enum_complex(self):
+        class Complex(enum.Enum):
             x = (1, 2)
 
-        with pytest.raises(EncodeError, match="Only enums with int or str"):
-            to_builtins(Bad.x)
+        res = to_builtins(Complex.x)
+        assert res is Complex.x.value
 
     @pytest.mark.parametrize(
         "in_type, out_type",


### PR DESCRIPTION
Previously we only supported encoding and decoding enums with integer or string values. We now support encoding enums with any value that is also a supported type. The restriction on decoding only integer or string values remains.

Fixes #680.