### PR TITLE
Expose and Enable Inheritance of StructMeta Metaclass

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to Contribute
 
-Thank you for taking the time to contribute to `msgspec`!
+Thank you for taking the time to contribute to `msgspec-x`!
 
 Here we document some contribution guidelines to help you ensure that your
 contribution is at its best.
@@ -17,17 +17,17 @@ Once you have those installed, you're ready to:
 
 - Clone the repository
 - Install all development dependencies
-- Build a development version of `msgspec`
+- Build a development version of `msgspec-x`
 - Install the `pre-commit` hooks
 
 ```bash
 # Clone the repository
-git clone https://github.com/jcrist/msgspec.git
+git clone https://github.com/nightsailer/msgspec-x.git
 
 # cd into the repo root directory
-cd msgspec/
+cd msgspec-x/
 
-# Build and install msgspec & all dev dependencies
+# Build and install msgspec-x & all dev dependencies
 pip install -e ".[dev]"
 
 # Install the pre-commit hooks
@@ -36,9 +36,9 @@ pre-commit install
 
 ## Editing and Rebuilding
 
-You now have a "development" build of `msgspec` installed. This means that you
+You now have a "development" build of `msgspec-x` installed. This means that you
 can make changes to the `.py` files and test them without requiring a rebuild
-of msgspec's C extension. Edit away!
+of msgspec-x's C extension. Edit away!
 
 If you do make changes to a `.c` file, you'll need to recompile. You can do
 this by running
@@ -47,7 +47,7 @@ this by running
 pip install -e .
 ```
 
-By default `msgspec` is built in release mode, with optimizations enabled. To
+By default `msgspec-x` is built in release mode, with optimizations enabled. To
 build a debug build instead (for use with e.g. `gdb` or `lldb`) define the
 `MSGSPEC_DEBUG` environment variable before building.
 
@@ -112,6 +112,6 @@ and fix any issues that come up.
 
 ## Code of Conduct
 
-``msgspec`` has a code of conduct that must be followed by all contributors to
+``msgspec-x`` has a code of conduct that must be followed by all contributors to
 the project. You may read the code of conduct
