### PR TITLE
Add more benchmarking

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,10 +85,10 @@ example, if you want to run a specific test file:
 just test tests/test_json.py
 ```
 
-To invoke `pytest` directly, you can use the `test-env` recipe:
+To invoke `pytest` directly, you can use the `env` recipe with the `test` environment:
 
 ```
-just test-env pytest --help
+just env test pytest --help
 ```
 
 ## Linting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,11 @@ jobs:
         ASAN_OPTIONS: "detect_leaks=0"
       run: >-
         LD_PRELOAD=`gcc -print-file-name=libasan.so`
-        just test-env coverage run -m pytest -s
+        just env test coverage run -m pytest -s
 
     - name: Generate coverage files
       run: |-
-        just test-env coverage xml
+        just env test coverage xml
         gcov -abcu `find build/temp*/ -name *.o`
 
     - name: Upload coverage artifacts

--- a/benchmarks/bench_validation/__main__.py
+++ b/benchmarks/bench_validation/__main__.py
@@ -19,10 +19,24 @@ parser.add_argument(
     help="Whether to output the results as json",
 )
 parser.add_argument(
-    "-n",
+    "--size",
+    "-s",
     type=int,
     help="The number of objects in the generated data, defaults to 1000",
     default=1000,
+)
+parser.add_argument(
+    "--iterations",
+    "-n",
+    type=int,
+    help="The number of iterations to perform for each library, defaults to auto-detection",
+)
+parser.add_argument(
+    "--rounds",
+    "-r",
+    type=int,
+    help="The number of times to repeat the benchmark for each library if --iterations is selected, defaults to 5",
+    default=5,
 )
 parser.add_argument(
     "--lib",
@@ -48,8 +62,10 @@ if args.versions:
     sys.exit(0)
 
 
-data = json.dumps(make_filesystem_data(args.n)).encode("utf-8")
+data = json.dumps(make_filesystem_data(int(args.size))).encode("utf-8")
 
+iterations = str(args.iterations or 0)
+rounds = str(args.rounds or 0)
 header = "-" * shutil.get_terminal_size().columns
 results = []
 with tempfile.NamedTemporaryFile() as f:
@@ -65,6 +81,8 @@ with tempfile.NamedTemporaryFile() as f:
                     "benchmarks.bench_validation.runner",
                     lib,
                     f.name,
+                    iterations,
+                    rounds,
                 ],
                 stderr=subprocess.STDOUT,
             )


### PR DESCRIPTION
Changed:

1. Removed the possible recursion limit errors in the validation benchmarks when setting a high number of objects in the generated data.
2. Allowed for selecting an explicit number of iterations and rounds when running the validation benchmarks.
3. Exposed the `env-run` recipe and removed the `*-env` environment-specific recipes.

---

Example of new options:

```
vscode ➜ /workspaces/msgspec (perf) $ just bench validation --lib msgspec -o 5000 -n 1000 -r 10
+---------+-------------+-----+-------------+-----+------------+-----+--------------+-----+
|         | encode (μs) | vs. | decode (μs) | vs. | total (μs) | vs. | memory (MiB) | vs. |
+=========+=============+=====+=============+=====+============+=====+==============+=====+
| msgspec | 911.7       | 1.0 | 2456.8      | 1.0 | 3368.6     | 1.0 | 0.0          | 0.0 |
+---------+-------------+-----+-------------+-----+------------+-----+--------------+-----+
```