### PR TITLE
feat: add mypy plugin for type-checking structs.replace kwargs

### DIFF
--- a/src/msgspec/mypy.py
+++ b/src/msgspec/mypy.py
@@ -1,0 +1,174 @@
+"""Mypy plugin for msgspec.
+
+Provides type-checking support for ``msgspec.structs.replace``, validating
+that keyword arguments match the fields of the target Struct.
+
+Enable by adding ``msgspec.mypy`` to your mypy plugins::
+
+    # mypy.ini or pyproject.toml
+    [mypy]
+    plugins = [msgspec.mypy]
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from functools import reduce
+
+import mypy.plugin
+from mypy.meet import meet_types
+from mypy.nodes import ARG_NAMED_OPT, ARG_POS, FuncDef
+from mypy.plugin import FunctionSigContext, Plugin
+from mypy.typeops import expand_type_by_instance
+from mypy.types import (
+    AnyType,
+    CallableType,
+    Instance,
+    ProperType,
+    Type,
+    TypeVarType,
+    UninhabitedType,
+    UnionType,
+    get_proper_type,
+)
+
+try:
+    from mypy.typeops import format_type_bare
+except ImportError:
+    from mypy.checker import format_type_bare  # type: ignore[no-redef]
+
+MSGSPEC_STRUCT_FULLNAME = "msgspec.Struct"
+
+
+def _is_msgspec_struct(typ: Instance) -> bool:
+    return any(base.fullname == MSGSPEC_STRUCT_FULLNAME for base in typ.type.mro)
+
+
+def _get_struct_init_type(typ: Instance) -> CallableType | None:
+    if not _is_msgspec_struct(typ):
+        return None
+    init_method = typ.type.get_method("__init__")
+    if not isinstance(init_method, FuncDef) or not isinstance(
+        init_method.type, CallableType
+    ):
+        return None
+    return init_method.type
+
+
+def _fail_not_struct(
+    ctx: FunctionSigContext, t: ProperType, parent_t: ProperType
+) -> None:
+    t_name = format_type_bare(t, ctx.api.options)
+    if parent_t is t:
+        msg = (
+            f'Argument 1 to "replace" has a variable type "{t_name}"'
+            f" not bound to a msgspec Struct"
+            if isinstance(t, TypeVarType)
+            else f'Argument 1 to "replace" has incompatible type "{t_name}";'
+            f" expected a msgspec Struct"
+        )
+    else:
+        pt_name = format_type_bare(parent_t, ctx.api.options)
+        msg = (
+            f'Argument 1 to "replace" has type "{pt_name}" whose item "{t_name}"'
+            f" is not bound to a msgspec Struct"
+            if isinstance(t, TypeVarType)
+            else f'Argument 1 to "replace" has incompatible type "{pt_name}" whose'
+            f' item "{t_name}" is not a msgspec Struct'
+        )
+    ctx.api.fail(msg, ctx.context)
+
+
+def _get_expanded_struct_types(
+    ctx: FunctionSigContext,
+    typ: ProperType,
+    display_typ: ProperType,
+    parent_typ: ProperType,
+) -> list[Mapping[str, Type]] | None:
+    if isinstance(typ, AnyType):
+        return None
+    if isinstance(typ, UnionType):
+        ret: list[Mapping[str, Type]] | None = []
+        for item in typ.relevant_items():
+            item = get_proper_type(item)
+            item_types = _get_expanded_struct_types(ctx, item, item, parent_typ)
+            if ret is not None and item_types is not None:
+                ret += item_types
+            else:
+                ret = None  # but keep iterating to emit all errors
+        return ret
+    if isinstance(typ, TypeVarType):
+        return _get_expanded_struct_types(
+            ctx, get_proper_type(typ.upper_bound), display_typ, parent_typ
+        )
+    if isinstance(typ, Instance):
+        init_func = _get_struct_init_type(typ)
+        if init_func is None:
+            _fail_not_struct(ctx, display_typ, parent_typ)
+            return None
+        init_func = expand_type_by_instance(init_func, typ)
+        # [1:] to skip the self argument of Struct.__init__
+        field_names = [n for n in init_func.arg_names[1:] if n is not None]
+        field_types = init_func.arg_types[1:]
+        return [dict(zip(field_names, field_types))]
+    _fail_not_struct(ctx, display_typ, parent_typ)
+    return None
+
+
+def _meet_fields(types: list[Mapping[str, Type]]) -> Mapping[str, Type]:
+    field_to_types: defaultdict[str, list[Type]] = defaultdict(list)
+    for fields in types:
+        for name, typ in fields.items():
+            field_to_types[name].append(typ)
+    return {
+        name: (
+            get_proper_type(reduce(meet_types, f_types))
+            if len(f_types) == len(types)
+            else UninhabitedType()
+        )
+        for name, f_types in field_to_types.items()
+    }
+
+
+def _replace_sig_callback(ctx: mypy.plugin.FunctionSigContext) -> CallableType:
+    if len(ctx.args) != 2:
+        ctx.api.fail(
+            f'"{ctx.default_signature.name}" has unexpected type annotation',
+            ctx.context,
+        )
+        return ctx.default_signature
+
+    if len(ctx.args[0]) != 1:
+        return ctx.default_signature  # leave it to the type checker to complain
+
+    inst_arg = ctx.args[0][0]
+    inst_type = get_proper_type(ctx.api.get_expression_type(inst_arg))
+    inst_type_str = format_type_bare(inst_type, ctx.api.options)
+
+    struct_types = _get_expanded_struct_types(ctx, inst_type, inst_type, inst_type)
+    if struct_types is None:
+        return ctx.default_signature
+    fields = _meet_fields(struct_types)
+
+    return CallableType(
+        arg_names=["struct", *fields.keys()],
+        arg_kinds=[ARG_POS] + [ARG_NAMED_OPT] * len(fields),
+        arg_types=[inst_type, *fields.values()],
+        ret_type=inst_type,
+        fallback=ctx.default_signature.fallback,
+        name=f"replace of {inst_type_str}",
+    )
+
+
+class MsgspecPlugin(Plugin):
+    def get_function_signature_hook(
+        self, fullname: str
+    ) -> Callable[[FunctionSigContext], CallableType] | None:
+        if fullname == "msgspec.structs.replace":
+            return _replace_sig_callback
+        return None
+
+
+def plugin(version: str) -> type[MsgspecPlugin]:
+    return MsgspecPlugin

--- a/tests/typing/test_mypy_plugin.py
+++ b/tests/typing/test_mypy_plugin.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import tempfile
+import textwrap
+from collections.abc import Sequence
+from pathlib import Path
+
+from mypy import api as mypy_api
+
+_MYPY_INI = """\
+[mypy]
+strict = True
+plugins = msgspec.mypy
+"""
+
+
+def _run_mypy(code: str) -> tuple[Sequence[str], int]:
+    """Run mypy on a code snippet with the msgspec mypy plugin enabled.
+
+    Returns (output_lines, exit_code).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = Path(tmpdir) / "mypy.ini"
+        config_path.write_text(_MYPY_INI)
+        source_path = Path(tmpdir) / "test_source.py"
+        source_path.write_text(textwrap.dedent(code))
+
+        result = mypy_api.run(
+            [
+                "--no-incremental",
+                "--show-error-codes",
+                "--show-traceback",
+                "--config-file",
+                str(config_path),
+                str(source_path),
+            ]
+        )
+    stdout, stderr, exit_code = result
+    lines = [line for line in stdout.strip().splitlines() if line.strip()]
+    if stderr.strip():
+        lines.append("STDERR: " + stderr.strip())
+    return lines, exit_code
+
+
+def _assert_mypy_ok(code: str) -> None:
+    lines, exit_code = _run_mypy(code)
+    assert exit_code == 0, "Expected no errors, got:\n" + "\n".join(lines)
+
+
+def _assert_mypy_errors(code: str, expected_fragments: Sequence[str]) -> None:
+    lines, exit_code = _run_mypy(code)
+    assert exit_code != 0, "Expected errors but mypy passed"
+    output = "\n".join(lines)
+    for fragment in expected_fragments:
+        assert fragment in output, (
+            f"Expected fragment {fragment!r} not found in mypy output:\n{output}"
+        )
+
+
+class TestReplace:
+    def test_replace_valid_field(self) -> None:
+        _assert_mypy_ok(
+            """
+            import msgspec
+            from msgspec.structs import replace
+
+            class C(msgspec.Struct):
+                name: str
+                value: int
+
+            c = C(name="foo", value=1)
+            c2 = replace(c, name="bar")
+            c3 = replace(c, value=2)
+            c4 = replace(c, name="bar", value=2)
+            c5 = replace(c)
+        """
+        )
+
+    def test_replace_invalid_field(self) -> None:
+        _assert_mypy_errors(
+            """
+            import msgspec
+            from msgspec.structs import replace
+
+            class C(msgspec.Struct):
+                name: str
+
+            c = C(name="foo")
+            replace(c, foobar=42)
+            """,
+            ['Unexpected keyword argument "foobar"'],
+        )
+
+    def test_replace_wrong_type(self) -> None:
+        _assert_mypy_errors(
+            """
+            import msgspec
+            from msgspec.structs import replace
+
+            class C(msgspec.Struct):
+                name: str
+
+            c = C(name="foo")
+            replace(c, name=42)
+            """,
+            ['Argument "name" to "replace" of "C" has incompatible type "int"; expected "str"'],
+        )
+
+    def test_replace_too_many_positional(self) -> None:
+        _assert_mypy_errors(
+            """
+            import msgspec
+            from msgspec.structs import replace
+
+            class C(msgspec.Struct):
+                name: str
+
+            c = C(name="foo")
+            replace(c, "foo")
+            """,
+            ["Too many positional arguments"],
+        )
+
+    def test_replace_preserves_type(self) -> None:
+        _assert_mypy_ok(
+            """
+            import msgspec
+            from msgspec.structs import replace
+
+            class C(msgspec.Struct):
+                name: str
+
+            c = C(name="foo")
+            c2: C = replace(c, name="bar")
+        """
+        )
+
+
+class TestReplaceFromNonStruct:
+    def test_replace_int(self) -> None:
+        _assert_mypy_errors(
+            """
+            from msgspec.structs import replace
+            replace(42, name="foo")
+            """,
+            ['Argument 1 to "replace" has incompatible type "int"'],
+        )
+
+    def test_replace_none(self) -> None:
+        _assert_mypy_errors(
+            """
+            from msgspec.structs import replace
+            replace(None, name="foo")
+            """,
+            ['Argument 1 to "replace"'],
+        )
+
+
+class TestReplaceFromAny:
+    def test_replace_any(self) -> None:
+        _assert_mypy_ok(
+            """
+            from typing import Any
+            from msgspec.structs import replace
+
+            any_val: Any = 42
+            ret = replace(any_val)
+        """
+        )
+
+
+class TestReplaceGeneric:
+    def test_replace_generic_valid(self) -> None:
+        _assert_mypy_ok(
+            """
+            from typing import Generic, TypeVar
+            import msgspec
+            from msgspec.structs import replace
+
+            T = TypeVar("T")
+
+            class A(msgspec.Struct, Generic[T]):
+                x: T
+
+            a = A(x=42)
+            a2 = replace(a, x=42)
+        """
+        )
+
+    def test_replace_generic_wrong_type(self) -> None:
+        _assert_mypy_errors(
+            """
+            from typing import Generic, TypeVar
+            import msgspec
+            from msgspec.structs import replace
+
+            T = TypeVar("T")
+
+            class A(msgspec.Struct, Generic[T]):
+                x: T
+
+            a = A(x=42)
+            replace(a, x="42")
+            """,
+            [
+                'Argument "x" to "replace" of "A[int]" has incompatible type "str"; expected "int"'
+            ],
+        )
+
+
+class TestReplaceUnion:
+    def test_replace_union_valid(self) -> None:
+        _assert_mypy_ok(
+            """
+            from typing import Generic, TypeVar, Union
+            import msgspec
+            from msgspec.structs import replace
+
+            T = TypeVar("T")
+
+            class A(msgspec.Struct, Generic[T]):
+                x: T
+                y: bool
+
+            class B(msgspec.Struct):
+                x: int
+                y: int
+
+            a_or_b: Union[A[int], B]
+            _ = replace(a_or_b, x=42, y=True)
+        """
+        )
+
+    def test_replace_union_incompatible_field(self) -> None:
+        _assert_mypy_errors(
+            """
+            from typing import Union
+            import msgspec
+            from msgspec.structs import replace
+
+            class A(msgspec.Struct):
+                x: int
+                z: str
+
+            class B(msgspec.Struct):
+                x: int
+                z: bytes
+
+            a_or_b: Union[A, B]
+            replace(a_or_b, z="42")
+            """,
+            [
+                'Argument "z" to "replace" of "A | B" has incompatible type "str"; expected "Never"'
+            ],
+        )
+
+
+class TestReplaceTypeVarBound:
+    def test_replace_typevar_bound_valid(self) -> None:
+        _assert_mypy_ok(
+            """
+            from typing import TypeVar
+            import msgspec
+            from msgspec.structs import replace
+
+            class A(msgspec.Struct):
+                x: int
+
+            class B(A):
+                pass
+
+            TA = TypeVar("TA", bound=A)
+
+            def f(t: TA) -> TA:
+                return replace(t, x=42)
+
+            f(A(x=42))
+            f(B(x=42))
+        """
+        )
+
+    def test_replace_typevar_bound_wrong_type(self) -> None:
+        _assert_mypy_errors(
+            """
+            from typing import TypeVar
+            import msgspec
+            from msgspec.structs import replace
+
+            class A(msgspec.Struct):
+                x: int
+
+            TA = TypeVar("TA", bound=A)
+
+            def f(t: TA) -> TA:
+                return replace(t, x="42")
+            """,
+            [
+                'Argument "x" to "replace" of "TA" has incompatible type "str"; expected "int"'
+            ],
+        )
+
+    def test_replace_typevar_bound_non_struct(self) -> None:
+        _assert_mypy_errors(
+            """
+            from typing import TypeVar
+            from msgspec.structs import replace
+
+            TInt = TypeVar("TInt", bound=int)
+
+            def f(t: TInt) -> None:
+                replace(t, x=42)
+            """,
+            [
+                'Argument 1 to "replace" has a variable type "TInt" not bound to a msgspec Struct'
+            ],
+        )
+
+
+class TestReplaceFrozen:
+    def test_replace_frozen_struct(self) -> None:
+        _assert_mypy_ok(
+            """
+            import msgspec
+            from msgspec.structs import replace
+
+            class C(msgspec.Struct, frozen=True):
+                name: str
+                value: int
+
+            c = C(name="foo", value=1)
+            c2 = replace(c, name="bar")
+        """
+        )
+
+    def test_replace_frozen_struct_invalid_field(self) -> None:
+        _assert_mypy_errors(
+            """
+            import msgspec
+            from msgspec.structs import replace
+
+            class C(msgspec.Struct, frozen=True):
+                name: str
+
+            c = C(name="foo")
+            replace(c, invalid="bar")
+            """,
+            ['Unexpected keyword argument "invalid"'],
+        )
+
+
+class TestReplaceFromFunction:
+    def test_replace_from_function_return(self) -> None:
+        _assert_mypy_ok(
+            """
+            import msgspec
+            from msgspec.structs import replace
+
+            class C(msgspec.Struct):
+                name: str
+
+            def make_c() -> C:
+                return C(name="foo")
+
+            c = replace(make_c(), name="bar")
+        """
+        )


### PR DESCRIPTION
## Summary

- Adds `msgspec.mypy` plugin that validates keyword arguments passed to `msgspec.structs.replace()`
- Without the plugin, mypy accepts any kwargs due to the `**changes: Any` signature in the stubs — including invalid field names and wrong types
- Follows the same approach used by mypy's built-in attrs `evolve()` plugin: hooks into `get_function_signature_hook` and generates a call-site-specific signature with the struct's fields as optional keyword arguments

### Usage

```ini
# mypy.ini or pyproject.toml
[mypy]
plugins = [msgspec.mypy]
```

### What it catches

```python
class User(msgspec.Struct):
    name: str
    age: int

u = User(name="Alice", age=30)

# These now produce mypy errors:
replace(u, invalid=42)      # Unexpected keyword argument "invalid"
replace(u, name=42)         # Incompatible type "int"; expected "str"
```

### Supported cases

- Plain and frozen structs
- Generic structs (`Struct[T]`)
- Unions of structs (field types are intersected)
- TypeVar bounds
- Any passthrough (no false positives)
- Function return values as first argument

## Test plan

- [x] 18 new tests in `tests/typing/test_mypy_plugin.py` — all passing
- [x] Existing `tests/typing/test_mypy.py` still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)