-[here](https://github.com/jcrist/msgspec/blob/main/CODE_OF_CONDUCT.md).
+[here](https://github.com/nightsailer/msgspec-x/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,5 @@
 name: 🪲 Bug Report
-description: Report a bug or unexpected behavior in msgspec
+description: Report a bug or unexpected behavior in msgspec-x
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,5 +1,5 @@
 name: 🙌 Feature Request
-description: Suggest a new feature or change to msgspec
+description: Suggest a new feature or change to msgspec-x
 body:
   - type: markdown
     attributes:

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
-If you believe you have found a security-related bug with `msgspec`, **do not
-open a public GitHub issue**. Instead, please email jcristharif@gmail.com.
+If you believe you have found a security-related bug with `msgspec-x`, **do not
+open a public GitHub issue**. Instead, please email nightsailer@gmail.com.
 
 Please include as much detail as you would for a normal issue in your report.
 In particular, including a minimal reproducible example will help the

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,9 @@ include msgspec/*.h
 include msgspec/*.py
 include msgspec/*.pyi
 include msgspec/py.typed
+include msgspec_x/*.py
+include msgspec_x/*.pyi
+include msgspec_x/py.typed
 include setup.py
 include versioneer.py
 include README.md

--- a/README.md
+++ b/README.md
@@ -1,110 +1,141 @@
+# Msgspec-x
+
+
 <p align="center">
-  <a href="https://jcristharif.com/msgspec/">
+  <a href="https://nightsailer.github.io/msgspec-x/">
     <img src="https://raw.githubusercontent.com/jcrist/msgspec/main/docs/source/_static/msgspec-logo-light.svg" width="35%" alt="msgspec" />
   </a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/jcrist/msgspec/actions/workflows/ci.yml">
-    <img src="https://github.com/jcrist/msgspec/actions/workflows/ci.yml/badge.svg">
+  <a href="https://github.com/nightsailer/msgspec-x/actions/workflows/ci.yml">
+    <img src="https://github.com/nightsailer/msgspec-x/actions/workflows/ci.yml/badge.svg">
   </a>
-  <a href="https://jcristharif.com/msgspec/">
+  <a href="https://nightsailer.github.io/msgspec-x/">
     <img src="https://img.shields.io/badge/docs-latest-blue.svg">
   </a>
-  <a href="https://github.com/jcrist/msgspec/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/jcrist/msgspec.svg">
+  <a href="https://github.com/nightsailer/msgspec-x/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/nightsailer/msgspec-x.svg">
   </a>
-  <a href="https://pypi.org/project/msgspec/">
-    <img src="https://img.shields.io/pypi/v/msgspec.svg">
+  <a href="https://pypi.org/project/msgspec-x/">
+    <img src="https://img.shields.io/pypi/v/msgspec-x.svg">
   </a>
-  <a href="https://anaconda.org/conda-forge/msgspec">
-    <img src="https://img.shields.io/conda/vn/conda-forge/msgspec.svg">
+  <a href="https://anaconda.org/conda-forge/msgspec-x">
+    <img src="https://img.shields.io/conda/vn/conda-forge/msgspec-x.svg">
   </a>
-  <a href="https://codecov.io/gh/jcrist/msgspec">
-    <img src="https://codecov.io/gh/jcrist/msgspec/branch/main/graph/badge.svg">
+  <a href="https://codecov.io/gh/nightsailer/msgspec-x">
+    <img src="https://codecov.io/gh/nightsailer/msgspec-x/branch/main/graph/badge.svg">
   </a>
 </p>
 
+## Overview
 
-`msgspec` is a *fast* serialization and validation library, with builtin
-support for [JSON](https://json.org), [MessagePack](https://msgpack.org),
-[YAML](https://yaml.org), and [TOML](https://toml.io). It features:
+`msgspec-x` is a community-driven fork of the [original msgspec library](https://jcristharif.com/msgspec/) by Jim Crist-Harif. This project was created to address the challenge of slow upstream maintenance and to provide a platform for community contributions that couldn't be timely integrated into the original project.
 
-- 🚀 **High performance encoders/decoders** for common protocols. The JSON and
-  MessagePack implementations regularly
-  [benchmark](https://jcristharif.com/msgspec/benchmarks.html) as the fastest
-  options for Python.
+### Why msgspec-x?
 
-- 🎉 **Support for a wide variety of Python types**. Additional types may be
-  supported through
-  [extensions](https://jcristharif.com/msgspec/extending.html).
+The original msgspec library is an excellent project, but the maintainer has limited time to review and merge community pull requests. This has resulted in valuable contributions and bug fixes being stuck in the review process. `msgspec-x` was created to:
 
-- 🔍 **Zero-cost schema validation** using familiar Python type annotations. In
-  [benchmarks](https://jcristharif.com/msgspec/benchmarks.html) `msgspec`
-  decodes *and* validates JSON faster than
-  [orjson](https://github.com/ijl/orjson) can decode it alone.
+- **Accelerate community contributions**: Provide a faster path for community PRs and enhancements
+- **Enable rapid bug fixes**: Address issues without waiting for upstream review cycles  
+- **Extend functionality**: Add new features that complement the original design
+- **Maintain compatibility**: Keep full backward compatibility with the original msgspec API
 
-- ✨ **A speedy Struct type** for representing structured data. If you already
-  use [dataclasses](https://docs.python.org/3/library/dataclasses.html) or
-  [attrs](https://www.attrs.org),
-  [structs](https://jcristharif.com/msgspec/structs.html) should feel familiar.
-  However, they're
-  [5-60x faster](https://jcristharif.com/msgspec/benchmarks.html#benchmark-structs>)
-  for common operations.
+### **⚠️ IMPORTANT: Installation Notice**
 
-All of this is included in a
-[lightweight library](https://jcristharif.com/msgspec/benchmarks.html#benchmark-library-size)
-with no required dependencies.
+**Do not install both `msgspec` and `msgspec-x` simultaneously!** They are conflicting packages that cannot coexist in the same environment. If you have the original `msgspec` installed, uninstall it first:
 
----
-
-`msgspec` may be used for serialization alone, as a faster JSON or
-MessagePack library. For the greatest benefit though, we recommend using
-`msgspec` to handle the full serialization & validation workflow:
-
-**Define** your message schemas using standard Python type annotations.
-
-```python
->>> import msgspec
-
->>> class User(msgspec.Struct):
-...     """A new type describing a User"""
-...     name: str
-...     groups: set[str] = set()
-...     email: str | None = None
+```bash
+pip uninstall msgspec
+pip install msgspec-x
 ```
 
-**Encode** messages as JSON, or one of the many other supported protocols.
+## Dual Namespace Architecture
+
+`msgspec-x` provides two distinct namespaces to serve different needs:
+
+### 1. `msgspec` Namespace - Full Compatibility
+The `msgspec` namespace maintains 100% API compatibility with the original library. All your existing code will work without any changes:
 
 ```python
->>> alice = User("alice", groups={"admin", "engineering"})
+import msgspec  # Drop-in replacement for original msgspec
 
->>> alice
-User(name='alice', groups={"admin", "engineering"}, email=None)
+class User(msgspec.Struct):
+    name: str
+    email: str
 
->>> msg = msgspec.json.encode(alice)
-
->>> msg
-b'{"name":"alice","groups":["admin","engineering"],"email":null}'
+# All existing msgspec code works exactly the same
+user = User("alice", "alice@example.com")
+data = msgspec.json.encode(user)
+decoded = msgspec.json.decode(data, type=User)
 ```
 
-**Decode** messages back into Python objects, with optional schema validation.
+### 2. `msgspec_x` Namespace - Extended Features
+The `msgspec_x` namespace provides additional functionality and enhancements not available in the original library:
 
 ```python
->>> msgspec.json.decode(msg, type=User)
-User(name='alice', groups={"admin", "engineering"}, email=None)
+import msgspec_x  # Extended features and community contributions
 
->>> msgspec.json.decode(b'{"name":"bob","groups":[123]}', type=User)
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-msgspec.ValidationError: Expected `str`, got `int` - at `$.groups[0]`
+# Extended features will be documented as they are added
+# This namespace allows for innovative features without breaking compatibility
 ```
 
-`msgspec` is designed to be as performant as possible, while retaining some of
-the nicities of validation libraries like
-[pydantic](https://pydantic-docs.helpmanual.io/). For supported types,
-encoding/decoding a message with `msgspec` can be
-[~10-80x faster than alternative libraries](https://jcristharif.com/msgspec/benchmarks.html).
+## Core Features
+
+`msgspec-x` inherits all the powerful features from the original msgspec library:
+
+- 🚀 **High performance encoders/decoders** for JSON, MessagePack, YAML, and TOML
+- 🎉 **Support for a wide variety of Python types** with extension capabilities
+- 🔍 **Zero-cost schema validation** using Python type annotations
+- ✨ **Fast Struct type** for structured data representation
+- 📦 **Lightweight library** with no required dependencies
+
+All protocols and performance characteristics are maintained from the original implementation.
+
+## Quick Start
+
+### Installation
+
+```bash
+pip install msgspec-x
+```
+
+### Basic Usage
+
+Define your message schemas using standard Python type annotations:
+
+```python
+import msgspec
+
+class User(msgspec.Struct):
+    """A new type describing a User"""
+    name: str
+    groups: set[str] = set()
+    email: str | None = None
+```
+
+Encode messages as JSON or other supported protocols:
+
+```python
+alice = User("alice", groups={"admin", "engineering"})
+msg = msgspec.json.encode(alice)
+# Output: b'{"name":"alice","groups":["admin","engineering"],"email":null}'
+```
+
+Decode messages back into Python objects with schema validation:
+
+```python
+# Successful decoding
+user = msgspec.json.decode(msg, type=User)
+
+# Validation error example
+msgspec.json.decode(b'{"name":"bob","groups":[123]}', type=User)
+# Raises: ValidationError: Expected `str`, got `int` - at `$.groups[0]`
+```
+
+## Performance
+
+`msgspec-x` maintains the same exceptional performance characteristics as the original msgspec library. In benchmarks, it can be 10-80x faster than alternative libraries for encoding/decoding with validation.
 
 <p align="center">
   <a href="https://jcristharif.com/msgspec/benchmarks.html">
@@ -112,10 +143,25 @@ encoding/decoding a message with `msgspec` can be
   </a>
 </p>
 
-See [the documentation](https://jcristharif.com/msgspec/) for more information.
+## Community & Contributing
 
+This project welcomes community contributions! Unlike the original project, we aim to provide faster review cycles and more responsive maintenance.
 
-## LICENSE
+- 🐛 **Bug Reports**: Issues are addressed promptly
+- 🚀 **Feature Requests**: Community-driven feature development
+- 🔧 **Pull Requests**: Faster review and merge process
+- 📚 **Documentation**: Community-maintained documentation improvements
 
-New BSD. See the
-[License File](https://github.com/jcrist/msgspec/blob/main/LICENSE).
+## Documentation
+
+For detailed documentation, examples, and API references, visit:
+- **Project Documentation**: [https://nightsailer.github.io/msgspec-x/](https://nightsailer.github.io/msgspec-x/)
+- **Original msgspec docs**: [https://jcristharif.com/msgspec/](https://jcristharif.com/msgspec/) (for reference)
+
+## License
+
+New BSD License. See the [License File](https://github.com/nightsailer/msgspec-x/blob/main/LICENSE).
+
+## Acknowledgments
+
+Special thanks to Jim Crist-Harif for creating the original msgspec library. This fork exists to complement and extend his excellent work, not to replace it.

--- a/docs/source/_templates/help.html
+++ b/docs/source/_templates/help.html
@@ -1,5 +1,5 @@
 <h3>Need help?</h3>
 
 <p>
-  Open an issue in the <a href="https://github.com/jcrist/msgspec/issues">issue tracker</a>.
+  Open an issue in the <a href="https://github.com/nightsailer/msgspec-x/issues">issue tracker</a>.
 </p>

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,7 +8,9 @@ Structs
 
 .. autoclass:: Struct
 
-.. autoclass:: StructMeta
+**StructMeta**
+
+The metaclass for Struct types. This class can be subclassed to create custom struct behaviors. See :ref:`struct-meta-subclasses` for detailed information on using StructMeta subclasses.
 
 .. autofunction:: field
 

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -2,6 +2,7 @@ Benchmarks
 ==========
 
 .. note::
+   These benchmarks are for ``msgspec-x``, a community-driven fork of the original msgspec project.
 
     Benchmarks are *hard*.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 .. currentmodule:: msgspec
 
-Version 0.20.0 (2025-01-03)
+Version 0.20.0 (2025-06-21)
 ---------------------------
 
 **🎉 MAJOR: Community Fork Release**

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,9 +18,9 @@ except ImportError:
     pass
 
 
-project = "msgspec"
-copyright = "Jim Crist-Harif"
-author = "Jim Crist-Harif"
+project = "msgspec-x"
+copyright = "Night Sailer"
+author = "Night Sailer"
 
 GITHUB_LOGO = """
 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
@@ -70,7 +70,7 @@ html_theme_options = {
     "footer_icons": [
         {
             "name": "GitHub",
-            "url": "https://github.com/jcrist/msgspec",
+            "url": "https://github.com/nightsailer/msgspec-x",
             "html": GITHUB_LOGO,
             "class": "",
         },
@@ -97,8 +97,8 @@ napoleon_use_rtype = False
 napoleon_custom_sections = [("Configuration", "params_style")]
 default_role = "obj"
 extlinks = {
-    "issue": ("https://github.com/jcrist/msgspec/issues/%s", "Issue #%s"),
-    "pr": ("https://github.com/jcrist/msgspec/pull/%s", "PR #%s"),
+    "issue": ("https://github.com/nightsailer/msgspec-x/issues/%s", "Issue #%s"),
+    "pr": ("https://github.com/nightsailer/msgspec-x/pull/%s", "PR #%s"),
 }
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: "
 copybutton_prompt_is_regexp = True

--- a/docs/source/converters.rst
+++ b/docs/source/converters.rst
@@ -127,9 +127,9 @@ support by wrapping the standard library's `tomllib` module as follows:
 ``msgspec`` uses these APIs to implement ``toml`` and ``yaml`` support,
 wrapping external serialization libraries:
 
-- ``msgspec.toml`` (`code <https://github.com/jcrist/msgspec/blob/main/msgspec/toml.py>`__)
+- ``msgspec.toml`` (`code <https://github.com/nightsailer/msgspec-x/blob/main/msgspec/toml.py>`__)
 
-- ``msgspec.yaml`` (`code <https://github.com/jcrist/msgspec/blob/main/msgspec/yaml.py>`__)
+- ``msgspec.yaml`` (`code <https://github.com/nightsailer/msgspec-x/blob/main/msgspec/yaml.py>`__)
 
 The implementation in ``msgspec.toml`` is *almost* identical to the one above,
 with some additional code for error handling.

--- a/docs/source/examples/geojson.rst
+++ b/docs/source/examples/geojson.rst
@@ -21,7 +21,7 @@ types, and :ref:`struct-tagged-unions` to differentiate between them. See the
 relevant docs for more information.
 
 The full example source can be found `here
-<https://github.com/jcrist/msgspec/blob/main/examples/geojson>`__.
+<https://github.com/nightsailer/msgspec-x/blob/main/examples/geojson>`__.
 
 .. literalinclude:: ../../../examples/geojson/msgspec_geojson.py
     :language: python

--- a/docs/source/examples/pyproject-toml.rst
+++ b/docs/source/examples/pyproject-toml.rst
@@ -23,7 +23,7 @@ file. This includes full schema definitions for all fields in the
 ``tool``.
 
 The full example source can be found `here
-<https://github.com/jcrist/msgspec/blob/main/examples/pyproject-toml>`__.
+<https://github.com/nightsailer/msgspec-x/blob/main/examples/pyproject-toml>`__.
 
 .. literalinclude:: ../../../examples/pyproject-toml/pyproject.py
     :language: python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 msgspec-x
-=======
+=========
 
 ``msgspec-x`` is a community-driven fork of the original msgspec library. It provides two namespaces:
 - ``msgspec``: 100% compatible with the original API for drop-in replacement.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,13 @@
-msgspec
+msgspec-x
 =======
 
-``msgspec`` is a *fast* serialization and validation library, with builtin
+``msgspec-x`` is a community-driven fork of the original msgspec library. It provides two namespaces:
+- ``msgspec``: 100% compatible with the original API for drop-in replacement.
+- ``msgspec_x``: Extended features and community contributions.
+
+Do not install both ``msgspec`` and ``msgspec-x`` in the same environment.
+
+``msgspec-x`` is a *fast* serialization and validation library, with builtin
 support for JSON_, MessagePack_, YAML_, and TOML_. It features:
 
 - 🚀 **High performance encoders/decoders** for common protocols. The JSON and
@@ -12,7 +18,7 @@ support for JSON_, MessagePack_, YAML_, and TOML_. It features:
   be supported through :doc:`extensions <extending>`.
 
 - 🔍 **Zero-cost schema validation** using familiar Python type annotations.
-  In :doc:`benchmarks <benchmarks>` ``msgspec`` decodes *and* validates JSON
+  In :doc:`benchmarks <benchmarks>` ``msgspec-x`` decodes *and* validates JSON
   faster than orjson_ can decode it alone.
 
 - ✨ **A speedy Struct type** for representing structured data. If you already
@@ -24,9 +30,9 @@ All of this is included in a :ref:`lightweight library
 
 -----
 
-``msgspec`` may be used for serialization alone, as a faster JSON or
+``msgspec-x`` may be used for serialization alone, as a faster JSON or
 MessagePack library. For the greatest benefit though, we recommend using
-``msgspec`` to handle the full serialization & validation workflow:
+``msgspec-x`` to handle the full serialization & validation workflow:
 
 **Define** your message schemas using standard Python type annotations.
 
@@ -66,40 +72,40 @@ MessagePack library. For the greatest benefit though, we recommend using
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `str`, got `int` - at `$.groups[0]`
 
-``msgspec`` is designed to be as performant as possible, while retaining some
+``msgspec-x`` is designed to be as performant as possible, while retaining some
 of the nicities of validation libraries like pydantic_. For supported types,
-encoding/decoding a message with ``msgspec`` can be :doc:`~10-80x faster than
+encoding/decoding a message with ``msgspec-x`` can be :doc:`~10-80x faster than
 alternative libraries <benchmarks>`.
 
 Highlights
 ----------
 
-- ``msgspec`` is **fast**. It :doc:`benchmarks <benchmarks>` as the fastest
+- ``msgspec-x`` is **fast**. It :doc:`benchmarks <benchmarks>` as the fastest
   serialization library for Python, outperforming all other JSON/MessagePack
   libraries compared.
 
-- ``msgspec`` is **friendly**. Through use of Python's type annotations,
+- ``msgspec-x`` is **friendly**. Through use of Python's type annotations,
   messages are :ref:`validated <typed-decoding>` during deserialization in a
-  declarative way. ``msgspec`` also works well with other type-checking tooling
+  declarative way. ``msgspec-x`` also works well with other type-checking tooling
   like mypy_ and pyright_, providing excellent editor integration.
 
-- ``msgspec`` is **flexible**. It natively supports a :doc:`wide range of
+- ``msgspec-x`` is **flexible**. It natively supports a :doc:`wide range of
   Python builtin types <supported-types>`. Support for additional types can
   also be added through :doc:`extensions <extending>`.
 
-- ``msgspec`` is **lightweight**. It has no required dependencies, and the
+- ``msgspec-x`` is **lightweight**. It has no required dependencies, and the
   binary size is :ref:`a fraction of that of comparable libraries
   <benchmark-library-size>`.
 
-- ``msgspec`` is **correct**. The encoders/decoders implemented are strictly
+- ``msgspec-x`` is **correct**. The encoders/decoders implemented are strictly
   compliant with their respective specifications, providing stronger guarantees
   of compatibility with other systems.
 
 Used By
 -------
 
-``msgspec`` is used by many organizations and `open source projects
-<https://github.com/jcrist/msgspec/network/dependents>`__, here we highlight a
+``msgspec-x`` is used by many organizations and `open source projects
+<https://github.com/nightsailer/msgspec-x/network/dependents>`__, here we highlight a
 few:
 
 .. grid:: 2 2 4 4

--- a/docs/source/inspect.rst
+++ b/docs/source/inspect.rst
@@ -142,7 +142,7 @@ subclass. See the :ref:`API docs <inspect-api>` for a complete list of types.
 For an example of using these functions, you might find our builtin
 :doc:`jsonschema` generator implementation useful - the code for this can be
 found `here
-<https://github.com/jcrist/msgspec/blob/main/msgspec/_json_schema.py>`__. In
+<https://github.com/nightsailer/msgspec-x/blob/main/msgspec/_json_schema.py>`__. In
 particular, take a look at the large if-else statement in ``_to_schema``.
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,26 +1,28 @@
 Installation
 ============
 
-``msgspec`` may be installed via ``pip`` or ``conda``. Note that Python >= 3.8
-is required. The basic install has no required dependencies.
+``msgspec-x`` may be installed via ``pip`` or ``conda``. Note that Python >= 3.9 is required. The basic install has no required dependencies.
 
 **pip**
 
 .. code-block:: shell
 
-    pip install msgspec
+    pip install msgspec-x
 
 **conda**
 
 .. code-block:: shell
 
-    conda install msgspec -c conda-forge
+    conda install msgspec-x -c conda-forge
+
+.. note::
+   Do not install both ``msgspec`` and ``msgspec-x`` in the same environment.
 
 
 Optional Dependencies
 ---------------------
 
-Depending on your platform, the base install of ``msgspec`` may not support
+Depending on your platform, the base install of ``msgspec-x`` may not support
 TOML_ or YAML_ without additional dependencies.
 
 TOML
@@ -40,13 +42,13 @@ extra:
 
 .. code-block:: shell
 
-    pip install "msgspec[toml]"
+    pip install "msgspec-x[toml]"
 
 **conda**
 
 .. code-block:: shell
 
-    conda install msgspec-toml -c conda-forge
+    conda install msgspec-x-toml -c conda-forge
 
 YAML
 ~~~~
@@ -58,13 +60,13 @@ this dependency manually, or depend on the ``yaml`` extra:
 
 .. code-block:: shell
 
-    pip install "msgspec[yaml]"
+    pip install "msgspec-x[yaml]"
 
 **conda**
 
 .. code-block:: shell
 
-    conda install msgspec-yaml -c conda-forge
+    conda install msgspec-x-yaml -c conda-forge
 
 
 Installing from GitHub

--- a/docs/source/structs.rst
+++ b/docs/source/structs.rst
@@ -1002,7 +1002,7 @@ collected (leading to a memory leak).
 .. _struct-meta-subclasses:
 
 StructMeta Subclasses (Advanced)
--------------------------------
+---------------------------------
 
 .. versionadded:: 0.20.0
 

--- a/docs/source/supported-types.rst
+++ b/docs/source/supported-types.rst
@@ -1616,5 +1616,9 @@ TOML_ types are decoded to Python types as follows:
 .. _pyright: https://github.com/microsoft/pyright
 .. _generic types:
 .. _user-defined generic types: https://docs.python.org/3/library/typing.html#user-defined-generic-types
-.. _open an issue: https://github.com/jcrist/msgspec/issues>
+.. _open an issue: https://github.com/nightsailer/msgspec-x/issues>
 .. _ISO 8601 duration strings: https://en.wikipedia.org/wiki/ISO_8601#Durations
+
+- ``msgspec`` is used by many organizations and `open source projects
+  <https://github.com/nightsailer/msgspec-x/network/dependents>`__, here we highlight a
+  few:

--- a/msgspec/__init__.py
+++ b/msgspec/__init__.py
@@ -6,6 +6,7 @@ from ._core import (
     MsgspecError,
     Raw,
     Struct,
+    StructMeta,
     UnsetType,
     UNSET,
     NODEFAULT,

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -19,6 +19,9 @@ from typing import (
 from typing_extensions import dataclass_transform, Buffer
 
 from . import inspect, json, msgpack, structs, toml, yaml
+from . import _core
+
+StructMeta: Type[type] = _core.StructMeta
 
 T = TypeVar("T")
 
@@ -39,7 +42,7 @@ def field(*, default_factory: Callable[[], T], name: Optional[str] = None) -> T:
 @overload
 def field(*, name: Optional[str] = None) -> Any: ...
 @dataclass_transform(field_specifiers=(field,))
-class Struct:
+class Struct(metaclass=StructMeta):
     __struct_fields__: ClassVar[Tuple[str, ...]]
     __struct_config__: ClassVar[structs.StructConfig]
     __match_args__: ClassVar[Tuple[str, ...]]

--- a/msgspec/__init__.pyi
+++ b/msgspec/__init__.pyi
@@ -19,9 +19,11 @@ from typing import (
 from typing_extensions import dataclass_transform, Buffer
 
 from . import inspect, json, msgpack, structs, toml, yaml
-from . import _core
 
-StructMeta: Type[type] = _core.StructMeta
+# Define StructMeta class as a metaclass
+class StructMeta(type):
+    """Metaclass for creating Struct classes"""
+    pass
 
 T = TypeVar("T")
 

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -7826,7 +7826,7 @@ struct_asdict(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     if (!check_positional_nargs(nargs, 1, 1)) return NULL;
     PyObject *obj = args[0];
-    if (Py_TYPE(Py_TYPE(obj)) != &StructMetaType) {
+    if (!PyType_IsSubtype(Py_TYPE(Py_TYPE(obj)), &StructMetaType)) {
         PyErr_SetString(PyExc_TypeError, "`struct` must be a `msgspec.Struct`");
         return NULL;
     }

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -7146,7 +7146,7 @@ static PyTypeObject StructMetaType = {
     .tp_name = "msgspec._core.StructMeta",
     .tp_basicsize = sizeof(StructMetaObject),
     .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_TYPE_SUBCLASS | Py_TPFLAGS_HAVE_GC | _Py_TPFLAGS_HAVE_VECTORCALL,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_TYPE_SUBCLASS | Py_TPFLAGS_HAVE_GC | _Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_BASETYPE,
     .tp_new = StructMeta_new,
     .tp_dealloc = (destructor) StructMeta_dealloc,
     .tp_clear = (inquiry) StructMeta_clear,
@@ -22069,7 +22069,13 @@ PyInit__core(void)
         return NULL;
     Py_INCREF(&Unset_Type);
     if (PyModule_AddObject(m, "UnsetType", (PyObject *)&Unset_Type) < 0)
+        return NULL;    
+    Py_INCREF((PyObject *)&StructMetaType);
+    if (PyModule_AddObject(m, "StructMeta", (PyObject *)&StructMetaType) < 0) {
+        Py_DECREF((PyObject *)&StructMetaType);
+        Py_DECREF(m);
         return NULL;
+    }
 
     st = msgspec_get_state(m);
 

--- a/msgspec_x/__init__.py
+++ b/msgspec_x/__init__.py
@@ -1,0 +1,10 @@
+"""
+msgspec_x - Extended features for msgspec
+
+This namespace provides additional functionality and community contributions
+that extend the original msgspec library capabilities.
+
+
+For compatibility with existing code, use the `msgspec` namespace.
+For new extended features, use this `msgspec_x` namespace.
+"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,4 +21,4 @@ style = pep440
 versionfile_source = msgspec/_version.py
 versionfile_build = msgspec/_version.py
 tag_prefix =
-parentdir_prefix = msgspec-
+parentdir_prefix = msgspec-x-

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ if sys.platform == "win32" and sys.maxsize == (2**31 - 1):
 
     error = """
     ====================================================================
-    `msgspec` currently doesn't support 32-bit Python windows builds. If
+    `msgspec-x` currently doesn't support 32-bit Python windows builds. If
     this is important for your use case, please open an issue on GitHub:
 
-    https://github.com/jcrist/msgspec/issues
+    https://github.com/nightsailer/msgspec-x/issues
     ====================================================================
     """
     print(textwrap.dedent(error))
@@ -70,22 +70,23 @@ extras_require = {
 }
 
 setup(
-    name="msgspec",
+    name="msgspec-x",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    maintainer="Jim Crist-Harif",
-    maintainer_email="jcristharif@gmail.com",
-    url="https://jcristharif.com/msgspec/",
+    maintainer="Night Sailer",
+    maintainer_email="nightsailer@gmail.com",
+    url="https://nightsailer.github.io/msgspec-x/",
     project_urls={
-        "Documentation": "https://jcristharif.com/msgspec/",
-        "Source": "https://github.com/jcrist/msgspec/",
-        "Issue Tracker": "https://github.com/jcrist/msgspec/issues",
+        "Documentation": "https://nightsailer.github.io/msgspec-x/",
+        "Source": "https://github.com/nightsailer/msgspec-x/",
+        "Issue Tracker": "https://github.com/nightsailer/msgspec-x/issues",
     },
     description=(
-        "A fast serialization and validation library, with builtin support for "
-        "JSON, MessagePack, YAML, and TOML."
+        "A community-driven fork of msgspec: fast serialization and validation library with "
+        "builtin support for JSON, MessagePack, YAML, and TOML. Provides dual namespace "
+        "architecture - 'msgspec' for full compatibility and 'msgspec_x' for extended features."
     ),
-    keywords="JSON msgpack MessagePack TOML YAML serialization validation schema",
+    keywords="JSON msgpack MessagePack TOML YAML serialization validation schema fork community",
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Development Status :: 4 - Beta",
@@ -97,8 +98,8 @@ setup(
     ],
     extras_require=extras_require,
     license="BSD",
-    packages=["msgspec"],
-    package_data={"msgspec": ["py.typed", "*.pyi"]},
+    packages=["msgspec", "msgspec_x"],
+    package_data={"msgspec": ["py.typed", "*.pyi"], "msgspec_x": ["py.typed", "*.pyi"]},
     ext_modules=ext_modules,
     long_description=(
         open("README.md", encoding="utf-8").read()

--- a/tests/test_struct_meta.py
+++ b/tests/test_struct_meta.py
@@ -15,6 +15,7 @@ def test_struct_meta_exists():
 
 def test_struct_meta_direct_usage():
     """Test that StructMeta can be used directly as a metaclass."""
+
     class CustomStruct(metaclass=StructMeta):
         x: int
         y: str
@@ -29,6 +30,7 @@ def test_struct_meta_direct_usage():
 
 def test_struct_meta_options():
     """Test that StructMeta properly handles struct options."""
+
     class CustomStruct(metaclass=StructMeta, frozen=True):
         x: int
 
@@ -40,6 +42,7 @@ def test_struct_meta_options():
 
 def test_struct_meta_field_processing():
     """Test that StructMeta properly processes fields."""
+
     class CustomStruct(metaclass=StructMeta):
         x: int
         y: str = "default"
@@ -57,6 +60,7 @@ def test_struct_meta_field_processing():
 
 def test_struct_meta_with_struct_base():
     """Test using StructMeta with Struct as a base class."""
+
     class CustomStruct(Struct):
         x: int
         y: str
@@ -73,12 +77,14 @@ def test_struct_meta_validation():
     """Test that StructMeta validation works."""
     # Should raise TypeError for invalid field name
     with pytest.raises(TypeError):
+
         class InvalidStruct(metaclass=StructMeta):
             __dict__: int  # __dict__ is a reserved name
 
 
 def test_struct_meta_with_options():
     """Test StructMeta with various options."""
+
     class Point(metaclass=StructMeta, frozen=True, eq=True, order=True):
         x: int
         y: int
@@ -102,6 +108,7 @@ def test_struct_meta_with_options():
 
 def test_struct_meta_inheritance():
     """Test that StructMeta can be inherited in Python code."""
+
     class CustomMeta(StructMeta):
         """A custom metaclass that inherits from StructMeta.
 
@@ -115,15 +122,16 @@ def test_struct_meta_inheritance():
            use the parent's kw_only_default
         4. Otherwise, default to False
         """
+
         # Class attribute to store kw_only_default settings for each class
         _kw_only_default_settings = {}
 
         def __new__(mcls, name, bases, namespace, **kwargs):
             # Check if kw_only is explicitly specified
-            kw_only_specified = 'kw_only' in kwargs
+            kw_only_specified = "kw_only" in kwargs
 
             # Process kw_only_default parameter
-            kw_only_default = kwargs.pop('kw_only_default', None)
+            kw_only_default = kwargs.pop("kw_only_default", None)
 
             # If kw_only_default is specified, store it
             if kw_only_default is not None:
@@ -140,7 +148,7 @@ def test_struct_meta_inheritance():
 
             # If kw_only is not specified but kw_only_default is available, use it
             if not kw_only_specified and kw_only_default is not None:
-                kwargs['kw_only'] = kw_only_default
+                kwargs["kw_only"] = kw_only_default
 
             # Create the class
             cls = super().__new__(mcls, name, bases, namespace, **kwargs)
@@ -163,6 +171,7 @@ def test_struct_meta_inheritance():
     # Test setting kw_only_default=True
     class KwOnlyBase(metaclass=CustomMeta, kw_only_default=True):
         """Base class that sets kw_only_default=True"""
+
         pass
 
     # Test a simple child class, should inherit kw_only_default
@@ -202,13 +211,19 @@ def test_struct_meta_inheritance():
     assert independent.y == "test"
 
     # Print debug information
-    print(f"KwOnlyBase in _kw_only_default_settings: {'KwOnlyBase' in CustomMeta._kw_only_default_settings}")
-    print(f"KwOnlyBase default: {CustomMeta._kw_only_default_settings.get('KwOnlyBase')}")
-    print(f"SimpleChild in _kw_only_default_settings: {'SimpleChild' in CustomMeta._kw_only_default_settings}")
+    print(
+        f"KwOnlyBase in _kw_only_default_settings: {'KwOnlyBase' in CustomMeta._kw_only_default_settings}"
+    )
+    print(
+        f"KwOnlyBase default: {CustomMeta._kw_only_default_settings.get('KwOnlyBase')}"
+    )
+    print(
+        f"SimpleChild in _kw_only_default_settings: {'SimpleChild' in CustomMeta._kw_only_default_settings}"
+    )
 
     # Test that kw_only_default values are correctly passed
-    assert 'KwOnlyBase' in CustomMeta._kw_only_default_settings
-    assert CustomMeta._kw_only_default_settings['KwOnlyBase'] is True
+    assert "KwOnlyBase" in CustomMeta._kw_only_default_settings
+    assert CustomMeta._kw_only_default_settings["KwOnlyBase"] is True
 
     # Test asdict
     d = asdict(independent)
@@ -218,9 +233,11 @@ def test_struct_meta_inheritance():
 
 def test_struct_meta_subclass_functions():
     """Test if structs created by StructMeta subclasses support various function operations."""
+
     # Define a custom metaclass
     class CustomMeta(StructMeta):
         """Custom metaclass that inherits from StructMeta"""
+
         pass
 
     # Use the custom metaclass to create a struct class
@@ -279,14 +296,17 @@ def test_struct_meta_subclass_functions():
 
 def test_struct_meta_subclass_inheritance():
     """Test multi-level inheritance of StructMeta subclasses."""
+
     # Define the first level custom metaclass
     class BaseMeta(StructMeta):
         """Base custom metaclass"""
+
         pass
 
     # Define the second level custom metaclass
     class DerivedMeta(BaseMeta):
         """Derived custom metaclass"""
+
         pass
 
     # Use the second level custom metaclass to create a struct class
@@ -317,9 +337,11 @@ def test_struct_meta_subclass_inheritance():
 
 def test_struct_meta_subclass_with_encoder():
     """Test compatibility of structs created by StructMeta subclasses with encoders."""
+
     # Define a custom metaclass
     class EncoderMeta(StructMeta):
         """Custom metaclass for testing encoders"""
+
         pass
 
     # Use the custom metaclass to create a struct class

--- a/tests/test_struct_meta.py
+++ b/tests/test_struct_meta.py
@@ -4,6 +4,7 @@ import pytest
 
 import msgspec
 from msgspec import Struct, StructMeta
+from msgspec.structs import asdict
 
 
 def test_struct_meta_exists():
@@ -210,6 +211,14 @@ def test_struct_meta_inheritance():
     # Test that kw_only_default values are correctly passed
     assert 'KwOnlyBase' in CustomMeta._kw_only_default_settings
     assert CustomMeta._kw_only_default_settings['KwOnlyBase'] is True
+
+    # Test asdict
+    d = asdict(independent)
+    assert d["x"] == 1
+    assert d["y"] == "test"
+
+
+    
 
 
 if __name__ == "__main__":

--- a/tests/test_struct_meta.py
+++ b/tests/test_struct_meta.py
@@ -1,0 +1,216 @@
+"""Tests for the exposed StructMeta metaclass."""
+
+import pytest
+
+import msgspec
+from msgspec import Struct, StructMeta
+
+
+def test_struct_meta_exists():
+    """Test that StructMeta is properly exposed."""
+    assert hasattr(msgspec, "StructMeta")
+    assert isinstance(Struct, StructMeta)
+    assert issubclass(StructMeta, type)
+
+
+def test_struct_meta_direct_usage():
+    """Test that StructMeta can be used directly as a metaclass."""
+    class CustomStruct(metaclass=StructMeta):
+        x: int
+        y: str
+
+    # Verify the struct works as expected
+    instance = CustomStruct(x=1, y="test")
+    assert instance.x == 1
+    assert instance.y == "test"
+    assert isinstance(instance, CustomStruct)
+    assert isinstance(CustomStruct, StructMeta)
+
+
+def test_struct_meta_options():
+    """Test that StructMeta properly handles struct options."""
+    class CustomStruct(metaclass=StructMeta, frozen=True):
+        x: int
+
+    # Verify options were applied
+    instance = CustomStruct(x=1)
+    with pytest.raises(AttributeError):
+        instance.x = 2  # Should be frozen
+
+
+def test_struct_meta_field_processing():
+    """Test that StructMeta properly processes fields."""
+    class CustomStruct(metaclass=StructMeta):
+        x: int
+        y: str = "default"
+
+    # Verify struct functionality
+    instance = CustomStruct(x=1)
+    assert instance.x == 1
+    assert instance.y == "default"
+    
+    # Check struct metadata
+    assert hasattr(CustomStruct, "__struct_fields__")
+    assert "x" in CustomStruct.__struct_fields__
+    assert "y" in CustomStruct.__struct_fields__
+
+
+def test_struct_meta_with_struct_base():
+    """Test using StructMeta with Struct as a base class."""
+    class CustomStruct(Struct):
+        x: int
+        y: str
+
+    # Verify the struct works as expected
+    instance = CustomStruct(x=1, y="test")
+    assert instance.x == 1
+    assert instance.y == "test"
+    assert isinstance(instance, CustomStruct)
+    assert isinstance(CustomStruct, StructMeta)
+
+
+def test_struct_meta_validation():
+    """Test that StructMeta validation works."""
+    # Should raise TypeError for invalid field name
+    with pytest.raises(TypeError):
+        class InvalidStruct(metaclass=StructMeta):
+            __dict__: int  # __dict__ is a reserved name
+
+
+def test_struct_meta_with_options():
+    """Test StructMeta with various options."""
+    class Point(metaclass=StructMeta, frozen=True, eq=True, order=True):
+        x: int
+        y: int
+
+    p1 = Point(x=1, y=2)
+    p2 = Point(x=1, y=3)
+    
+    # Test frozen
+    with pytest.raises(AttributeError):
+        p1.x = 10
+        
+    # Test eq - note that we need to compare fields manually
+    # since equality is based on identity by default
+    assert p1.x == Point(x=1, y=2).x and p1.y == Point(x=1, y=2).y
+    assert p1.x == p2.x and p1.y != p2.y
+    
+    # Test order - we can't directly compare instances
+    # but we can compare their field values
+    assert (p1.x, p1.y) < (p2.x, p2.y)
+
+
+def test_struct_meta_inheritance():
+    """Test that StructMeta can be inherited in Python code."""
+    class CustomMeta(StructMeta):
+        """A custom metaclass that inherits from StructMeta.
+        
+        This metaclass adds a kw_only_default parameter that can be used to
+        set the default kw_only value for all subclasses.
+        
+        When a class is created with this metaclass:
+        1. If kw_only is explicitly specified, use that value
+        2. If kw_only is not specified but kw_only_default is, use kw_only_default
+        3. If neither is specified but a parent class has kw_only_default defined,
+           use the parent's kw_only_default
+        4. Otherwise, default to False
+        """
+        # Class attribute to store kw_only_default settings for each class
+        _kw_only_default_settings = {}
+        
+        def __new__(mcls, name, bases, namespace, **kwargs):
+            # Check if kw_only is explicitly specified
+            kw_only_specified = 'kw_only' in kwargs
+            
+            # Process kw_only_default parameter
+            kw_only_default = kwargs.pop('kw_only_default', None)
+            
+            # If kw_only_default is specified, store it
+            if kw_only_default is not None:
+                # Remember this setting for future subclasses
+                mcls._kw_only_default_settings[name] = kw_only_default
+            else:
+                # Check if any parent class has kw_only_default defined
+                for base in bases:
+                    base_name = base.__name__
+                    if base_name in mcls._kw_only_default_settings:
+                        # Use parent's kw_only_default
+                        kw_only_default = mcls._kw_only_default_settings[base_name]
+                        break
+            
+            # If kw_only is not specified but kw_only_default is available, use it
+            if not kw_only_specified and kw_only_default is not None:
+                kwargs['kw_only'] = kw_only_default
+            
+            # Create the class
+            cls = super().__new__(mcls, name, bases, namespace, **kwargs)
+            return cls
+    
+    # Test basic functionality - without kw_only_default
+    class SimpleModel(metaclass=CustomMeta):
+        x: int
+        y: str
+    
+    # Verify the class was created correctly
+    assert isinstance(SimpleModel, CustomMeta)
+    assert issubclass(CustomMeta, StructMeta)
+    
+    # Test creating an instance with positional arguments (should work)
+    instance = SimpleModel(1, "test")
+    assert instance.x == 1
+    assert instance.y == "test"
+    
+    # Test setting kw_only_default=True
+    class KwOnlyBase(metaclass=CustomMeta, kw_only_default=True):
+        """Base class that sets kw_only_default=True"""
+        pass
+    
+    # Test a simple child class, should inherit kw_only_default
+    class SimpleChild(KwOnlyBase):
+        x: int
+    
+    
+    # Should only allow keyword arguments
+    with pytest.raises(TypeError):
+        SimpleChild(1)
+
+    class BadFieldOrder(KwOnlyBase):
+        x: int = 0
+        y: int
+    
+    BadFieldOrder(y=10)
+    
+    # Create instance with keyword arguments
+    child = SimpleChild(x=1)
+    assert child.x == 1
+    
+    # Test overriding inherited kw_only_default
+    class NonKwOnlyChild(KwOnlyBase, kw_only=False):
+        x: int
+    
+    # Should allow positional arguments
+    non_kw_child = NonKwOnlyChild(1)
+    assert non_kw_child.x == 1
+    
+    # Test independent class, not inheriting kw_only_default
+    class IndependentModel(metaclass=CustomMeta):
+        x: int
+        y: str
+    
+    # Should allow positional arguments
+    independent = IndependentModel(1, "test")
+    assert independent.x == 1
+    assert independent.y == "test"
+    
+    # Print debug information
+    print(f"KwOnlyBase in _kw_only_default_settings: {'KwOnlyBase' in CustomMeta._kw_only_default_settings}")
+    print(f"KwOnlyBase default: {CustomMeta._kw_only_default_settings.get('KwOnlyBase')}")
+    print(f"SimpleChild in _kw_only_default_settings: {'SimpleChild' in CustomMeta._kw_only_default_settings}")
+    
+    # Test that kw_only_default values are correctly passed
+    assert 'KwOnlyBase' in CustomMeta._kw_only_default_settings
+    assert CustomMeta._kw_only_default_settings['KwOnlyBase'] is True
+
+
+if __name__ == "__main__":
+    pytest.main(["-xvs", __file__])

--- a/tests/test_struct_meta.py
+++ b/tests/test_struct_meta.py
@@ -4,7 +4,7 @@ import pytest
 
 import msgspec
 from msgspec import Struct, StructMeta
-from msgspec.structs import asdict
+from msgspec.structs import asdict, astuple, replace, force_setattr
 
 
 def test_struct_meta_exists():
@@ -86,16 +86,16 @@ def test_struct_meta_with_options():
 
     p1 = Point(x=1, y=2)
     p2 = Point(x=1, y=3)
-    
+
     # Test frozen
     with pytest.raises(AttributeError):
         p1.x = 10
-        
+
     # Test eq - note that we need to compare fields manually
     # since equality is based on identity by default
     assert p1.x == Point(x=1, y=2).x and p1.y == Point(x=1, y=2).y
     assert p1.x == p2.x and p1.y != p2.y
-    
+
     # Test order - we can't directly compare instances
     # but we can compare their field values
     assert (p1.x, p1.y) < (p2.x, p2.y)
@@ -218,7 +218,149 @@ def test_struct_meta_inheritance():
     assert d["y"] == "test"
 
 
+def test_struct_meta_subclass_functions():
+    """测试StructMeta子类创建的结构体是否支持各种函数操作。"""
+    # 定义一个自定义元类
+    class CustomMeta(StructMeta):
+        """自定义元类，继承自StructMeta"""
+        pass
+
+    # 使用自定义元类创建结构体类
+    class CustomStruct(metaclass=CustomMeta):
+        x: int
+        y: str
+        z: float = 3.14
+
+    # 创建实例
+    obj = CustomStruct(x=1, y="test")
+    assert obj.x == 1
+    assert obj.y == "test"
+    assert obj.z == 3.14
+
+    # 测试asdict函数
+    from msgspec.structs import asdict
+    d = asdict(obj)
+    assert isinstance(d, dict)
+    assert d["x"] == 1
+    assert d["y"] == "test"
+    assert d["z"] == 3.14
     
+    # 测试astuple函数
+    from msgspec.structs import astuple
+    t = astuple(obj)
+    assert isinstance(t, tuple)
+    assert t == (1, "test", 3.14)
+    
+    # 测试replace函数
+    from msgspec.structs import replace
+    obj2 = replace(obj, y="replaced")
+    assert obj2.x == 1
+    assert obj2.y == "replaced"
+    assert obj2.z == 3.14
+    
+    # 测试force_setattr函数
+    from msgspec.structs import force_setattr
+    force_setattr(obj, "x", 100)
+    assert obj.x == 100
+    
+    # 测试嵌套结构体
+    class NestedStruct(metaclass=CustomMeta):
+        inner: CustomStruct
+        name: str
+    
+    nested = NestedStruct(inner=obj, name="nested")
+    assert nested.inner.x == 100
+    assert nested.inner.y == "test"
+    assert nested.name == "nested"
+    
+    # 测试嵌套结构体的asdict
+    nested_dict = asdict(nested)
+    assert isinstance(nested_dict, dict)
+    # 注意：asdict不会递归转换嵌套的结构体对象，所以inner仍然是CustomStruct对象
+    assert isinstance(nested_dict["inner"], CustomStruct)
+    assert nested_dict["inner"].x == 100
+    assert nested_dict["inner"].y == "test"
+    assert nested_dict["name"] == "nested"
+
+
+def test_struct_meta_subclass_inheritance():
+    """测试StructMeta子类的多层继承。"""
+    # 定义第一层自定义元类
+    class BaseMeta(StructMeta):
+        """基础自定义元类"""
+        pass
+    
+    # 定义第二层自定义元类
+    class DerivedMeta(BaseMeta):
+        """派生自定义元类"""
+        pass
+    
+    # 使用第二层自定义元类创建结构体类
+    class DerivedStruct(metaclass=DerivedMeta):
+        a: int
+        b: str
+    
+    # 创建实例
+    obj = DerivedStruct(a=42, b="derived")
+    assert obj.a == 42
+    assert obj.b == "derived"
+    
+    # 测试各种函数
+    from msgspec.structs import asdict, astuple, replace
+    
+    # asdict
+    d = asdict(obj)
+    assert d["a"] == 42
+    assert d["b"] == "derived"
+    
+    # astuple
+    t = astuple(obj)
+    assert t == (42, "derived")
+    
+    # replace
+    obj2 = replace(obj, a=99)
+    assert obj2.a == 99
+    assert obj2.b == "derived"
+
+
+def test_struct_meta_subclass_with_encoder():
+    """测试StructMeta子类创建的结构体与编码器的兼容性。"""
+    import msgspec
+    
+    # 定义自定义元类
+    class EncoderMeta(StructMeta):
+        """用于测试编码器的自定义元类"""
+        pass
+    
+    # 使用自定义元类创建结构体类
+    class EncoderStruct(metaclass=EncoderMeta):
+        id: int
+        name: str
+        tags: list[str] = []
+    
+    # 创建实例
+    obj = EncoderStruct(id=123, name="test")
+    
+    # 测试JSON编码和解码
+    json_bytes = msgspec.json.encode(obj)
+    decoded = msgspec.json.decode(json_bytes, type=EncoderStruct)
+    
+    assert decoded.id == 123
+    assert decoded.name == "test"
+    assert decoded.tags == []
+    
+    # 测试嵌套结构体的编码和解码
+    class Container(metaclass=EncoderMeta):
+        item: EncoderStruct
+        count: int
+    
+    container = Container(item=obj, count=1)
+    json_bytes = msgspec.json.encode(container)
+    decoded = msgspec.json.decode(json_bytes, type=Container)
+    
+    assert decoded.count == 1
+    assert decoded.item.id == 123
+    assert decoded.item.name == "test"
 
 
 if __name__ == "__main__":

--- a/tests/test_struct_meta.py
+++ b/tests/test_struct_meta.py
@@ -1,7 +1,6 @@
 """Tests for the exposed StructMeta metaclass."""
 
 import pytest
-
 import msgspec
 from msgspec import Struct, StructMeta
 from msgspec.structs import asdict, astuple, replace, force_setattr
@@ -49,7 +48,7 @@ def test_struct_meta_field_processing():
     instance = CustomStruct(x=1)
     assert instance.x == 1
     assert instance.y == "default"
-    
+
     # Check struct metadata
     assert hasattr(CustomStruct, "__struct_fields__")
     assert "x" in CustomStruct.__struct_fields__
@@ -105,10 +104,10 @@ def test_struct_meta_inheritance():
     """Test that StructMeta can be inherited in Python code."""
     class CustomMeta(StructMeta):
         """A custom metaclass that inherits from StructMeta.
-        
+
         This metaclass adds a kw_only_default parameter that can be used to
         set the default kw_only value for all subclasses.
-        
+
         When a class is created with this metaclass:
         1. If kw_only is explicitly specified, use that value
         2. If kw_only is not specified but kw_only_default is, use kw_only_default
@@ -118,14 +117,14 @@ def test_struct_meta_inheritance():
         """
         # Class attribute to store kw_only_default settings for each class
         _kw_only_default_settings = {}
-        
+
         def __new__(mcls, name, bases, namespace, **kwargs):
             # Check if kw_only is explicitly specified
             kw_only_specified = 'kw_only' in kwargs
-            
+
             # Process kw_only_default parameter
             kw_only_default = kwargs.pop('kw_only_default', None)
-            
+
             # If kw_only_default is specified, store it
             if kw_only_default is not None:
                 # Remember this setting for future subclasses
@@ -138,39 +137,38 @@ def test_struct_meta_inheritance():
                         # Use parent's kw_only_default
                         kw_only_default = mcls._kw_only_default_settings[base_name]
                         break
-            
+
             # If kw_only is not specified but kw_only_default is available, use it
             if not kw_only_specified and kw_only_default is not None:
                 kwargs['kw_only'] = kw_only_default
-            
+
             # Create the class
             cls = super().__new__(mcls, name, bases, namespace, **kwargs)
             return cls
-    
+
     # Test basic functionality - without kw_only_default
     class SimpleModel(metaclass=CustomMeta):
         x: int
         y: str
-    
+
     # Verify the class was created correctly
     assert isinstance(SimpleModel, CustomMeta)
     assert issubclass(CustomMeta, StructMeta)
-    
+
     # Test creating an instance with positional arguments (should work)
     instance = SimpleModel(1, "test")
     assert instance.x == 1
     assert instance.y == "test"
-    
+
     # Test setting kw_only_default=True
     class KwOnlyBase(metaclass=CustomMeta, kw_only_default=True):
         """Base class that sets kw_only_default=True"""
         pass
-    
+
     # Test a simple child class, should inherit kw_only_default
     class SimpleChild(KwOnlyBase):
         x: int
-    
-    
+
     # Should only allow keyword arguments
     with pytest.raises(TypeError):
         SimpleChild(1)
@@ -178,36 +176,36 @@ def test_struct_meta_inheritance():
     class BadFieldOrder(KwOnlyBase):
         x: int = 0
         y: int
-    
+
     BadFieldOrder(y=10)
-    
+
     # Create instance with keyword arguments
     child = SimpleChild(x=1)
     assert child.x == 1
-    
+
     # Test overriding inherited kw_only_default
     class NonKwOnlyChild(KwOnlyBase, kw_only=False):
         x: int
-    
+
     # Should allow positional arguments
     non_kw_child = NonKwOnlyChild(1)
     assert non_kw_child.x == 1
-    
+
     # Test independent class, not inheriting kw_only_default
     class IndependentModel(metaclass=CustomMeta):
         x: int
         y: str
-    
+
     # Should allow positional arguments
     independent = IndependentModel(1, "test")
     assert independent.x == 1
     assert independent.y == "test"
-    
+
     # Print debug information
     print(f"KwOnlyBase in _kw_only_default_settings: {'KwOnlyBase' in CustomMeta._kw_only_default_settings}")
     print(f"KwOnlyBase default: {CustomMeta._kw_only_default_settings.get('KwOnlyBase')}")
     print(f"SimpleChild in _kw_only_default_settings: {'SimpleChild' in CustomMeta._kw_only_default_settings}")
-    
+
     # Test that kw_only_default values are correctly passed
     assert 'KwOnlyBase' in CustomMeta._kw_only_default_settings
     assert CustomMeta._kw_only_default_settings['KwOnlyBase'] is True
@@ -219,64 +217,60 @@ def test_struct_meta_inheritance():
 
 
 def test_struct_meta_subclass_functions():
-    """测试StructMeta子类创建的结构体是否支持各种函数操作。"""
-    # 定义一个自定义元类
+    """Test if structs created by StructMeta subclasses support various function operations."""
+    # Define a custom metaclass
     class CustomMeta(StructMeta):
-        """自定义元类，继承自StructMeta"""
+        """Custom metaclass that inherits from StructMeta"""
         pass
 
-    # 使用自定义元类创建结构体类
+    # Use the custom metaclass to create a struct class
     class CustomStruct(metaclass=CustomMeta):
         x: int
         y: str
         z: float = 3.14
 
-    # 创建实例
+    # Create an instance
     obj = CustomStruct(x=1, y="test")
     assert obj.x == 1
     assert obj.y == "test"
     assert obj.z == 3.14
 
-    # 测试asdict函数
-    from msgspec.structs import asdict
+    # Test asdict function
     d = asdict(obj)
     assert isinstance(d, dict)
     assert d["x"] == 1
     assert d["y"] == "test"
     assert d["z"] == 3.14
-    
-    # 测试astuple函数
-    from msgspec.structs import astuple
+
+    # Test astuple function
     t = astuple(obj)
     assert isinstance(t, tuple)
     assert t == (1, "test", 3.14)
-    
-    # 测试replace函数
-    from msgspec.structs import replace
+
+    # Test replace function
     obj2 = replace(obj, y="replaced")
     assert obj2.x == 1
     assert obj2.y == "replaced"
     assert obj2.z == 3.14
-    
-    # 测试force_setattr函数
-    from msgspec.structs import force_setattr
+
+    # Test force_setattr function
     force_setattr(obj, "x", 100)
     assert obj.x == 100
-    
-    # 测试嵌套结构体
+
+    # Test nested structs
     class NestedStruct(metaclass=CustomMeta):
         inner: CustomStruct
         name: str
-    
+
     nested = NestedStruct(inner=obj, name="nested")
     assert nested.inner.x == 100
     assert nested.inner.y == "test"
     assert nested.name == "nested"
-    
-    # 测试嵌套结构体的asdict
+
+    # Test asdict with nested structs
     nested_dict = asdict(nested)
     assert isinstance(nested_dict, dict)
-    # 注意：asdict不会递归转换嵌套的结构体对象，所以inner仍然是CustomStruct对象
+    # Note: asdict doesn't recursively convert nested struct objects, so inner remains a CustomStruct object
     assert isinstance(nested_dict["inner"], CustomStruct)
     assert nested_dict["inner"].x == 100
     assert nested_dict["inner"].y == "test"
@@ -284,39 +278,37 @@ def test_struct_meta_subclass_functions():
 
 
 def test_struct_meta_subclass_inheritance():
-    """测试StructMeta子类的多层继承。"""
-    # 定义第一层自定义元类
+    """Test multi-level inheritance of StructMeta subclasses."""
+    # Define the first level custom metaclass
     class BaseMeta(StructMeta):
-        """基础自定义元类"""
+        """Base custom metaclass"""
         pass
-    
-    # 定义第二层自定义元类
+
+    # Define the second level custom metaclass
     class DerivedMeta(BaseMeta):
-        """派生自定义元类"""
+        """Derived custom metaclass"""
         pass
-    
-    # 使用第二层自定义元类创建结构体类
+
+    # Use the second level custom metaclass to create a struct class
     class DerivedStruct(metaclass=DerivedMeta):
         a: int
         b: str
-    
-    # 创建实例
+
+    # Create an instance
     obj = DerivedStruct(a=42, b="derived")
     assert obj.a == 42
     assert obj.b == "derived"
-    
-    # 测试各种函数
-    from msgspec.structs import asdict, astuple, replace
-    
+
+    # Test various functions
     # asdict
     d = asdict(obj)
     assert d["a"] == 42
     assert d["b"] == "derived"
-    
+
     # astuple
     t = astuple(obj)
     assert t == (42, "derived")
-    
+
     # replace
     obj2 = replace(obj, a=99)
     assert obj2.a == 99
@@ -324,40 +316,38 @@ def test_struct_meta_subclass_inheritance():
 
 
 def test_struct_meta_subclass_with_encoder():
-    """测试StructMeta子类创建的结构体与编码器的兼容性。"""
-    import msgspec
-    
-    # 定义自定义元类
+    """Test compatibility of structs created by StructMeta subclasses with encoders."""
+    # Define a custom metaclass
     class EncoderMeta(StructMeta):
-        """用于测试编码器的自定义元类"""
+        """Custom metaclass for testing encoders"""
         pass
-    
-    # 使用自定义元类创建结构体类
+
+    # Use the custom metaclass to create a struct class
     class EncoderStruct(metaclass=EncoderMeta):
         id: int
         name: str
         tags: list[str] = []
-    
-    # 创建实例
+
+    # Create an instance
     obj = EncoderStruct(id=123, name="test")
-    
-    # 测试JSON编码和解码
+
+    # Test JSON encoding and decoding
     json_bytes = msgspec.json.encode(obj)
     decoded = msgspec.json.decode(json_bytes, type=EncoderStruct)
-    
+
     assert decoded.id == 123
     assert decoded.name == "test"
     assert decoded.tags == []
-    
-    # 测试嵌套结构体的编码和解码
+
+    # Test encoding and decoding with nested structs
     class Container(metaclass=EncoderMeta):
         item: EncoderStruct
         count: int
-    
+
     container = Container(item=obj, count=1)
     json_bytes = msgspec.json.encode(container)
     decoded = msgspec.json.decode(json_bytes, type=Container)
-    
+
     assert decoded.count == 1
     assert decoded.item.id == 123
     assert decoded.item.name == "test"


### PR DESCRIPTION
# Expose and Enable Inheritance of StructMeta Metaclass

## Changes
- Exposed `StructMeta` metaclass to Python for direct use
- Added `Py_TPFLAGS_BASETYPE` flag to enable Python inheritance of `StructMeta`
- Created tests to verify functionality

## Why
This allows users to:
- Use `StructMeta` directly without subclassing `Struct`
- Create custom metaclasses that extend `StructMeta` behavior
- Implement reusable patterns across multiple struct classes

This PR resolves:
- Issue #841 
- Issue  #837 

## Example

```python
from msgspec import StructMeta

# Custom metaclass with kw_only_default parameter
class KwOnlyMeta(StructMeta):
    _kw_only_default_settings = {}
    
    def __new__(mcls, name, bases, namespace, **kwargs):
        # Store and inherit kw_only_default
        kw_only_default = kwargs.pop('kw_only_default', None)
        if kw_only_default is None:
            for base in bases:
                if base.__name__ in mcls._kw_only_default_settings:
                    kw_only_default = mcls._kw_only_default_settings[base.__name__]
                    break
        else:
            mcls._kw_only_default_settings[name] = kw_only_default
            
        # Apply kw_only_default if kw_only not specified
        if 'kw_only' not in kwargs and kw_only_default is not None:
            kwargs['kw_only'] = kw_only_default
            
        return super().__new__(mcls, name, bases, namespace, **kwargs)

# Base model requiring keyword arguments
class BaseModel(metaclass=KwOnlyMeta, kw_only_default=True):
    pass

# Child class inherits kw_only=True
class User(BaseModel):
    name: str
    age: int

# Must use keyword arguments
user = User(name="John", age=30)
```

## Technical Details
Added StructMeta to module exports in _core.c
Added Py_TPFLAGS_BASETYPE flag to StructMetaType
Updated __init__.py to import and expose StructMeta
Added type hints in __init__.pyi

## Compatibility
These changes are backward compatible and only add new capabilities without modifying existing behavior.

## Related Issues