### PR TITLE
Update test workflow

### DIFF
--- a/.github/actions/fetch-release-history/action.yml
+++ b/.github/actions/fetch-release-history/action.yml
@@ -1,0 +1,41 @@
+name: Fetch Release History
+description: Fast, minimal fetch of commits since the latest release for version calculation with Git describe
+inputs:
+  github-token:
+    description: The GitHub token to use for the API
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Fetch release history
+    env:
+      GH_TOKEN: ${{ inputs.github-token }}
+    shell: bash
+    run: |-
+      latest_tag=$(
+        gh api "repos/${{ github.repository }}/releases/latest" \
+          --jq '.tag_name'
+      )
+      echo "Detected latest release tag: $latest_tag"
+
+      ahead_by=$(
+        gh api "repos/${{ github.repository }}/compare/${latest_tag}...${{ github.sha }}" \
+          --jq '.ahead_by'
+      )
+      echo "Commits since last release: $ahead_by"
+
+      if [ "$ahead_by" -gt 0 ]; then
+        echo "Fetching commits since last release"
+        git -c protocol.version=2 fetch \
+          --no-tags --no-recurse-submodules --filter=blob:none \
+          --deepen="$ahead_by" origin \
+          "${{ github.ref }}" \
+          "refs/tags/$latest_tag:refs/tags/$latest_tag"
+      else
+        echo "No commits since last release, fetching release tag only"
+        git -c protocol.version=2 fetch \
+          --no-tags --no-recurse-submodules --filter=blob:none \
+          origin \
+          "refs/tags/$latest_tag:refs/tags/$latest_tag"
+      fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,13 @@ on:
     - ".justfile"
     - "pyproject.toml"
     - "setup.py"
-    - "setup.cfg"
   release:
     types:
     - published
 
 jobs:
   validate:
-    name: Run static analysis and smoke tests
+    name: Run static analysis and prepare build
     runs-on: ubuntu-latest
 
     outputs:
@@ -30,6 +29,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
+
+    - name: Fetch release history
+      uses: ./.github/actions/fetch-release-history
+      with:
+        github-token: "${{ github.token }}"
 
     - name: Load environment file
       uses: ./.github/actions/load-env
@@ -51,16 +55,9 @@ jobs:
     - name: Run hooks
       run: just hooks-check
 
-    - name: Install testing dependencies
-      run: just env-sync test
-
-    - name: Run tests
-      run: just test-all
-
     - name: Build source distribution
       id: build-sdist
       run: |-
-        git clean -fdX
         uv build --sdist
         sdist_name=$(basename dist/*.tar.gz)
         echo "file-name=${sdist_name}" >> $GITHUB_OUTPUT
@@ -168,8 +165,8 @@ jobs:
         use_oidc: true
         directory: coverage-files
 
-  profile:
-    name: Run profiling tests
+  test-integration:
+    name: Run integration tests
     needs:
     - test
     runs-on: ubuntu-latest
@@ -192,12 +189,14 @@ jobs:
     - name: Install command runner
       run: uv tool install rust-just
 
-    - name: Install profiling dependencies
-      run: just env-sync prof
+    - name: Install testing dependencies
+      run: just env-sync test
 
-    # TODO: set up infra to commit results after each merge and then make tests compare
-    - name: Run profiling tests
-      run: just test-perf all --calibrate --rounds 10000
+    - name: Run doctests
+      run: just test-doc
+
+    - name: Run type checker compatibility tests
+      run: just test-typing
 
   build-wheels:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.archs }}
@@ -207,7 +206,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
-      matrix:
+      matrix: &build-matrix
         include:
         - os: ubuntu-24.04-arm
           archs: aarch64
@@ -254,6 +253,59 @@ jobs:
         name: artifact-wheels-${{ matrix.os }}-${{ matrix.archs }}
         path: wheelhouse/*.whl
         if-no-files-found: error
+
+  profile:
+    name: Run profiling tests on ${{ matrix.os }}
+    needs:
+    - build-wheels
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      fail-fast: false
+      matrix: *build-matrix
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Load environment file
+      uses: ./.github/actions/load-env
+
+    - name: Install Python
+      uses: actions/setup-python@v6
+      with:
+        python-version-file: pyproject.toml
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Install command runner
+      run: uv tool install rust-just
+
+    - name: Save path to profiling environment
+      id: env-path
+      run: echo "path=$(just env-path prof)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Install profiling dependencies
+      env:
+        UV_PROJECT_ENVIRONMENT: "${{ steps.env-path.outputs.path }}"
+      run: uv sync --only-group prof
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v6
+      with:
+        name: artifact-wheels-${{ matrix.os }}-${{ matrix.archs }}
+        path: dist
+        merge-multiple: true
+
+    - name: Install project from artifact
+      env:
+        VIRTUAL_ENV: "${{ steps.env-path.outputs.path }}"
+      run: uv pip install --no-index --find-links dist msgspec
+
+    # TODO: set up infra to commit results after each merge and then make tests compare
+    - name: Run profiling tests
+      run: just test-perf all --calibrate --rounds 10000
 
   upload-pypi:
     name: Upload artifacts to PyPI

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v5
 
+    - name: Fetch release history
+      uses: ./.github/actions/fetch-release-history
+      with:
+        github-token: "${{ github.token }}"
+
     - name: Load environment file
       uses: ./.github/actions/load-env
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,9 +213,3 @@ build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
 build-frontend = "build[uv]"
 test-command = "pytest {project}/tests/unit"
 test-groups = ["test-unit"]
-
-[tool.cibuildwheel.environment]
-CFLAGS = "-g0"
-
-# [tool.cibuildwheel.linux]
-# environment-pass = ["CFLAGS"]

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ if COVERAGE:
     extra_link_args.append("-lgcov")
 if DEBUG:
     extra_compile_args.extend(["-O0", "-g", "-UNDEBUG"])
+elif sys.platform != "win32":
+    extra_compile_args.extend(["-g0"])
 
 # from https://py-free-threading.github.io/faq/#im-trying-to-build-a-library-on-windows-but-msvc-says-c-atomic-support-is-not-enabled
 if sys.platform == "win32":


### PR DESCRIPTION
Changed:

1. Started using the built wheels for profiling tests rather than a job earlier in the pipeline.
2. Profiling tests now run on every platform.
3. Fixed issue with custom CFLAGS overriding the defaults.
4. Moved doctests and type checker compatibility tests to an integration test job that comes after the unit test/coverage matrix. The first job now only performs static analysis and builds the source distribution.
5. Added an action that fetches every commit since the last release in order to properly support version derivation from Git.