### PR TITLE
fix wrapping `ValidationError` and `DecodeError` in `ValidationError` in `dec_hook` #1012

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -5285,18 +5285,11 @@ ms_maybe_wrap_validation_error(PathNode *path) {
     MsgspecState *mod = msgspec_get_global_state();
 
     /* If it's a TypeError or ValueError, wrap it in a ValidationError.
-     * Otherwise we reraise the original error below
-     * Special case ValidationError and DecodeError which are also reraised, even though
-     * they inherit from ValueError. */
+     * Otherwise we reraise the original error below.
+     * Since DecodeError (and ValidationError) subclass from ValueError, we need
+     * to special case them below - we don't wrap in those cases. */
     if (
-        !(
-            PyType_IsSubtype(
-                (PyTypeObject *)exc_type, (PyTypeObject *)mod->ValidationError
-            ) ||
-            PyType_IsSubtype(
-                (PyTypeObject *)exc_type, (PyTypeObject *)mod->DecodeError
-            )
-        )
+        !PyType_IsSubtype((PyTypeObject *)exc_type, (PyTypeObject *)mod->DecodeError)
         &&
         (
             PyType_IsSubtype(

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -5282,14 +5282,29 @@ ms_maybe_wrap_validation_error(PathNode *path) {
     /* If null, some other c-extension has borked, just return */
     if (exc_type == NULL) return;
 
+    MsgspecState *mod = msgspec_get_global_state();
+
     /* If it's a TypeError or ValueError, wrap it in a ValidationError.
-     * Otherwise we reraise the original error below */
+     * Otherwise we reraise the original error below
+     * Special case ValidationError and DecodeError which are also reraised, even though
+     * they inherit from ValueError. */
     if (
-        PyType_IsSubtype(
-            (PyTypeObject *)exc_type, (PyTypeObject *)PyExc_ValueError
-        ) ||
-        PyType_IsSubtype(
-            (PyTypeObject *)exc_type, (PyTypeObject *)PyExc_TypeError
+        !(
+            PyType_IsSubtype(
+                (PyTypeObject *)exc_type, (PyTypeObject *)mod->ValidationError
+            ) ||
+            PyType_IsSubtype(
+                (PyTypeObject *)exc_type, (PyTypeObject *)mod->DecodeError
+            )
+        )
+        &&
+        (
+            PyType_IsSubtype(
+                (PyTypeObject *)exc_type, (PyTypeObject *)PyExc_ValueError
+            ) ||
+            PyType_IsSubtype(
+                (PyTypeObject *)exc_type, (PyTypeObject *)PyExc_TypeError
+            )
         )
     ) {
         PyObject *exc_type2, *exc2, *tb2;

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -292,6 +292,26 @@ class TestDecoder:
         with pytest.raises(TypeError, match="Oh no!"):
             dec.decode(msg)
 
+    @pytest.mark.parametrize(
+        "base_error_cls", [msgspec.ValidationError, msgspec.DecodeError]
+    )
+    def test_dec_hook_validation_error_subclass_propagates_directly(
+        self, proto, base_error_cls
+    ):
+        class MyError(base_error_cls):
+            pass
+
+        class Foo:
+            pass
+
+        def dec_hook(tp, val):
+            raise MyError("custom message")
+
+        dec = proto.Decoder(type=Foo, dec_hook=dec_hook)
+
+        with pytest.raises(MyError, match="custom message"):
+            dec.decode(b"[]")
+
 
 @pytest.mark.skipif(
     PY312,


### PR DESCRIPTION
Fix #1012.

Fix a regression introduced in #790 that would cause `ValidationError` and `DecodeError` raise in `dec_hook` to be wrapped in `ValidationError` again.