### PR TITLE
Update Pydantic doc links to new site structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ msgspec.ValidationError: Expected `str`, got `int` - at `$.groups[0]`
 
 `msgspec` is designed to be as performant as possible, while retaining some of
 the nicities of validation libraries like
-[pydantic](https://docs.pydantic.dev/latest/). For supported types,
+[pydantic](https://pydantic.dev/docs/validation/latest/get-started/). For supported types,
 encoding/decoding a message with `msgspec` can be
 [~10-80x faster than alternative libraries](https://jcristharif.com/msgspec/benchmarks.html).
 

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -542,7 +542,7 @@ smaller on disk.
 .. _rapidjson: https://github.com/python-rapidjson/python-rapidjson
 .. _attrs: https://www.attrs.org/en/stable/
 .. _dataclasses: https://docs.python.org/3/library/dataclasses.html
-.. _pydantic: https://docs.pydantic.dev/latest/
+.. _pydantic: https://pydantic.dev/docs/validation/latest/get-started/
 .. _cattrs: https://catt.rs/en/latest/
 .. _mashumaro: https://github.com/Fatal1ty/mashumaro
 .. _conda-forge: https://conda-forge.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,7 +167,7 @@ few:
 .. _attrs: https://www.attrs.org/en/stable/
 .. _dataclasses: https://docs.python.org/3/library/dataclasses.html
 .. _orjson: https://github.com/ijl/orjson
-.. _pydantic: https://docs.pydantic.dev/latest/
+.. _pydantic: https://pydantic.dev/docs/validation/latest/get-started/
 .. _mypy: https://mypy.readthedocs.io/en/stable/
 .. _pyright: https://github.com/microsoft/pyright
 

--- a/docs/structs.rst
+++ b/docs/structs.rst
@@ -1090,7 +1090,7 @@ collected (leading to a memory leak).
 .. _PEP 563: https://peps.python.org/pep-0563/
 .. _dataclasses: https://docs.python.org/3/library/dataclasses.html
 .. _attrs: https://www.attrs.org/en/stable/index.html
-.. _pydantic: https://docs.pydantic.dev/latest/
+.. _pydantic: https://pydantic.dev/docs/validation/latest/get-started/
 .. _mypy: https://mypy.readthedocs.io/en/stable/
 .. _pyright: https://github.com/microsoft/pyright
 .. _reference counting: https://en.wikipedia.org/wiki/Reference_counting

--- a/docs/supported-types.rst
+++ b/docs/supported-types.rst
@@ -845,7 +845,7 @@ additional features.
     msgspec.ValidationError: Expected `int`, got `str` - at `$.age`
 
 Other types that duck-type as ``dataclasses`` are also supported, such as
-`pydantic dataclasses <https://docs.pydantic.dev/latest/usage/dataclasses/>`__.
+`pydantic dataclasses <https://pydantic.dev/docs/validation/latest/concepts/dataclasses/>`__.
 
 .. code-block:: python
 
@@ -1598,7 +1598,7 @@ TOML_ types are decoded to Python types as follows:
 .. _MessagePack: https://msgpack.org
 .. _YAML: https://yaml.org
 .. _TOML: https://toml.io/en/
-.. _pydantic: https://docs.pydantic.dev/latest/
+.. _pydantic: https://pydantic.dev/docs/validation/latest/get-started/
 .. _pendulum: https://pendulum.eustace.io/
 .. _RFC8259: https://datatracker.ietf.org/doc/html/rfc8259
 .. _RFC3339: https://datatracker.ietf.org/doc/html/rfc3339

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -164,6 +164,6 @@ types.
 .. _YAML: https://yaml.org
 .. _TOML: https://toml.io/en/
 .. _type annotations: https://docs.python.org/3/library/typing.html
-.. _pydantic: https://docs.pydantic.dev/latest/
+.. _pydantic: https://pydantic.dev/docs/validation/latest/get-started/
 .. _mypy: https://mypy.readthedocs.io/en/stable/
 .. _pyright: https://github.com/microsoft/pyright


### PR DESCRIPTION
Pydantic restructured their docs site to `https://pydantic.dev/docs/(validation|ai|logfire)/`, breaking the existing links and causing the link checker job to fail on `main`.

This updates all references:
- `https://docs.pydantic.dev/latest/` → `https://pydantic.dev/docs/validation/latest/get-started/`
- `https://docs.pydantic.dev/latest/usage/dataclasses/` → `https://pydantic.dev/docs/validation/latest/concepts/dataclasses/`

Files updated: `README.md`, `docs/benchmarks.rst`, `docs/index.rst`, `docs/usage.rst`, `docs/supported-types.rst`, `docs/structs.rst`.