### PR TITLE
Reduce performance regression

### DIFF
--- a/msgspec/_utils.py
+++ b/msgspec/_utils.py
@@ -71,8 +71,8 @@ else:
     _eval_type = typing._eval_type
 
 
-if sys.version_info >= (3, 10):
-    from inspect import get_annotations as _get_class_annotations
+if sys.version_info >= (3, 14):
+    from annotationlib import get_annotations as _get_class_annotations
 else:
 
     def _get_class_annotations(cls):


### PR DESCRIPTION
The manual version should work on all pre-3.14 versions. This means we no longer need to import `inspect` on those versions.

It still imports annotationlib on 3.14. That's a bit harder to avoid, but I'll write up some ideas on the issue.

Part of #880.