### PR TITLE
Enable import sorting Ruff rule

### DIFF
--- a/benchmarks/bench_encodings.py
+++ b/benchmarks/bench_encodings.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import sys
 import dataclasses
-import json
-import timeit
 import importlib.metadata
-from typing import Any, Literal, Callable
-
-from .generate_data import make_filesystem_data
+import json
+import sys
+import timeit
+from typing import Any, Callable, Literal
 
 import msgspec
+
+from .generate_data import make_filesystem_data
 
 
 class File(msgspec.Struct, kw_only=True, omit_defaults=True, tag="file"):
@@ -61,9 +61,9 @@ class Benchmark:
 
 def json_benchmarks():
     import orjson
-    import ujson
     import rapidjson
     import simdjson
+    import ujson
 
     simdjson_ver = importlib.metadata.version("pysimdjson")
 

--- a/benchmarks/bench_structs.py
+++ b/benchmarks/bench_structs.py
@@ -217,8 +217,8 @@ def main():
     args = parser.parse_args()
 
     if args.versions:
-        import sys
         import importlib.metadata
+        import sys
 
         for _, lib, _ in BENCHMARKS:
             if lib is not None:

--- a/benchmarks/bench_validation/__main__.py
+++ b/benchmarks/bench_validation/__main__.py
@@ -1,11 +1,11 @@
 import argparse
 import json
-import tempfile
-from ..generate_data import make_filesystem_data
-import sys
-import subprocess
 import shutil
+import subprocess
+import sys
+import tempfile
 
+from ..generate_data import make_filesystem_data
 
 LIBRARIES = ["msgspec", "mashumaro", "cattrs", "pydantic"]
 

--- a/benchmarks/bench_validation/bench_cattrs.py
+++ b/benchmarks/bench_validation/bench_cattrs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import enum
 import datetime
+import enum
 from typing import Literal
 
 import attrs

--- a/benchmarks/bench_validation/bench_mashumaro.py
+++ b/benchmarks/bench_validation/bench_mashumaro.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import enum
 import dataclasses
 import datetime
+import enum
 from typing import Literal
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin

--- a/benchmarks/bench_validation/bench_msgspec.py
+++ b/benchmarks/bench_validation/bench_msgspec.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import enum
 import datetime
+import enum
 
 import msgspec
 

--- a/benchmarks/bench_validation/bench_pydantic.py
+++ b/benchmarks/bench_validation/bench_pydantic.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import enum
 import datetime
-from typing import Literal, Annotated
+import enum
+from typing import Annotated, Literal
 
 import pydantic
 

--- a/benchmarks/bench_validation/runner.py
+++ b/benchmarks/bench_validation/runner.py
@@ -1,9 +1,9 @@
+import gc
 import importlib
 import json
-import timeit
 import resource
 import sys
