### PR TITLE
Use safe_load in yaml

### DIFF
--- a/src/msgspec/yaml.py
+++ b/src/msgspec/yaml.py
@@ -178,7 +178,7 @@ def decode(buf, *, type=Any, strict=True, dec_hook=None):
         # call `memoryview` first, since `bytes(1)` is actually valid
         buf = bytes(memoryview(buf))
     try:
-        obj = yaml.load(buf, Loader)
+        obj = yaml.safe_load(buf, Loader)
     except yaml.YAMLError as exc:
         raise _DecodeError(str(exc)) from None
 


### PR DESCRIPTION
`yaml.load()` in `src/msgspec/yaml.py` doesn't pass a safe Loader. This can deserialize arbitrary Python objects and is an RCE risk if the YAML comes from user input or the network. Switched to `yaml.safe_load()`.