### PR TITLE
Add changelog for 0.21.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Version 0.21.1 (2026-04-13)
+
+- Fix `ValidationError` and `DecodeError` raised in `dec_hook` being incorrectly wrapped in another `ValidationError` ({pr}`1013`).
+- Fix a potential `NULL` dereference in `structmeta_get_module_ns` ({pr}`1016`).
+- Fix a reference leak in `ms_passes_big_int_constraints` ({pr}`1017`).
+- Fix missing `ref_template` parameter in `msgspec.json.schema` type stub ({pr}`1002`).
+- Clarify `order='deterministic'` encoder docstrings ({pr}`1011`).
+- Add a porting guide for users migrating from orjson ({pr}`1007`).
+
 ## Version 0.21.0 (2026-04-08)
 
 - Fix a segfault on Python 3.13+ that could occur when creating structs that contained a


### PR DESCRIPTION
## Summary

Changelog for the 0.21.1 patch release covering all changes since 0.21.0:

**Bug fixes:**
- Fix `ValidationError`/`DecodeError` wrapping regression in `dec_hook` (#1013, fixes #1012)
- Fix potential NULL dereference in `structmeta_get_module_ns` (#1016)
- Fix reference leak in `ms_passes_big_int_constraints` (#1017)

**Type stubs:**
- Add missing `ref_template` to `json.pyi` (#1002)

**Documentation:**
- Add porting guide for orjson users (#1007, closes #642)
- Clarify `order='deterministic'` docstring (#1011, closes #825)
- Update Pydantic doc links (#1008)
- Fix README logo for dark/light modes (#969)