### PR TITLE
Statically define project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,21 +8,86 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "msgspec"
 dynamic = [
-  "classifiers",
-  "description",
-  "keywords",
-  "license",
-  "maintainers",
-  "optional-dependencies",
-  "readme",
-  "requires-python",
-  "urls",
   "version",
+]
+description = "A fast serialization and validation library, with builtin support for JSON, MessagePack, YAML, and TOML."
+readme = "README.md"
+requires-python = ">=3.9"
+maintainers = [
+  { name = "Jim Crist-Harif", email = "jcristharif@gmail.com" },
+  { name = "Ofek Lev", email = "oss@ofek.dev" },
+]
+keywords = [
+  "JSON",
+  "MessagePack",
+  "TOML",
+  "YAML",
+  "msgpack",
+  "schema",
+  "serialization",
+  "validation",
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+
+[project.optional-dependencies]
+dev = [
+  "msgspec[doc,test]",
+  "coverage",
+  "mypy",
+  "pre-commit",
+  "pyright",
+]
+doc = [
+  "furo",
+  "ipython",
+  "sphinx",
+  "sphinx-copybutton",
+  "sphinx-design",
+]
+test = [
+  "msgspec[toml,yaml]",
+  "attrs",
+  "eval-type-backport ; python_version < '3.10'",
+  "msgpack",
+  "pytest",
+]
+toml = [
+  "tomli ; python_version < '3.11'",
+  "tomli_w",
+]
+yaml = [
+  "pyyaml",
+]
+
+[project.urls]
+Homepage = "https://jcristharif.com/msgspec/"
+"Issue Tracker" = "https://github.com/jcrist/msgspec/issues"
+Source = "https://github.com/jcrist/msgspec"
+
+[tool.setuptools]
+packages = ["msgspec"]
+
+[tool.setuptools.exclude-package-data]
+msgspec = [
+  "*.c",
+  "*.h",
 ]
 
 [tool.setuptools_scm]
 version_file = "msgspec/_version.py"
 parentdir_prefix_version = "msgspec-"
+
+[tool.uv.config-settings]
+editable_mode = "compat"
 
 [tool.ruff]
 extend-exclude = [
@@ -35,6 +100,8 @@ extend-exclude = [
   "msgpack.py",
   "test_JSONTestSuite.py",
   "conf.py",
+  # TODO: remove when this when we drop support for Python 3.9 (example uses match statements)
+  "examples/asyncio-kv/kv.py",
 ]
 line-length = 88
 
@@ -53,18 +120,6 @@ select = [
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
-
-[tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
-build-frontend = "build[uv]"
-test-command = "pytest {project}/tests"
-test-extras = ["test"]
-
-[tool.cibuildwheel.environment]
-CFLAGS = "-g0"
-
-# [tool.cibuildwheel.linux]
-# environment-pass = ["CFLAGS"]
 
 [tool.codespell]
 skip = "*.py,*.c,*.h"
@@ -85,3 +140,15 @@ markers = [
 filterwarnings = [
   "error",
 ]
+
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
+build-frontend = "build[uv]"
+test-command = "pytest {project}/tests"
+test-extras = ["test"]
+
+[tool.cibuildwheel.environment]
+CFLAGS = "-g0"
+
+# [tool.cibuildwheel.linux]
+# environment-pass = ["CFLAGS"]

--- a/setup.py
+++ b/setup.py
@@ -55,63 +55,10 @@ ext_modules = [
     )
 ]
 
-yaml_deps = ["pyyaml"]
-toml_deps = ['tomli ; python_version < "3.11"', "tomli_w"]
-doc_deps = ["sphinx", "furo", "sphinx-copybutton", "sphinx-design", "ipython"]
-test_deps = [
-    "pytest",
-    "msgpack",
-    "attrs",
-    'eval-type-backport ; python_version < "3.10"',
-    *yaml_deps,
-    *toml_deps,
-]
-dev_deps = ["pre-commit", "coverage", "mypy", "pyright", *doc_deps, *test_deps]
-
-extras_require = {
-    "yaml": yaml_deps,
-    "toml": toml_deps,
-    "doc": doc_deps,
-    "test": test_deps,
-    "dev": dev_deps,
-}
-
 setup(
     name="msgspec",
-    maintainer="Jim Crist-Harif",
-    maintainer_email="jcristharif@gmail.com",
-    url="https://jcristharif.com/msgspec/",
-    project_urls={
-        "Documentation": "https://jcristharif.com/msgspec/",
-        "Source": "https://github.com/jcrist/msgspec/",
-        "Issue Tracker": "https://github.com/jcrist/msgspec/issues",
-    },
-    description=(
-        "A fast serialization and validation library, with builtin support for "
-        "JSON, MessagePack, YAML, and TOML."
-    ),
-    keywords="JSON msgpack MessagePack TOML YAML serialization validation schema",
-    classifiers=[
-        "License :: OSI Approved :: BSD License",
-        "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
-    ],
-    extras_require=extras_require,
     license="BSD",
     packages=["msgspec"],
     package_data={"msgspec": ["py.typed", "*.pyi"]},
     ext_modules=ext_modules,
-    long_description=(
-        open("README.md", encoding="utf-8").read()
-        if os.path.exists("README.md")
-        else ""
-    ),
-    long_description_content_type="text/markdown",
-    python_requires=">=3.9",
-    zip_safe=False,
 )


### PR DESCRIPTION
As a follow-up to https://github.com/jcrist/msgspec/pull/905, this:

1. Defines more package metadata statically.
    1. The license field will come in a second PR as the version of `setuptools` that comes with Python 3.11 doesn't support the newer form of being a string. Upgrading to a newer version works but then we encounter an issue with build isolation behavior, so saving the fix for that separately with a minimal diff.
2. Added myself to the list of maintainers.
3. Ignored one of our examples for now in Ruff because the linter somehow started working properly with statically defined metadata.