### PR TITLE
Dev updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v5
 
+    - name: Install Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,21 +16,17 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
 
     - name: Install msgspec and dependencies
-      run: |
-        uv venv --no-project
-        uv pip install -e ".[doc]"
+      run: uv sync
 
     - name: Build Docs
       run: |
-        pushd docs
-        uv run make html
-        popd
+        uv run --directory docs -- make html
 
     - name: Restore link check cache
       uses: actions/cache@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,32 @@ Homepage = "https://jcristharif.com/msgspec/"
 "Issue Tracker" = "https://github.com/jcrist/msgspec/issues"
 Source = "https://github.com/jcrist/msgspec"
 
+[dependency-groups]
+dev = [
+  { include-group = "doc" },
+  { include-group = "test" },
+  "mypy",
+  "pre-commit",
+  "pyright",
+]
+doc = [
+  "furo",
+  "ipython",
+  "sphinx",
+  "sphinx-copybutton",
+  "sphinx-design",
+]
+test = [
+  "attrs",
+  "coverage",
+  "eval-type-backport; python_version < '3.10'",
+  "msgpack",
+  "pytest",
+  "pyyaml",
+  "tomli; python_version < '3.11'",
+  "tomli-w",
+]
+
 [tool.setuptools]
 packages = ["msgspec"]
 


### PR DESCRIPTION
1. Add dependency groups to make local development nicer. I'm sure users are somehow relying on the currently-defined extras so I haven't touched those. We should remove them eventually.
2. Updated all CI jobs except for one to use Python 3.13. The testing job still uses 3.11 because bumping that causes a segfault which we will investigate separately.