### PR TITLE
Fix argument type annotation of defstruct()

### DIFF
--- a/src/msgspec/__init__.pyi
+++ b/src/msgspec/__init__.pyi
@@ -1,5 +1,6 @@
 import enum
 from inspect import Signature
+from types import UnionType
 from typing import (
     Any,
     Callable,
@@ -123,7 +124,7 @@ class Struct(metaclass=StructMeta):
 
 def defstruct(
     name: str,
-    fields: Iterable[Union[str, Tuple[str, type], Tuple[str, type, Any]]],
+    fields: Iterable[Union[str, Tuple[str, Union[type, UnionType]], Tuple[str, Union[type, UnionType], Any]]],
     *,
     bases: Optional[Tuple[Type[Struct], ...]] = None,
     module: Optional[str] = None,

--- a/src/msgspec/__init__.pyi
+++ b/src/msgspec/__init__.pyi
@@ -1,6 +1,5 @@
 import enum
 from inspect import Signature
-from types import UnionType
 from typing import (
     Any,
     Callable,
@@ -124,7 +123,7 @@ class Struct(metaclass=StructMeta):
 
 def defstruct(
     name: str,
-    fields: Iterable[Union[str, Tuple[str, Union[type, UnionType]], Tuple[str, Union[type, UnionType], Any]]],
+    fields: Iterable[Union[str, Tuple[str, Any], Tuple[str, Any, Any]]],
     *,
     bases: Optional[Tuple[Type[Struct], ...]] = None,
     module: Optional[str] = None,

--- a/tests/typing/basic_typing_examples.py
+++ b/tests/typing/basic_typing_examples.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import pickle
-from typing import Any, Dict, Final, List, Type, Union
+from typing import Annotated, Any, Dict, Final, List, Literal, Type, Union
 
 import msgspec
 
@@ -387,7 +387,15 @@ def check_defstruct() -> None:
 def check_defstruct_field_types() -> None:
     Test = msgspec.defstruct(
         "Test",
-        ("x", ("y", int), ("z", str, "default"))
+        (
+            "x",
+            ("a", int),
+            ("b", int | None),
+            ("c", list[int]),
+            ("d", Annotated[int, msgspec.Meta(ge=0)]),
+            ("e", Literal["a", "b"]),
+            ("f", str, "default"),
+        ),
     )
 
 


### PR DESCRIPTION
Previously, defstruct() argument "fields" was annotated to be an iterable of tuples which contain "type" objects.

However, defstruct also reads and understands unions of types, as also documented in the example at https://jcristharif.com/msgspec/api.html#msgspec.defstruct

This patch fixes mypy complaining when passing a union.

Notes:

1. `types.UnionType` was introduced in Python 3.10, which is currently the minimum Python version for msgspec.
2. Since Python 3.14, `types.UnionType` is an alias for `typing.Union`
3. We might consider also explicitely supporting `typing.Union` here for Python <= 3.14 to support people spelling out `Union[int | str]` instead of `int | str`
4. We might also consider adapting the typing notation for optionals and unions in msgspec files, like the file patched here, to the pipe symbol (which as also introduced in 3.10). There is tools that do this, e.g. ruff.