### PR TITLE
Support Literal[True] and Literal[False] types

### DIFF
--- a/docs/supported-types.rst
+++ b/docs/supported-types.rst
@@ -1143,6 +1143,7 @@ purpose, but with a `typing.Literal` the decoded values are literal `int` or
 A literal can be composed of any of the following objects:
 
 - `None`
+- `bool` values (`True` and `False`)
 - `int` values
 - `str` values
 - Nested `typing.Literal` types
@@ -1169,6 +1170,12 @@ values, or doesn't match any of their component types.
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     msgspec.ValidationError: Expected `int`, got `str`
+
+    >>> msgspec.json.decode(b'true', type=Literal[True])
+    True
+
+    >>> msgspec.json.decode(b'false', type=Literal[True, False])
+    False
 
 ``NewType``
 -----------

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -2820,6 +2820,8 @@ AssocList_Sort(AssocList* list) {
 #define MS_TYPE_TYPEDDICT           (1ull << 33)
 #define MS_TYPE_DATACLASS           (1ull << 34)
 #define MS_TYPE_NAMEDTUPLE          (1ull << 35)
+#define MS_TYPE_BOOLLITERAL_TRUE    (1ull << 36)
+#define MS_TYPE_BOOLLITERAL_FALSE   (1ull << 37)
 /* Constraints */
 #define MS_CONSTR_INT_MIN           (1ull << 42)
 #define MS_CONSTR_INT_MAX           (1ull << 43)
@@ -2943,6 +2945,8 @@ typedef struct {
     PyObject *int_lookup;
     PyObject *str_lookup;
     bool literal_none;
+    bool literal_bool_true;
+    bool literal_bool_false;
 } LiteralInfo;
 
 typedef struct {
@@ -3543,6 +3547,8 @@ typedef struct {
     PyObject *literal_str_values;
     PyObject *literal_str_lookup;
     bool literal_none;
+    bool literal_bool_true;
+    bool literal_bool_false;
     /* Constraints */
     int64_t c_int_min;
     int64_t c_int_max;
@@ -4433,6 +4439,14 @@ typenode_collect_literal(TypeNodeCollectState *state, PyObject *literal) {
         if (obj == Py_None || obj == NONE_TYPE) {
             state->literal_none = true;
         }
+        else if (type == &PyBool_Type) {
+            if (obj == Py_True) {
+                state->literal_bool_true = true;
+            }
+            else {
+                state->literal_bool_false = true;
+            }
+        }
         else if (type == &PyLong_Type) {
             if (state->literal_int_values == NULL) {
                 state->literal_int_values = PySet_New(NULL);
@@ -4469,7 +4483,7 @@ typenode_collect_literal(TypeNodeCollectState *state, PyObject *literal) {
 invalid:
     PyErr_Format(
         PyExc_TypeError,
-        "Literal may only contain None/integers/strings - %R is not supported",
+        "Literal may only contain None/booleans/integers/strings - %R is not supported",
         literal
     );
 
@@ -4507,6 +4521,12 @@ typenode_collect_convert_literals(TypeNodeCollectState *state) {
             if (info->literal_none) {
                 state->types |= MS_TYPE_NONE;
             }
+            if (info->literal_bool_true) {
+                state->types |= MS_TYPE_BOOLLITERAL_TRUE;
+            }
+            if (info->literal_bool_false) {
+                state->types |= MS_TYPE_BOOLLITERAL_FALSE;
+            }
             Py_DECREF(cached);
             return 0;
         }
@@ -4535,6 +4555,12 @@ typenode_collect_convert_literals(TypeNodeCollectState *state) {
     if (state->literal_none) {
         state->types |= MS_TYPE_NONE;
     }
+    if (state->literal_bool_true) {
+        state->types |= MS_TYPE_BOOLLITERAL_TRUE;
+    }
+    if (state->literal_bool_false) {
+        state->types |= MS_TYPE_BOOLLITERAL_FALSE;
+    }
 
     if (n == 1) {
         /* A single `Literal` object, cache the lookups on it */
@@ -4545,6 +4571,8 @@ typenode_collect_convert_literals(TypeNodeCollectState *state) {
         Py_XINCREF(state->literal_str_lookup);
         info->str_lookup = state->literal_str_lookup;
         info->literal_none = state->literal_none;
+        info->literal_bool_true = state->literal_bool_true;
+        info->literal_bool_false = state->literal_bool_false;
         PyObject_GC_Track(info);
         PyObject *literal = PyList_GET_ITEM(state->literals, 0);
         int status = PyObject_SetAttr(
@@ -15329,6 +15357,14 @@ mpack_decode_bool(DecoderState *self, PyObject *val, TypeNode *type, PathNode *p
         Py_INCREF(val);
         return val;
     }
+    if (val == Py_True && (type->types & MS_TYPE_BOOLLITERAL_TRUE)) {
+        Py_INCREF(Py_True);
+        return Py_True;
+    }
+    if (val == Py_False && (type->types & MS_TYPE_BOOLLITERAL_FALSE)) {
+        Py_INCREF(Py_False);
+        return Py_False;
+    }
     return ms_validation_error("bool", type, path);
 }
 
@@ -16954,7 +16990,7 @@ json_decode_true(JSONDecoderState *self, TypeNode *type, PathNode *path) {
     if (MS_UNLIKELY(c1 != 'r' || c2 != 'u' || c3 != 'e')) {
         return json_err_invalid(self, "invalid character");
     }
-    if (type->types & (MS_TYPE_ANY | MS_TYPE_BOOL)) {
+    if (type->types & (MS_TYPE_ANY | MS_TYPE_BOOL | MS_TYPE_BOOLLITERAL_TRUE)) {
         Py_INCREF(Py_True);
         return Py_True;
     }
@@ -16975,7 +17011,7 @@ json_decode_false(JSONDecoderState *self, TypeNode *type, PathNode *path) {
     if (MS_UNLIKELY(c1 != 'a' || c2 != 'l' || c3 != 's' || c4 != 'e')) {
         return json_err_invalid(self, "invalid character");
     }
-    if (type->types & (MS_TYPE_ANY | MS_TYPE_BOOL)) {
+    if (type->types & (MS_TYPE_ANY | MS_TYPE_BOOL | MS_TYPE_BOOLLITERAL_FALSE)) {
         Py_INCREF(Py_False);
         return Py_False;
     }
@@ -20625,6 +20661,14 @@ convert_bool(
     if (type->types & MS_TYPE_BOOL) {
         Py_INCREF(obj);
         return obj;
+    }
+    if (obj == Py_True && (type->types & MS_TYPE_BOOLLITERAL_TRUE)) {
+        Py_INCREF(Py_True);
+        return Py_True;
+    }
+    if (obj == Py_False && (type->types & MS_TYPE_BOOLLITERAL_FALSE)) {
+        Py_INCREF(Py_False);
+        return Py_False;
     }
     return ms_validation_error("bool", type, path);
 }

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -3453,7 +3453,7 @@ typenode_simple_repr(TypeNode *self) {
     if (self->types & (MS_TYPE_ANY | MS_TYPE_CUSTOM | MS_TYPE_CUSTOM_GENERIC) || self->types == 0) {
         return PyUnicode_FromString("any");
     }
-    if (self->types & MS_TYPE_BOOL) {
+    if (self->types & (MS_TYPE_BOOL | MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
         if (!strbuilder_extend_literal(&builder, "bool")) return NULL;
     }
     if (self->types & (MS_TYPE_INT | MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -3453,7 +3453,7 @@ typenode_simple_repr(TypeNode *self) {
     if (self->types & (MS_TYPE_ANY | MS_TYPE_CUSTOM | MS_TYPE_CUSTOM_GENERIC) || self->types == 0) {
         return PyUnicode_FromString("any");
     }
-    if (self->types & (MS_TYPE_BOOL | MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
+    if (self->types & MS_TYPE_BOOL) {
         if (!strbuilder_extend_literal(&builder, "bool")) return NULL;
     }
     if (self->types & (MS_TYPE_INT | MS_TYPE_INTENUM | MS_TYPE_INTLITERAL)) {
@@ -15365,6 +15365,10 @@ mpack_decode_bool(DecoderState *self, PyObject *val, TypeNode *type, PathNode *p
         Py_INCREF(Py_False);
         return Py_False;
     }
+    if (type->types & (MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
+        ms_raise_validation_error(path, "Invalid enum value %R%U", val);
+        return NULL;
+    }
     return ms_validation_error("bool", type, path);
 }
 
@@ -16994,6 +16998,10 @@ json_decode_true(JSONDecoderState *self, TypeNode *type, PathNode *path) {
         Py_INCREF(Py_True);
         return Py_True;
     }
+    if (type->types & MS_TYPE_BOOLLITERAL_FALSE) {
+        ms_raise_validation_error(path, "Invalid enum value %R%U", Py_True);
+        return NULL;
+    }
     return ms_validation_error("bool", type, path);
 }
 
@@ -17014,6 +17022,10 @@ json_decode_false(JSONDecoderState *self, TypeNode *type, PathNode *path) {
     if (type->types & (MS_TYPE_ANY | MS_TYPE_BOOL | MS_TYPE_BOOLLITERAL_FALSE)) {
         Py_INCREF(Py_False);
         return Py_False;
+    }
+    if (type->types & MS_TYPE_BOOLLITERAL_TRUE) {
+        ms_raise_validation_error(path, "Invalid enum value %R%U", Py_False);
+        return NULL;
     }
     return ms_validation_error("bool", type, path);
 }
@@ -20669,6 +20681,10 @@ convert_bool(
     if (obj == Py_False && (type->types & MS_TYPE_BOOLLITERAL_FALSE)) {
         Py_INCREF(Py_False);
         return Py_False;
+    }
+    if (type->types & (MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
+        ms_raise_validation_error(path, "Invalid enum value %R%U", obj);
+        return NULL;
     }
     return ms_validation_error("bool", type, path);
 }

--- a/src/msgspec/inspect.py
+++ b/src/msgspec/inspect.py
@@ -315,11 +315,11 @@ class LiteralType(Type):
     Parameters
     ----------
     values: tuple
-        A tuple of possible values for this literal instance. Only `str` or
-        `int` literals are supported.
+        A tuple of possible values for this literal instance. Only `bool`,
+        `str`, or `int` literals are supported.
     """
 
-    values: Union[Tuple[str, ...], Tuple[int, ...]]
+    values: Union[Tuple[bool, ...], Tuple[str, ...], Tuple[int, ...]]
 
 
 class CustomType(Type):

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -849,13 +849,8 @@ class TestLiterals:
     @pytest.mark.parametrize(
         "typ",
         [
-            Literal[1, False],
             Literal["ok", b"bad"],
             Literal[1, object()],
-            Union[Literal[1, 2], Literal[3, False]],
-            Union[Literal["one", "two"], Literal[3, False]],
-            Literal[Literal[1, 2], Literal[3, False]],
-            Literal[Literal["one", "two"], Literal[3, False]],
             Literal[1, 2, List[int]],
             Literal[1, 2, List],
         ],
@@ -931,6 +926,29 @@ class TestLiterals:
 
         with pytest.raises(ValidationError, match="Invalid enum value 'carrot'"):
             dec.decode(msgspec.msgpack.encode("carrot"))
+
+    @pytest.mark.parametrize(
+        "typ, good, bad",
+        [
+            (Literal[True], [True], [False]),
+            (Literal[False], [False], [True]),
+            (Literal[True, False], [True, False], []),
+            (Literal[1, False], [1, False], [True]),
+            (Literal[True, "yes", None], [True, "yes", None], [False]),
+        ],
+    )
+    def test_literal_bool(self, typ, good, bad):
+        dec = msgspec.msgpack.Decoder(typ)
+        for val in good:
+            assert dec.decode(msgspec.msgpack.encode(val)) == val
+        for val in bad:
+            with pytest.raises(ValidationError):
+                dec.decode(msgspec.msgpack.encode(val))
+
+    def test_mix_bool_and_bool_literal(self):
+        dec = msgspec.msgpack.Decoder(Union[Literal[True], bool])
+        assert dec.decode(msgspec.msgpack.encode(True)) is True
+        assert dec.decode(msgspec.msgpack.encode(False)) is False
 
     def test_mix_int_and_int_literal(self):
         dec = msgspec.msgpack.Decoder(Union[Literal[-1, 1], int])

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -945,6 +945,11 @@ class TestLiterals:
             with pytest.raises(ValidationError):
                 dec.decode(msgspec.msgpack.encode(val))
 
+    def test_literal_bool_error_message(self):
+        dec = msgspec.msgpack.Decoder(Literal[True])
+        with pytest.raises(ValidationError, match="Invalid enum value False"):
+            dec.decode(msgspec.msgpack.encode(False))
+
     def test_mix_bool_and_bool_literal(self):
         dec = msgspec.msgpack.Decoder(Union[Literal[True], bool])
         assert dec.decode(msgspec.msgpack.encode(True)) is True

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -921,6 +921,18 @@ class TestLiteral:
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             convert("A", typ)
 
+    def test_bool_literal(self):
+        assert convert(True, Literal[True]) is True
+        assert convert(False, Literal[False]) is False
+        assert convert(True, Literal[True, False]) is True
+        assert convert(False, Literal[True, False]) is False
+        with pytest.raises(ValidationError, match="Invalid enum value False"):
+            convert(False, Literal[True])
+        with pytest.raises(ValidationError, match="Invalid enum value True"):
+            convert(True, Literal[False])
+        with pytest.raises(ValidationError, match="Expected `bool`, got `str`"):
+            convert("yes", Literal[True])
+
 
 class TestSequences:
     def test_any_sequence(self):

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1251,7 +1251,9 @@ class TestLiteral:
             dec.decode(b"42")
         with pytest.raises(msgspec.ValidationError, match="Expected `bool`, got `str`"):
             dec.decode(b'"hello"')
-        with pytest.raises(msgspec.ValidationError, match="Expected `bool`, got `null`"):
+        with pytest.raises(
+            msgspec.ValidationError, match="Expected `bool`, got `null`"
+        ):
             dec.decode(b"null")
 
 

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1199,6 +1199,10 @@ class TestLiteral:
             (1, 2, "three", "four"),
             (1, None),
             ("one", None),
+            (True,),
+            (False,),
+            (True, False),
+            (True, 1, "yes"),
         ],
     )
     def test_literal(self, values):
@@ -1228,6 +1232,27 @@ class TestLiteral:
 
         with pytest.raises(msgspec.ValidationError, match="Invalid enum value 'bad'"):
             dec.decode(b'"bad"')
+
+    def test_bool_literal_true_only(self):
+        dec = msgspec.json.Decoder(Literal[True])
+        assert dec.decode(b"true") is True
+        with pytest.raises(msgspec.ValidationError, match="Invalid enum value False"):
+            dec.decode(b"false")
+
+    def test_bool_literal_false_only(self):
+        dec = msgspec.json.Decoder(Literal[False])
+        assert dec.decode(b"false") is False
+        with pytest.raises(msgspec.ValidationError, match="Invalid enum value True"):
+            dec.decode(b"true")
+
+    def test_bool_literal_errors(self):
+        dec = msgspec.json.Decoder(Literal[True])
+        with pytest.raises(msgspec.ValidationError, match="Expected `bool`, got `int`"):
+            dec.decode(b"42")
+        with pytest.raises(msgspec.ValidationError, match="Expected `bool`, got `str`"):
+            dec.decode(b'"hello"')
+        with pytest.raises(msgspec.ValidationError, match="Expected `bool`, got `null`"):
+            dec.decode(b"null")
 
 
 class TestFloat:


### PR DESCRIPTION
Reopening #996 (auto-closed when fork was deleted).

## Summary
- Add support for `Literal[True]`, `Literal[False]`, and `Literal[True, False]` in type definitions
- Introduce `MS_TYPE_BOOLLITERAL_TRUE` / `MS_TYPE_BOOLLITERAL_FALSE` flags to distinguish bool literals from plain `bool`
- Handle `PyBool_Type` before `PyLong_Type` in `typenode_collect_literal` (since `bool` is a subclass of `int`)
- Update decode paths (JSON, msgpack, convert) to validate against specific bool literal values
- Update `inspect.py` `LiteralType.values` type annotation to include `bool`

Closes #859