### PR TITLE
Fix broken ravyn.dev link in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -139,7 +139,7 @@ few:
         .. image:: _static/anywidget.png
             :target: https://anywidget.dev/
 
-    .. grid-item-card:: `Ravyn <https://www.ravyn.dev/encoders/#example>`_
+    .. grid-item-card:: `Ravyn <https://www.ravyn.dev/encoders/#msgspec-encoder>`_
 
         .. image:: _static/ravyn.png
             :target: https://www.ravyn.dev/


### PR DESCRIPTION
## Summary
- Fix broken `#example` fragment in ravyn.dev link to `#msgspec-encoder`

Closes #976