### PR TITLE
Expose class to get_tag hook

### DIFF
--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -6104,10 +6104,19 @@ structmeta_construct_tag(StructMetaInfo *info, MsgspecState *mod, PyObject *cls)
                 return -1;
             }
 
-            PyTuple_SetItem(temp_args, 0, qualname);
             Py_INCREF(cls);
+            PyTuple_SetItem(temp_args, 0, qualname);
             PyTuple_SetItem(temp_args, 1, cls);
+
+            // Try call with two Args
             info->tag_value = PyObject_Call(info->temp_tag, temp_args, NULL);
+
+            if (info->tag_value == NULL && PyErr_ExceptionMatches(PyExc_TypeError)) {
+                PyErr_Clear(); 
+                // Call with one Arg
+                info->tag_value = PyObject_CallOneArg(info->temp_tag, qualname);
+            }
+
             Py_DECREF(temp_args);
             if (info->tag_value == NULL) return -1;
         }

--- a/msgspec/_core.c
+++ b/msgspec/_core.c
@@ -6097,8 +6097,18 @@ structmeta_construct_tag(StructMetaInfo *info, MsgspecState *mod, PyObject *cls)
         if (PyCallable_Check(info->temp_tag)) {
             PyObject *qualname = simple_qualname(cls);
             if (qualname == NULL) return -1;
-            info->tag_value = PyObject_CallOneArg(info->temp_tag, qualname);
-            Py_DECREF(qualname);
+
+            PyObject *temp_args = PyTuple_New(2);
+            if (temp_args == NULL) {
+                Py_DECREF(qualname);
+                return -1;
+            }
+
+            PyTuple_SetItem(temp_args, 0, qualname);
+            Py_INCREF(cls);
+            PyTuple_SetItem(temp_args, 1, cls);
+            info->tag_value = PyObject_Call(info->temp_tag, temp_args, NULL);
+            Py_DECREF(temp_args);
             if (info->tag_value == NULL) return -1;
         }
         else {


### PR DESCRIPTION
I had a use case, where I needed the fully qualified name of the class in the get_tag hook. 
This change calls the hook function with the class as second, optional param, making this change non-breaking.

Alternatively, the second param could be the module path, but this is more flexible.

Usage

```python
from msgspec import Struct

def get_tag(qualname, cls):
  # This still uses the qualname extraction in simple_qualname, see:
  # https://github.com/jcrist/msgspec/blob/bb5bc8dc75509ec6a2e6e0f0b3359028e584c651/msgspec/_core.c#L6060
  return f"{cls.__module__}.{qualname}"

# or
def get_tag(_, cls):
  # Native Python behavior
  return f"{cls.__module__}.{cls.__qualname__}"
  
# still works
def get_tag(qualname):
  return qualname

class S(Struct, tag=get_tag):
  a: int = 1
```


Any feedback welcome. Nice lib :)