### PR TITLE
Make `DecodeError` and `ValidationError` inherit from ValueError 

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -22506,29 +22506,31 @@ PyInit__core(void)
         "Base class for all Msgspec exceptions",
         NULL, NULL
     );
-    if (st->MsgspecError == NULL)
-        return NULL;
+    if (st->MsgspecError == NULL) return NULL;
+
     st->EncodeError = PyErr_NewExceptionWithDoc(
         "msgspec.EncodeError",
         "An error occurred while encoding an object",
         st->MsgspecError, NULL
     );
-    if (st->EncodeError == NULL)
-        return NULL;
+    if (st->EncodeError == NULL) return NULL;
+
+    temp_obj = PyTuple_Pack(2, st->MsgspecError, PyExc_ValueError);
+    if (temp_obj == NULL) return NULL;
     st->DecodeError = PyErr_NewExceptionWithDoc(
         "msgspec.DecodeError",
         "An error occurred while decoding an object",
-        PyTuple_Pack(2, st->MsgspecError, PyExc_ValueError), NULL
+        temp_obj, NULL
     );
-    if (st->DecodeError == NULL)
-        return NULL;
+    Py_XDECREF(temp_obj);
+    if (st->DecodeError == NULL) return NULL;
+
     st->ValidationError = PyErr_NewExceptionWithDoc(
         "msgspec.ValidationError",
         "The message didn't match the expected schema",
         st->DecodeError, NULL
     );
-    if (st->ValidationError == NULL)
-        return NULL;
+    if (st->ValidationError == NULL) return NULL;
 
     Py_INCREF(st->MsgspecError);
     if (PyModule_AddObject(m, "MsgspecError", st->MsgspecError) < 0)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -292,14 +292,6 @@ class TestDecoder:
         with pytest.raises(TypeError, match="Oh no!"):
             dec.decode(msg)
 
-    @pytest.mark.parametrize("err_cls", [msgspec.DecodeError, msgspec.ValidationError])
-    def test_decode_errors_subclass_of_value_error(self, err_cls):
-        assert issubclass(err_cls, ValueError)
-
-    @pytest.mark.parametrize("err_cls", [msgspec.EncodeError, msgspec.MsgspecError])
-    def test_other_errors_not_subclass_of_value_error(self, err_cls):
-        assert not issubclass(err_cls, ValueError)
-
 
 @pytest.mark.skipif(
     PY312,


### PR DESCRIPTION
FIxes #634

