### PR TITLE
fix `NULL` check in  `structmeta_get_module_ns`

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -5658,7 +5658,7 @@ structmeta_get_module_ns(MsgspecState *mod, StructMetaInfo *info) {
     PyObject *modules = PySys_GetObject("modules");
     if (modules == NULL) return NULL;
     PyObject *module = PyDict_GetItem(modules, name);
-    if (mod == NULL) return NULL;
+    if (module == NULL) return NULL;
     return PyObject_GetAttr(module, mod->str___dict__);
 }
 


### PR DESCRIPTION
Fix a bug in `structmeta_get_module_ns` that could theoretically lead to a segfault due to a missing `NULL` check, even though it's quite unlikely to ever hit that path