### PR TITLE
Add dedicated profiling workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
-      matrix: &build-matrix
+      matrix:
         include:
         - os: ubuntu-24.04-arm
           archs: aarch64
@@ -255,57 +255,12 @@ jobs:
         if-no-files-found: error
 
   profile:
-    name: Run profiling tests on ${{ matrix.os }}
+    name: Run profiling tests
     needs:
     - build-wheels
-    runs-on: "${{ matrix.os }}"
-    strategy:
-      fail-fast: false
-      matrix: *build-matrix
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v5
-
-    - name: Load environment file
-      uses: ./.github/actions/load-env
-
-    - name: Install Python
-      uses: actions/setup-python@v6
-      with:
-        python-version-file: pyproject.toml
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-
-    - name: Install command runner
-      run: uv tool install rust-just
-
-    - name: Save path to profiling environment
-      id: env-path
-      run: echo "path=$(just env-path prof)" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Install profiling dependencies
-      env:
-        UV_PROJECT_ENVIRONMENT: "${{ steps.env-path.outputs.path }}"
-      run: uv sync --only-group prof
-
-    - name: Download artifacts
-      uses: actions/download-artifact@v6
-      with:
-        name: artifact-wheels-${{ matrix.os }}-${{ matrix.archs }}
-        path: dist
-        merge-multiple: true
-
-    - name: Install project from artifact
-      env:
-        VIRTUAL_ENV: "${{ steps.env-path.outputs.path }}"
-      run: uv pip install --no-index --find-links dist msgspec
-
-    # TODO: set up infra to commit results after each merge and then make tests compare
-    - name: Run profiling tests
-      run: just test-perf all --calibrate --rounds 10000
+    uses: ./.github/workflows/profile.yml
+    with:
+      version: dev
 
   upload-pypi:
     name: Upload artifacts to PyPI

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -1,0 +1,95 @@
+name: Profile
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version of msgspec to profile
+        required: true
+        type: string
+      python:
+        description: Minor version of Python to use for profiling
+        type: string
+        default: latest
+  workflow_call:
+    inputs:
+      version:
+        description: Version of msgspec to profile
+        required: true
+        type: string
+      python:
+        description: Minor version of Python to use for profiling
+        type: string
+        default: latest
+
+jobs:
+  profile:
+    name: Profile ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }} (${{ matrix.archs }})
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-24.04-arm
+          archs: aarch64
+        - os: ubuntu-latest
+          archs: x86_64
+        - os: macos-latest
+          archs: arm64
+        - os: macos-15-intel
+          archs: x86_64
+        # - os: windows-11-arm
+        #   archs: ARM64
+        - os: windows-latest
+          archs: AMD64
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Load environment file
+      uses: ./.github/actions/load-env
+
+    - name: Install Python
+      uses: actions/setup-python@v6
+      with:
+        python-version-file: pyproject.toml
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Install command runner
+      run: uv tool install rust-just
+
+    - name: Set profiling environment metadata
+      id: metadata
+      shell: bash
+      run: |-
+        echo "env-path=$(just env-path prof)" >> $GITHUB_OUTPUT
+        if [[ "${{ inputs.python }}" != "latest" ]]; then
+          echo "UV_PYTHON=${{ inputs.python }}" >> $GITHUB_ENV
+        fi
+
+    - name: Install profiling dependencies
+      env:
+        UV_PROJECT_ENVIRONMENT: "${{ steps.metadata.outputs.env-path }}"
+      run: uv sync --only-group prof
+
+    - name: Download artifacts
+      if: inputs.version == 'dev'
+      uses: actions/download-artifact@v6
+      with:
+        name: artifact-wheels-${{ matrix.os }}-${{ matrix.archs }}
+        path: dist
+        merge-multiple: true
+
+    - name: Install version ${{ inputs.version }} from ${{ inputs.version == 'dev' && 'artifact' || 'PyPI' }}
+      env:
+        VIRTUAL_ENV: "${{ steps.metadata.outputs.env-path }}"
+      run: >-
+        uv pip install${{ inputs.version == 'dev' && ' --no-index --find-links dist' || '' }}
+        ${{ format('msgspec{0}{1}', inputs.version != 'dev' && '==' || '', inputs.version != 'dev' && inputs.version || '') }}
+
+    # TODO: set up infra to commit results after each merge and then make tests compare
+    - name: Run profiling tests
+      run: just test-perf all --calibrate --rounds 10000


### PR DESCRIPTION
This extracts the profiling job matrix within the existing test workflow into its own that can be called from other workflows. Additionally, it can be manually ran from the UI against existing versions on PyPI.