### PR TITLE
Set shape on exported memoryviews

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -15051,6 +15051,7 @@ mpack_decode_bin(
         Py_buffer *buffer = PyMemoryView_GET_BUFFER(view);
         buffer->buf = s;
         buffer->len = size;
+        buffer->shape = &(buffer->len);
         return view;
     }
 
@@ -15910,6 +15911,7 @@ mpack_decode_ext(
     buffer = PyMemoryView_GET_BUFFER(view);
     buffer->buf = data_buf;
     buffer->len = size;
+    buffer->shape = &(buffer->len);
 
     out = PyObject_CallFunctionObjArgs(self->ext_hook, pycode, view, NULL);
 done:

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -683,6 +683,7 @@ class TestTypedDecoder:
         res = msgspec.msgpack.decode(msg, type=memoryview)
         assert isinstance(res, memoryview)
         assert bytes(res) == b"abcde"
+        assert len(res) == 5
         if input_type is memoryview:
             assert sys.getrefcount(ref) == 3
             del msg
@@ -1301,6 +1302,7 @@ class TestExt:
         def ext_hook(code, buf):
             assert isinstance(buf, memoryview)
             assert bytes(buf) == exp_buf
+            assert len(buf) == len(exp_buf)
             assert code == 5
             return pickle.loads(buf)
 


### PR DESCRIPTION
Previously we would update the exposed `len` but not the `shape`. This went unnoticed since many consuming APIs only check `len` and not `shape`. This fixes the bug and adds some tests to ensure both fields are properly set.

Fixes #835.