-import gc
+import timeit
 
 library, path, runs, repeats = sys.argv[1:5]
 num_runs = int(runs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ ignore = [
 select = [
   "E", # PEP8 Errors
   "F", # Pyflakes
+  "I", # Import sorting
   "W", # PEP8 Warnings
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 
 from setuptools import setup
 from setuptools.extension import Extension

--- a/src/msgspec/_json_schema.py
+++ b/src/msgspec/_json_schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import textwrap
 from collections.abc import Iterable
-from typing import Any, Optional, Callable
+from typing import Any, Callable, Optional
 
 from . import inspect as mi, to_builtins
 

--- a/src/msgspec/_utils.py
+++ b/src/msgspec/_utils.py
@@ -2,7 +2,6 @@
 import collections
 import sys
 import typing
-
 from typing import _AnnotatedAlias  # noqa: F401
 
 try:

--- a/src/msgspec/structs.py
+++ b/src/msgspec/structs.py
@@ -8,8 +8,8 @@ from ._core import (  # noqa
     StructConfig,
     asdict,
     astuple,
-    replace,
     force_setattr,
+    replace,
 )
 from ._utils import get_class_annotations as _get_class_annotations
 

--- a/src/msgspec/toml.py
+++ b/src/msgspec/toml.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime as _datetime
-from typing import TYPE_CHECKING, overload, TypeVar, Any
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from . import (
     DecodeError as _DecodeError,
@@ -10,7 +10,8 @@ from . import (
 )
 
 if TYPE_CHECKING:
-    from typing import Callable, Optional, Type, Union, Literal
+    from typing import Callable, Literal, Optional, Type, Union
+
     from typing_extensions import Buffer
 
 

--- a/src/msgspec/yaml.py
+++ b/src/msgspec/yaml.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime as _datetime
-from typing import TYPE_CHECKING, overload, TypeVar, Any
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from . import (
     DecodeError as _DecodeError,
@@ -10,7 +10,8 @@ from . import (
 )
 
 if TYPE_CHECKING:
-    from typing import Callable, Optional, Type, Union, Literal
+    from typing import Callable, Literal, Optional, Type, Union
+
     from typing_extensions import Buffer
 
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -32,7 +32,8 @@ from typing import (
 )
 
 import pytest
-from .utils import temp_module, max_call_depth
+
+from .utils import max_call_depth, temp_module
 
 try:
     import attrs
@@ -40,7 +41,7 @@ except ImportError:
     attrs = None
 
 import msgspec
-from msgspec import Meta, Struct, ValidationError, UNSET, UnsetType
+from msgspec import UNSET, Meta, Struct, UnsetType, ValidationError
 
 UTC = datetime.timezone.utc
 

--- a/tests/unit/test_constraints.py
+++ b/tests/unit/test_constraints.py
@@ -1,7 +1,7 @@
 import datetime
 import math
 import re
-from typing import Dict, List, Union, Annotated
+from typing import Annotated, Dict, List, Union
 
 import pytest
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -19,16 +19,17 @@ from typing import (
     NamedTuple,
     Set,
     Tuple,
-    TypeVar,
     TypedDict,
+    TypeVar,
     Union,
 )
 
 import pytest
-from .utils import temp_module, max_call_depth
 
 import msgspec
 from msgspec import Meta, Struct, ValidationError, convert, to_builtins
+
+from .utils import max_call_depth, temp_module
 
 try:
     import attrs

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -27,12 +27,12 @@ from typing import (
 )
 
 import pytest
-from .utils import temp_module
 
 import msgspec
 import msgspec.inspect as mi
 from msgspec import Meta
 
+from .utils import temp_module
 
 PY312 = sys.version_info[:2] >= (3, 12)
 py312_plus = pytest.mark.skipif(not PY312, reason="3.12+ only")

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -24,11 +24,11 @@ from typing import (
 )
 
 import pytest
-from .utils import temp_module
 
 import msgspec
 from msgspec import Meta
 
+from .utils import temp_module
 
 T = TypeVar("T")
 

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -8,14 +8,15 @@ import sys
 import weakref
 from contextlib import contextmanager
 from inspect import Parameter, Signature
-from typing import Any, List, Optional, Generic, TypeVar
+from typing import Any, Generic, List, Optional, TypeVar
 
 import pytest
-from .utils import temp_module
 
 import msgspec
 from msgspec import NODEFAULT, UNSET, Struct, defstruct, field
 from msgspec.structs import StructConfig
+
+from .utils import temp_module
 
 if hasattr(copy, "replace"):
     # Added in Python 3.13

--- a/tests/unit/test_struct_meta.py
+++ b/tests/unit/test_struct_meta.py
@@ -1,9 +1,10 @@
 """Tests for the exposed StructMeta metaclass."""
 
 import pytest
+
 import msgspec
 from msgspec import Struct, StructMeta
-from msgspec.structs import asdict, astuple, replace, force_setattr
+from msgspec.structs import asdict, astuple, force_setattr, replace
 
 
 def test_struct_meta_exists():

--- a/tests/unit/test_to_builtins.py
+++ b/tests/unit/test_to_builtins.py
@@ -11,7 +11,7 @@ from typing import Any, NamedTuple, Union
 
 import pytest
 
-from msgspec import UNSET, Struct, UnsetType, to_builtins, defstruct
+from msgspec import UNSET, Struct, UnsetType, defstruct, to_builtins
 
 PY310 = sys.version_info[:2] >= (3, 10)
 PY311 = sys.version_info[:2] >= (3, 11)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,9 +4,10 @@ import sys
 from typing import Generic, List, Optional, Set, TypeVar
 
 import pytest
-from .utils import temp_module, package_not_installed
 
 from msgspec._utils import get_class_annotations
+
+from .utils import package_not_installed, temp_module
 
 PY310 = sys.version_info[:2] >= (3, 10)
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,5 +1,5 @@
-import sys
 import inspect
+import sys
 import textwrap
 import types
 import uuid


### PR DESCRIPTION
The option `tool.ruff.lint.isort.combine-as-imports` is enabled in the `pyproject.toml` file, so I assume that import sorting is intended to be on. If this is not wanted, I can open a new PR to remove the config option from `pyproject.toml`.