### PR TITLE
Fix profiling tests on Windows ARM64

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -38,23 +38,23 @@ jobs:
     - name: Load environment file
       uses: ./.github/actions/load-env
 
-    - name: Install Python
-      uses: actions/setup-python@v6
-      with:
-        python-version-file: pyproject.toml
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-
-    - name: Install command runner
-      run: uv tool install rust-just
-
     - name: Fetch latest supported Python
       if: inputs.python == ''
       id: latest-supported-python
       uses: ./.github/actions/latest-supported-python
       with:
         github-token: "${{ github.token }}"
+
+    - name: Install Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "${{ inputs.python || steps.latest-supported-python.outputs.version }}"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Install command runner
+      run: uv tool install rust-just
 
     - name: Set profiling environment metadata
       id: metadata


### PR DESCRIPTION
The last successful build [used](https://github.com/jcrist/msgspec/actions/runs/19622631680/job/56186214935#step:9:19) Python 3.13 because we select the highest minor version supported by our existing wheels on PyPI. After releasing support for Python 3.14, the profiling tests began using that. The Windows images [only ship](https://github.com/actions/partner-runner-images/blob/d9e1653e90833bddbea1310ac1a90d101949bca1/images/arm-windows-11-image.md#python) 3.12 & 3.13 in the tool cache and, since we didn't specify a version, 3.13 was [set up](https://github.com/jcrist/msgspec/actions/runs/19669298165/job/56334577777?pr=933#step:4:17). This made uv [download](https://github.com/jcrist/msgspec/actions/runs/19669298165/job/56334577777?pr=933#step:9:19) its own Python distribution but it selected the one for x86_64 because the team [chose](https://github.com/astral-sh/uv/pull/13724) to ([temporarily](https://github.com/astral-sh/uv/issues/12906)) rely on emulation until more wheels in the ecosystem were built natively. We build wheels in a separate step that serves subsequent jobs and the profiling tests download the specific wheel artifact for the given platform rather than downloading everything, hence the error of trying to install an ARM wheel on a different architecture.