### PR TITLE
Refactor CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,22 +71,57 @@ jobs:
         with:
           files: coverage.xml,_core.c.gcov,atof.h.gcov,ryu.h.gcov
 
+  build_sdist:
+    name: Build Source Distribution
+    runs-on: ubuntu-latest
+
+    outputs:
+      artifact-name: ${{ steps.locate-artifact.outputs.file-name }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build source distribution
+        run: uv build --sdist
+
+      - name: Locate source distribution
+        id: locate-artifact
+        run: |-
+          sdist_name=$(basename dist/*)
+          echo "file-name=${sdist_name}" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-sdist
+          path: dist/${{ steps.locate-artifact.outputs.file-name }}
+          if-no-files-found: error
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.archs }}
+    needs:
+      - build_sdist
+      - lint
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
-
-    env:
-      CIBW_TEST_EXTRAS: "test"
-      CIBW_TEST_COMMAND: "pytest {project}/tests"
-      CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
-      CIBW_SKIP: "*-win32 *_i686 *_s390x *_ppc64le"
-      CIBW_ARCHS_MACOS: "x86_64 arm64"
-      CIBW_ARCHS_LINUX: "x86_64 aarch64"
-      CIBW_TEST_SKIP: "*_arm64 *-musllinux_*"
-      CIBW_ENVIRONMENT: "CFLAGS=-g0"
+        include:
+        - os: ubuntu-24.04-arm
+          archs: aarch64
+        - os: ubuntu-latest
+          archs: x86_64
+        - os: macos-latest
+          archs: arm64
+        - os: macos-15-intel
+          archs: x86_64
+        # - os: windows-11-arm
+        #   archs: ARM64
+        - os: windows-latest
+          archs: AMD64
 
     steps:
       - uses: actions/checkout@v4
@@ -102,37 +137,32 @@ jobs:
         run: |
             echo "CIBW_SKIP=${CIBW_SKIP} *-musllinux_* cp39-*_aarch64 cp311-*_aarch64 cp312-*_aarch64 cp313-*_aarch64 cp314-*_aarch64 cp314t-*_aarch64" >> $GITHUB_ENV
 
+      - name: Download source distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact-sdist
+          path: dist
+
+      # TODO: Remove this once the action supports specifying extras, see:
+      # https://github.com/pypa/cibuildwheel/pull/2630
+      - name: Install uv
+        if: runner.os != 'Linux'
+        uses: astral-sh/setup-uv@v7
+
       - name: Build & Test Wheels
         uses: pypa/cibuildwheel@v3.2.1
+        with:
+          package-dir: dist/${{ needs.build_sdist.outputs.artifact-name }}
+        env:
+          CIBW_ARCHS: ${{ matrix.archs }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         if: github.event_name == 'release' && github.event.action == 'published'
         with:
-          name: artifact-wheels-${{ matrix.os }}
+          name: artifact-wheels-${{ matrix.os }}-${{ matrix.archs }}
           path: ./wheelhouse/*.whl
-
-  build_sdist:
-    name: Build Source Distribution
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Build source distribution
-        run: python setup.py sdist
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-sdist
-          path: dist/*.tar.gz
+          if-no-files-found: error
 
   upload_pypi:
     needs: [build_wheels, build_sdist]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install UV
+      - name: Install uv
         uses: astral-sh/setup-uv@v7
 
       - name: Install msgspec and dependencies

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ include versioneer.py
 include README.md
 include LICENSE
 include MANIFEST.in
+recursive-include tests *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,15 @@ select = [
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
+
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
+build-frontend = "build[uv]"
+test-command = "pytest {project}/tests"
+test-extras = ["test"]
+
+[tool.cibuildwheel.environment]
+CFLAGS = "-g0"
+
+# [tool.cibuildwheel.linux]
+# environment-pass = ["CFLAGS"]


### PR DESCRIPTION
This is part one of a CI refactor. Changes:

1. The wheel build matrix has been chunked into `(platform, arch)` pairs rather than everything being built sequentially on a single job per platform.
    1. The macOS x86_64 builds now use the latest runner supporting that architecture as there is no benefit to building on older platforms unlike Linux/glibc.
2. The source distribution job now always runs and the artifact is used to build each wheel rather than building from the source tree.
3. As a temporary directory is now used to unpack the source distribution and build wheels, the test phase began failing because the `tests` directory was not included in the source distribution. This probably was an oversight and is now fixed.
4. Tests now run on every supported target.
5. For the build jobs, uv is now used to manage virtual environments and build both the source distributions and wheels.
6. Artifact upload jobs now fail if there are no matches.
7. Most `cibuildwheel` configuration now lives in `pyproject.toml`.
8. Rather than skipping certain tests/build target patterns we are now explicit with what we configure.

Notes:

1. I noticed that the `CFLAGS` environment variable wasn't properly being passed to the containers used to build the wheels for Linux. For now, I have this configuration fix commented out and will try properly applying it in the next PR.
2. I added a job that builds Windows ARM but commented that out as well for now and will try that in a separate PR.

---

The build workflow now finishes faster in wall clock time by ~1.5 minutes but of course cumulatively is the same. Whenever we can drop macOS x86_64 the time will be further reduced by ~2 minutes.

### Old build times

<img width="412" height="211" alt="image" src="https://github.com/user-attachments/assets/9e433fc3-4afa-45e9-98e9-6d5efd417743" />

### New build times

<img width="355" height="310" alt="image" src="https://github.com/user-attachments/assets/61a80cb9-d25f-42e0-9acc-e927a539f2cf" />
