### PR TITLE
Fix UnsetType type annotation (#916)

### DIFF
--- a/src/msgspec/__init__.pyi
+++ b/src/msgspec/__init__.pyi
@@ -71,6 +71,8 @@ T = TypeVar("T")
 class UnsetType(enum.Enum):
     UNSET = "UNSET"
 
+    def __bool__(self) -> Literal[False]: ...
+
 UNSET = UnsetType.UNSET
 
 class _NoDefault(enum.Enum):

--- a/tests/basic_typing_examples.py
+++ b/tests/basic_typing_examples.py
@@ -28,11 +28,17 @@ def check_unset() -> None:
     pickle.dumps(msgspec.UNSET)
 
 
-def check_unset_type_lowering(x: int | msgspec.UnsetType) -> None:
+def check_unset_type_lowering_identity(x: int | msgspec.UnsetType) -> None:
     if x is msgspec.UNSET:
         reveal_type(x)  # assert "int" not in typ.lower()
     else:
         reveal_type(x)  # assert "unset" not in typ.lower()
+
+def check_unset_type_lowering_truthiness(x: int | msgspec.UnsetType) -> None:
+    if x:
+        reveal_type(x)  # assert "unset" not in typ.lower()
+    else:
+        reveal_type(x)  # assert "unset" in typ.lower()
 
 
 def check_nodefault() -> None:


### PR DESCRIPTION
This is consistent with the definition in _core.c:

```c
static int unset_bool(PyObject *obj) {
    return 0;
};

static PyNumberMethods unset_as_number = {
    .nb_bool = unset_bool,
};

PyTypeObject Unset_Type = {
    PyVarObject_HEAD_INIT(NULL, 0)
    .tp_name = "msgspec.UnsetType",
    .tp_doc = unset__doc__,
    .tp_repr = unset_repr,
    .tp_flags = Py_TPFLAGS_DEFAULT,
    .tp_methods = unset_methods,
    .tp_as_number = &unset_as_number,
    .tp_new = unset_new,
    .tp_dealloc = 0,
    .tp_itemsize = 0,
    .tp_basicsize = 0
};
```