### PR TITLE
Isolate build configuration

### DIFF
--- a/.cibuildwheel.toml
+++ b/.cibuildwheel.toml
@@ -1,0 +1,5 @@
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
+build-frontend = "build[uv]"
+test-command = "pytest {project}/tests/unit"
+test-groups = ["test-unit"]

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = ./site,./.venv,*.py,*.c,*.h

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+source_pkgs =
+    msgspec
+source_dirs =
+    tests/unit
+omit =
+    src/msgspec/_version.py
+
+[paths]
+msgspec =
+    src/msgspec
+    */msgspec/src/msgspec
+    */msgspec/dev/*/venvs/*/lib*/python*/site-packages/msgspec
+    *\msgspec\dev\*\venvs\*\Lib\site-packages\msgspec
+tests =
+    tests/unit
+    */msgspec/tests/unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,24 @@ on:
     branches:
     - main
     paths:
-    - "src/msgspec/**"
-    - ".github/workflows/ci.yml"
-    - ".pre-commit-config.yaml"
-    - ".justfile"
-    - "pyproject.toml"
-    - "setup.py"
+    # Changes to the package itself
+    - src/msgspec/**
+    - pyproject.toml
+    - setup.py
+    - MANIFEST.in
+    # Changes to CI execution
+    - .github/workflows/ci.yml
+    - .github/workflows/profile.yml
+    - .cibuildwheel.toml
+    - .justfile
+    # Changes to testing
+    - tests/**
+    - .codecov.yml
+    - .codespellrc
+    - .coveragerc
+    - .pre-commit-config.yaml
+    - .pytest.toml
+    - .ruff.toml
   release:
     types:
     - published
@@ -243,6 +255,7 @@ jobs:
     - name: Build & Test Wheels
       uses: pypa/cibuildwheel@v3.2.1
       with:
+        config-file: .cibuildwheel.toml
         package-dir: dist/${{ needs.validate.outputs.sdist-name }}
       env:
         CIBW_ARCHS: "${{ matrix.archs }}"

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Install profiling dependencies
       env:
         UV_PROJECT_ENVIRONMENT: "${{ steps.metadata.outputs.env-path }}"
-      run: uv sync --only-group prof
+      run: uv sync --only-group test-prof
 
     - name: Download artifacts
       if: inputs.version == 'dev'

--- a/.justfile
+++ b/.justfile
@@ -297,7 +297,7 @@ _with_env env action *args:
     } else if env == "doc" { \
       "--group doc" \
     } else if env == "prof" { \
-      "--group prof" \
+      "--group test-prof" \
     } else if env == "bench" { \
       "--group bench" \
     } else if env == "hooks" { \

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,0 +1,7 @@
+# TODO: remove this file once we drop support for Python 3.9
+[pytest]
+testpaths =
+    tests/unit
+    tests/typing
+filterwarnings =
+    error

--- a/.pytest.toml
+++ b/.pytest.toml
@@ -1,0 +1,11 @@
+[pytest]
+# This determines which tests are collected when no arguments are passed.
+# We default to all non-profiling test suites and we run unit tests first.
+testpaths = [
+  "tests/unit",
+  "tests/typing",
+]
+# Turn all warnings into errors.
+filterwarnings = [
+  "error",
+]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,30 @@
+line-length = 88
+extend-exclude = [
+  "*.pyi",
+  "src/msgspec/__init__.py",
+  "src/msgspec/_version.py",
+  "src/msgspec/json.py",
+  "src/msgspec/msgpack.py",
+  "tests/typing/basic_typing_examples.py",
+  "tests/unit/test_JSONTestSuite.py",
+  "docs/conf.py",
+  # TODO: remove when this when we drop support for Python 3.9 (example uses match statements)
+  "examples/asyncio-kv/kv.py",
+]
+
+[lint]
+select = [
+  "E", # PEP8 Errors
+  "F", # Pyflakes
+  "I", # Import sorting
+  "W", # PEP8 Warnings
+]
+ignore = [
+  "E721", # Comparing types instead of isinstance
+  "E741", # Ambiguous variable names
+  "E501", # Conflicts with ruff format
+  "W191", # Conflicts with ruff format
+]
+
+[lint.isort]
+combine-as-imports = true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ prune examples
 prune scripts
 exclude .*
 exclude lychee.toml
+include .cibuildwheel.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,23 +104,27 @@ hooks = [
   "prek>=0.2.13",
   "ruff==0.14.1",
 ]
-prof = [
+test-base = [
+  # TODO: require >=9 once we drop support for Python 3.9
+  "pytest>=8",
+]
+test-prof = [
+  { include-group = "test-base" },
   "memray; sys_platform != 'win32'",
-  "pytest",
   "pytest-benchmark",
   "pytest-memray; sys_platform != 'win32'",
 ]
 test-typing = [
+  { include-group = "test-base" },
   "mypy",
   "pyright",
-  "pytest",
 ]
 test-unit = [
+  { include-group = "test-base" },
   "attrs",
   "coverage",
   "eval-type-backport; python_version < '3.10'",
   "msgpack",
-  "pytest",
   "pyyaml",
   "tomli; python_version < '3.11'",
   "tomli-w",
@@ -144,73 +148,3 @@ parentdir_prefix_version = "msgspec-"
 
 [tool.uv.config-settings]
 editable_mode = "compat"
-
-[tool.ruff]
-extend-exclude = [
-  "*.pyi",
-  "__init__.py",
-  "src/msgspec/_version.py",
-  "basic_typing_examples.py",
-  "json.py",
-  "msgpack.py",
-  "test_JSONTestSuite.py",
-  "conf.py",
-  # TODO: remove when this when we drop support for Python 3.9 (example uses match statements)
-  "examples/asyncio-kv/kv.py",
-]
-line-length = 88
-
-[tool.ruff.lint]
-ignore = [
-  "E721", # Comparing types instead of isinstance
-  "E741", # Ambiguous variable names
-  "E501", # Conflicts with ruff format
-  "W191", # Conflicts with ruff format
-]
-select = [
-  "E", # PEP8 Errors
-  "F", # Pyflakes
-  "I", # Import sorting
-  "W", # PEP8 Warnings
-]
-
-[tool.ruff.lint.isort]
-combine-as-imports = true
-
-[tool.codespell]
-skip = "./site,./.venv,*.py,*.c,*.h"
-
-[tool.coverage.run]
-source_pkgs = ["msgspec"]
-source_dirs = ["tests/unit"]
-omit = [
-  "src/msgspec/_version.py",
-]
-
-[tool.coverage.paths]
-msgspec = [
-  "src/msgspec",
-  "*/msgspec/src/msgspec",
-  "*/msgspec/dev/*/venvs/*/lib*/python*/site-packages/msgspec",
-  "*\\msgspec\\dev\\*\\venvs\\*\\Lib\\site-packages\\msgspec",
-]
-tests = [
-  "tests/unit",
-  "*/msgspec/tests/unit",
-]
-
-[tool.pytest.ini_options]
-testpaths = [
-  # The order here determines the order in which tests are run.
-  "tests/unit",
-  "tests/typing",
-]
-filterwarnings = [
-  "error",
-]
-
-[tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
-build-frontend = "build[uv]"
-test-command = "pytest {project}/tests/unit"
-test-groups = ["test-unit"]

--- a/tests/unit/test_struct_meta.py
+++ b/tests/unit/test_struct_meta.py
@@ -1,6 +1,7 @@
 """Tests for the exposed StructMeta metaclass."""
 
-from abc import ABCMeta, abstractmethod, _abc_init
+from abc import ABCMeta, _abc_init, abstractmethod
+
 import pytest
 
 import msgspec


### PR DESCRIPTION
This moves configuration that doesn't influence built distributions out of `pyproject.toml`. Tools that compute a dependency graph like uv cannot distinguish distribution-affecting `pyproject.toml` changes from others because it's all about the file hash (same as other build systems like Bazel). In this case, commands like `uv run` must rebuild the package whenever changes occur, which is particularly cumbersome for rapid development because of the time it takes to build the extension module.

The only thing that couldn't be moved is the definition of the `dependency-groups` table because uv currently [doesn't support](https://docs.astral.sh/uv/reference/settings/#dependency-groups) an equivalent mechanism for defining such groups of dependencies.