### PR TITLE
Add bool dunder method for type def of UnsetType

### DIFF
--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -25,6 +25,8 @@ T = TypeVar("T")
 class UnsetType(enum.Enum):
     UNSET = "UNSET"
 
+    def __bool__() -> Literal[False]:...
+
 UNSET = UnsetType.UNSET
 
 class _NoDefault(enum.Enum):


### PR DESCRIPTION
Currently instances of UnsetType are falsy as would be expected but the type definition doesn't reflect this.

Tiny change so that I and others could stop seeing red squiggly lines