### PR TITLE
Enable more static analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ uv.lock
 .pytest_cache/
 htmlcov/
 
+# Ruff Cache
+.ruff_cache/
+
 # Mypy Cache
 .mypy_cache/
 

--- a/.justfile
+++ b/.justfile
@@ -77,7 +77,7 @@ test-all *args: (
 [group: "Testing"]
 test-unit *args: (
   env-run "test"
-  "pytest tests/unit"
+  "pytest -o testpaths=tests/unit"
   args
 )
 alias test := test-unit
@@ -86,7 +86,7 @@ alias test := test-unit
 [group: "Testing"]
 test-typing *args: (
   env-run "test"
-  "pytest tests/typing"
+  "pytest -o testpaths=tests/typing"
   args
 )
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,13 +1,8 @@
 line-length = 88
 extend-exclude = [
-  "*.pyi",
-  "src/msgspec/__init__.py",
   "src/msgspec/_version.py",
-  "src/msgspec/json.py",
-  "src/msgspec/msgpack.py",
   "tests/typing/basic_typing_examples.py",
   "tests/unit/test_JSONTestSuite.py",
-  "docs/conf.py",
   # TODO: remove when this when we drop support for Python 3.9 (example uses match statements)
   "examples/asyncio-kv/kv.py",
 ]
@@ -25,6 +20,12 @@ ignore = [
   "E501", # Conflicts with ruff format
   "W191", # Conflicts with ruff format
 ]
+
+[lint.extend-per-file-ignores]
+"src/msgspec/__init__.py" = ["E402", "F401"]
+"src/msgspec/__init__.pyi" = ["F401"]
+"src/msgspec/json.py" = ["F401"]
+"src/msgspec/msgpack.py" = ["F401"]
 
 [lint.isort]
 combine-as-imports = true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,9 @@
+prune .devcontainer
 prune .github
 prune benchmarks
 prune docs
 prune examples
 prune scripts
-exclude .*
 exclude lychee.toml
+exclude .*
 include .cibuildwheel.toml

--- a/src/msgspec/__init__.py
+++ b/src/msgspec/__init__.py
@@ -1,4 +1,6 @@
 from ._core import (
+    NODEFAULT,
+    UNSET,
     DecodeError,
     EncodeError,
     Field as _Field,
@@ -8,11 +10,9 @@ from ._core import (
     Struct,
     StructMeta,
     UnsetType,
-    UNSET,
-    NODEFAULT,
     ValidationError,
-    defstruct,
     convert,
+    defstruct,
     to_builtins,
 )
 
@@ -24,10 +24,5 @@ def field(*, default=NODEFAULT, default_factory=NODEFAULT, name=None):
 field.__doc__ = _Field.__doc__
 
 
-from . import msgpack
-from . import json
-from . import yaml
-from . import toml
-from . import inspect
-from . import structs
+from . import inspect, json, msgpack, structs, toml, yaml
 from ._version import __version__

--- a/src/msgspec/__init__.pyi
+++ b/src/msgspec/__init__.pyi
@@ -17,7 +17,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import dataclass_transform, Buffer
+from typing_extensions import Buffer, dataclass_transform
 
 from . import inspect, json, msgpack, structs, toml, yaml
 

--- a/src/msgspec/json.pyi
+++ b/src/msgspec/json.pyi
@@ -1,10 +1,8 @@
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import (
     Any,
-    Callable,
     Dict,
     Generic,
-    Iterable,
     Literal,
     Optional,
     Tuple,
@@ -104,13 +102,19 @@ def decode(
     strict: bool = True,
     dec_hook: dec_hook_sig = None,
 ) -> Any: ...
-def encode(obj: Any, /, *, enc_hook: enc_hook_sig = None, order: Literal[None, "deterministic", "sorted"] = None) -> bytes: ...
+def encode(
+    obj: Any,
+    /,
+    *,
+    enc_hook: enc_hook_sig = None,
+    order: Literal[None, "deterministic", "sorted"] = None,
+) -> bytes: ...
 def schema(type: Any, *, schema_hook: schema_hook_sig = None) -> Dict[str, Any]: ...
 def schema_components(
     types: Iterable[Any],
     *,
     schema_hook: schema_hook_sig = None,
-    ref_template: str = "#/$defs/{name}"
+    ref_template: str = "#/$defs/{name}",
 ) -> Tuple[Tuple[Dict[str, Any], ...], Dict[str, Any]]: ...
 @overload
 def format(buf: str, /, *, indent: int = 2) -> str: ...

--- a/src/msgspec/msgpack.pyi
+++ b/src/msgspec/msgpack.pyi
@@ -12,7 +12,6 @@ from typing import (
 
 from typing_extensions import Buffer
 
-
 T = TypeVar("T")
 
 enc_hook_sig = Optional[Callable[[Any], Any]]
@@ -106,4 +105,10 @@ def decode(
     dec_hook: dec_hook_sig = None,
     ext_hook: ext_hook_sig = None,
 ) -> Any: ...
-def encode(obj: Any, /, *, enc_hook: enc_hook_sig = None, order: Literal[None, "deterministic", "sorted"] = None) -> bytes: ...
+def encode(
+    obj: Any,
+    /,
+    *,
+    enc_hook: enc_hook_sig = None,
+    order: Literal[None, "deterministic", "sorted"] = None,
+) -> bytes: ...


### PR DESCRIPTION
Changed:

1. Reduced what files Ruff ignores.
2. Fixed the contents of the source distribution so that the dev container config is not shipped.
3. Properly allow the test recipes to overwrite the test collection paths with arguments rather than extending them.