### PR TITLE
chore(build): updated Github CI Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
@@ -144,7 +146,5 @@ jobs:
           path: dist
           pattern: artifact-*
 
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: github.event_name == 'release' && github.event.action == 'published'
         with:
-          name: artifact-wheels
+          name: artifact-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ extras_require = {
 }
 
 setup(
-    name="msgspec",
+    name="litestar-msgspec",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     maintainer="Jim Crist-Harif",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ extras_require = {
 }
 
 setup(
-    name="litestar-msgspec",
+    name="msgspec",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     maintainer="Jim Crist-Harif",


### PR DESCRIPTION
@jcrist, in my recent testing with Python 3.13, msgspec, and Litestar, I found myself needing binary wheels to speed things up.

There were a few GH actions that have implemented breaking changes, and this PR has the minor updates required to publish releases.