### PR TITLE
fix leak in `typenode_collect_literal`

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -4415,7 +4415,7 @@ typenode_collect_literal(TypeNodeCollectState *state, PyObject *literal) {
     if (args == NULL) return -1;
 
     Py_ssize_t size = PyTuple_GET_SIZE(args);
-    if (size < 0) return -1;
+    if (size < 0) goto error;
 
     if (size == 0) {
         PyErr_Format(
@@ -4423,7 +4423,7 @@ typenode_collect_literal(TypeNodeCollectState *state, PyObject *literal) {
             "Literal types must have at least one item, %R is invalid",
             literal
         );
-        return -1;
+        goto error;
     }
 
     for (Py_ssize_t i = 0; i < size; i++) {


### PR DESCRIPTION
Fix leak caused by a missing `Py_DECREF` on an error path in `typenode_collect_literal`. Only possible on Python <3.12, as empty tuples are immortalized from 3.12 onwards.