### PR TITLE
Fix TypeError in type_info for mixed-type Literals

### DIFF
--- a/src/msgspec/inspect.py
+++ b/src/msgspec/inspect.py
@@ -315,11 +315,11 @@ class LiteralType(Type):
     Parameters
     ----------
     values: tuple
-        A tuple of possible values for this literal instance. Only `str` or
-        `int` literals are supported.
+        A tuple of possible values for this literal instance. Values may be
+        ``None``, ``int``, or ``str`` literals.
     """
 
-    values: Union[Tuple[str, ...], Tuple[int, ...]]
+    values: Tuple[Union[None, int, str], ...]
 
 
 class CustomType(Type):
@@ -885,7 +885,14 @@ class _Translator:
             args = tuple(self.translate(a) for a in args if a is not _UnsetType)
             return args[0] if len(args) == 1 else UnionType(args)
         elif t is Literal:
-            return LiteralType(tuple(sorted(args)))
+            return LiteralType(
+                tuple(
+                    sorted(
+                        args,
+                        key=lambda x: ("", 0) if x is None else (type(x).__name__, x),
+                    )
+                )
+            )
         elif _is_enum(t):
             return EnumType(t)
         elif is_struct_type(t):

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -350,6 +350,25 @@ def test_str_literal():
     assert mi.type_info(Literal["c", "a", "b"]) == mi.LiteralType(("a", "b", "c"))
 
 
+def test_none_literal():
+    assert mi.type_info(Literal[None]) == mi.LiteralType((None,))
+
+
+def test_mixed_int_none_literal():
+    result = mi.type_info(Literal[1, None])
+    assert result == mi.LiteralType((None, 1))
+
+
+def test_mixed_str_int_literal():
+    result = mi.type_info(Literal[1, "a"])
+    assert result == mi.LiteralType((1, "a"))
+
+
+def test_mixed_none_int_str_literal():
+    result = mi.type_info(Literal["b", 1, None, "a"])
+    assert result == mi.LiteralType((None, 1, "a", "b"))
+
+
 def test_int_enum():
     class Example(enum.IntEnum):
         B = 3


### PR DESCRIPTION
Closes #1018

`inspect.type_info()` crashes with `TypeError` when called on `Literal` types that mix value types:

```python
import msgspec.inspect as mi
from typing import Literal

mi.type_info(Literal[1, None])
# TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

**Cause:** `sorted(args)` on line 888 fails in Python 3 when args contain values of different types (e.g. `int` and `NoneType`).

**Fix:** Use a type-aware sort key `("", 0) if x is None else (type(x).__name__, x)` that groups values by type name, with `None` always sorting first. Also updates the `LiteralType.values` annotation to `Tuple[Union[None, int, str], ...]` since mixed-type tuples are valid.

**Before:** `type_info(Literal[1, None])` raises `TypeError`
**After:** `type_info(Literal[1, None])` returns `LiteralType(values=(None, 1))`

Existing behavior for same-type Literals is unchanged (e.g. `Literal[3, 1, 2]` still produces `(1, 2, 3)`).

**Validation:** all 168 inspect tests pass (including 4 new regression tests), ruff lint + format clean.