### PR TITLE
Enable LTO on macOS ARM64

### DIFF
--- a/.cibuildwheel.toml
+++ b/.cibuildwheel.toml
@@ -3,11 +3,3 @@ build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
 build-frontend = "build[uv]"
 test-command = "pytest {project}/tests/unit"
 test-groups = ["test-unit"]
-
-[tool.cibuildwheel.linux]
-before-build = [
-  "yum install -y clang gcc",
-]
-
-[tool.cibuildwheel.linux.environment]
-CC = "clang"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 
 from setuptools import setup
@@ -38,8 +39,9 @@ if DEBUG:
     extra_compile_args.extend(["-O0", "-g", "-UNDEBUG"])
 elif sys.platform != "win32":
     extra_compile_args.extend(["-g0"])
-    extra_compile_args.extend(["-flto=thin"])
-    extra_link_args.extend(["-flto=thin"])
+    if sys.platform == "darwin" and platform.machine().lower() == "arm64":
+        extra_compile_args.extend(["-flto=thin"])
+        extra_link_args.extend(["-flto=thin"])
 
 # from https://py-free-threading.github.io/faq/#im-trying-to-build-a-library-on-windows-but-msvc-says-c-atomic-support-is-not-enabled
 if sys.platform == "win32":


### PR DESCRIPTION
Full LTO seems to cause a regression so this uses ThinLTO only on macOS (Clang) and only on ARM64. Here are the results of a few runs (the Intel runners just seem terrible):

---

## Before

### ARM64

<details>
<summary>encode: 145.9584 / decode: 351.2980</summary>

https://github.com/jcrist/msgspec/actions/runs/19412999871/job/55537240877

Name (time in us) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS (Kops/s) | Rounds | Iterations
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
encode | 130.4833 (1.0) | 1,755.7709 (1.0) | 153.0818 (1.0) | 42.0774 (1.0) | 145.9584 (1.0) | 14.0292 (1.0) | 446;834 | 6.5325 (1.0) | 10000 | 10
decode | 324.3583 (2.49) | 10,951.2000 (6.24) | 374.9843 (2.45) | 154.3808 (3.67) | 351.2980 (2.41) | 20.2022 (1.44) | 246;1309 | 2.6668 (0.41) | 10000 | 10
</details>

<details>
<summary>encode: 143.2750 / decode: 354.1458</summary>

https://github.com/jcrist/msgspec/actions/runs/19412999871/job/55539651179

Name (time in us) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS (Kops/s) | Rounds | Iterations
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
encode | 130.3250 (1.0) | 2,596.3542 (1.0) | 154.4214 (1.0) | 50.5128 (1.0) | 143.2750 (1.0) | 13.8417 (1.0) | 471;1029 | 6.4758 (1.0) | 10000 | 10
decode | 323.7542 (2.48) | 4,192.2167 (1.61) | 375.4091 (2.43) | 119.6400 (2.37) | 354.1458 (2.47) | 34.9271 (2.52) | 225;631 | 2.6638 (0.41) | 10000 | 10
</details>

### x86_64

<details>
<summary>encode: 228.6268 / decode: 729.5701</summary>

https://github.com/jcrist/msgspec/actions/runs/19412999871/job/55537240884

Name (time in us) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS (Kops/s) | Rounds | Iterations
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
encode | 206.4159 (1.0) | 7,320.7824 (1.61) | 250.7420 (1.0) | 94.9931 (1.0) | 228.6268 (1.0) | 36.5537 (1.0) | 722;1198 | 3.9882 (1.0) | 10000 | 10
decode | 694.9477 (3.37) | 4,550.2093 (1.0) | 749.2888 (2.99) | 110.4365 (1.16) | 729.5701 (3.19) | 49.4375 (1.35) | 498;662 | 1.3346 (0.33) | 10000 | 10
</details>

<details>
<summary>encode: 230.9933 / decode: 757.6821</summary>

