### PR TITLE
Don't fail when parsing types with invalid `__parameters__`

### DIFF
--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -50,12 +50,22 @@ else:
 
 
 def _apply_params(obj, mapping):
-    if params := getattr(obj, "__parameters__", None):
-        args = tuple(mapping.get(p, p) for p in params)
-        return obj[args]
-    elif isinstance(obj, typing.TypeVar):
+    if isinstance(obj, typing.TypeVar):
         return mapping.get(obj, obj)
-    return obj
+
+    try:
+        parameters = tuple(obj.__parameters__)
+    except Exception:
+        # Not parameterized or __parameters__ is invalid, ignore
+        return obj
+
+    if not parameters:
+        # Not parametrized
+        return obj
+
+    # Parametrized
+    args = tuple(mapping.get(p, p) for p in parameters)
+    return obj[args]
 
 
 def _get_class_mro_and_typevar_mappings(obj):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -190,3 +190,14 @@ class TestGetClassAnnotations:
             z: str
 
         assert get_class_annotations(Sub2) == {"x": int, "y": float, "z": str}
+
+    def test_generic_invalid_parameters(self):
+        class Invalid:
+            @property
+            def __parameters__(self):
+                pass
+
+        class Sub(Base[Invalid]):
+            pass
+
+        assert get_class_annotations(Sub) == {"x": Invalid}


### PR DESCRIPTION
Fixes #769.