### PR TITLE
[docs] fix two typos in benchmarks & structs section

### DIFF
--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -72,7 +72,7 @@ The libraries we're comparing are the following:
 - cattrs_ (23.2.3)
 
 Each benchmark creates a message containing one or more ``File``/``Directory``
-instances, then then serializes, deserializes, and validates it in a loop.
+instances, then serializes, deserializes, and validates it in a loop.
 
 The full benchmark source can be found
 `here <https://github.com/jcrist/msgspec/tree/main/benchmarks/bench_validation>`__.

--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -277,7 +277,7 @@ The generated ``__init__()`` for ``Subclass`` looks like:
 
 .. code-block:: python
 
-    def __init__(self, c: float, d: bytes = b"", * a: str, b: int = 0):
+    def __init__(self, c: float, d: bytes = b"", *, a: str, b: int = 0):
 
 The field ordering rules for ``Struct`` types are identical to those for
 `dataclasses`, see the `dataclasses docs <dataclasses>`_ for more information.


### PR DESCRIPTION
Hello Jim, greetings!

While reading the docs for msgspec, I saw these two typos so I decided to submit this PR and contribute to this super super duper awesome project. Please let me know if this is alright.

Btw, thank you for making this amazing library. The more I use msgspec and discover all the functionality msgspec provides by slowly exploring various sections of docs, how ultra performant it is, how detailed the docs are, the simplicity of its usage, it feels like OMG jaw dropping moment to me. Your work is truly amazing. 😻

Wish you a great year ahead! 🙌🏼 