https://github.com/jcrist/msgspec/actions/runs/19412999871/job/55539352389

Name (time in us) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS (Kops/s) | Rounds | Iterations
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
encode | 210.2697 (1.0) | 5,402.5395 (1.0) | 251.5679 (1.0) | 100.4256 (1.0) | 230.9933 (1.0) | 43.8295 (1.0) | 340;569 | 3.9751 (1.0) | 10000 | 10
decode | 697.6369 (3.32) | 14,816.0169 (2.74) | 807.6615 (3.21) | 318.6815 (3.17) | 757.6821 (3.28) | 103.2592 (2.36) | 235;698 | 1.2381 (0.31) | 10000 | 10
</details>

---

## After

### ARM64

<details>
<summary>encode: 137.4250 / decode: 341.0833</summary>

https://github.com/jcrist/msgspec/actions/runs/19413142685/job/55537726515

Name (time in us) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS (Kops/s) | Rounds | Iterations
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
encode | 125.5625 (1.0) | 1,878.1959 (1.26) | 146.3765 (1.0) | 53.2579 (1.0) | 137.4250 (1.0) | 3.5416 (1.0) | 378;1460 | 6.8317 (1.0) | 10000 | 10
decode | 309.8791 (2.47) | 1,487.6791 (1.0) | 351.2185 (2.40) | 71.5229 (1.34) | 341.0833 (2.48) | 21.1479 (5.97) | 509;788 | 2.8472 (0.42) | 10000 | 10
</details>

<details>
<summary>encode: 143.0917 / decode: 341.9875</summary>

https://github.com/jcrist/msgspec/actions/runs/19413142685/job/55539646141

Name (time in us) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS (Kops/s) | Rounds | Iterations
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
encode | 125.4333 (1.0) | 1,788.0458 (1.0) | 148.8024 (1.0) | 41.2471 (1.0) | 143.0917 (1.0) | 14.7687 (1.0) | 396;575 | 6.7203 (1.0) | 10000 | 10
decode | 303.9750 (2.42) | 7,741.4625 (4.33) | 375.3218 (2.52) | 174.8312 (4.24) | 341.9875 (2.39) | 24.7896 (1.68) | 493;1304 | 2.6644 (0.40) | 10000 | 10
</details>

### x86_64

<details>
<summary>encode: 224.2774 / decode: 690.9108</summary>

https://github.com/jcrist/msgspec/actions/runs/19413142685/job/55537726518

Name (time in us) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS (Kops/s) | Rounds | Iterations
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
encode | 207.8972 (1.0) | 8,588.2149 (1.0) | 253.7614 (1.0) | 145.7307 (1.0) | 224.2774 (1.0) | 52.2173 (1.83) | 290;703 | 3.9407 (1.0) | 10000 | 10
decode | 684.0644 (3.29) | 14,789.9789 (1.72) | 749.2749 (2.95) | 312.8542 (2.15) | 690.9108 (3.08) | 28.4929 (1.0) | 386;1463 | 1.3346 (0.34) | 10000 | 10
</details>

<details>
<summary>encode: 339.4682 / decode: 924.6652</summary>

https://github.com/jcrist/msgspec/actions/runs/19413142685/job/55539486694

Name (time in us) | Min | Max | Mean | StdDev | Median | IQR | Outliers | OPS | Rounds | Iterations
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
encode | 256.4145 (1.0) | 29,541.7157 (3.10) | 415.5266 (1.0) | 584.9506 (1.74) | 339.4682 (1.0) | 129.0764 (1.0) | 243;649 | 2,406.5850 (1.0) | 10000 | 10
decode | 780.7286 (3.04) | 9,538.8675 (1.0) | 1,033.4723 (2.49) | 336.9571 (1.0) | 924.6652 (2.72) | 247.0121 (1.91) | 866;452 | 967.6118 (0.40) | 10000 | 10
</details>