### PR TITLE
Simplify JSON schema of Optionals

### DIFF
--- a/msgspec/_json_schema.py
+++ b/msgspec/_json_schema.py
@@ -310,6 +310,13 @@ class _SchemaGenerator:
             if t.min_length is not None:
                 schema["minProperties"] = t.min_length
         elif isinstance(t, mi.UnionType):
+            # don't wrap simple optionals in an anyOf
+            if len(t.types) == 2 and t.includes_none:
+                return (
+                    self.to_schema(t.types[0])
+                    if not isinstance(t.types[0], mi.NoneType)
+                    else self.to_schema(t.types[1])
+                )
             structs = {}
             other = []
             tag_field = None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -309,7 +309,7 @@ def test_struct_object():
                         "items": {"$ref": "#/$defs/Point"},
                     },
                     "name": {
-                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "type": "string",
                         "default": None,
                     },
                     "metadata": {
@@ -722,7 +722,7 @@ def test_dataclass_or_attrs(module):
                         "items": {"$ref": "#/$defs/Point"},
                     },
                     "name": {
-                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "type": "string",
                         "default": None,
                     },
                     "metadata": {


### PR DESCRIPTION
I am using msgspec to generate JSON schemas for MCP tools, and MCP clients don't recognize the descriptions of optional fields when they are embedded in an `anyOf`. By special-casing the `Optional[...]` case of `Union` when generating a JSON schema to not use `anyOf`, MCP clients are able to recognize the "description" as well as the optionality of the field.