### PR TITLE
fix reference leak in `ms_decode_bigint`

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -10222,7 +10222,8 @@ ms_decode_bigint(const char *buf, Py_ssize_t size, TypeNode *type, PathNode *pat
             goto out_of_range;
         }
         else {
-            /* Restore the exception state */
+            /* Restore the exception state.
+            * No need to decref here as PyErr_Restore steals references to the args */
             PyErr_Restore(exc_type, exc, tb);
         }
     }

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -10204,14 +10204,21 @@ ms_decode_bigint(const char *buf, Py_ssize_t size, TypeNode *type, PathNode *pat
     if (MS_UNLIKELY(out == NULL)) {
         PyObject *exc_type, *exc, *tb;
 
-        /* Fetch the exception state */
+        /* Fetch the exception state. Take a reference to each if not NULL */
         PyErr_Fetch(&exc_type, &exc, &tb);
 
         if (exc_type == NULL) {
-            /* Some other c-extension has borked, just return */
+            /* Some other c-extension has borked, just return.
+            * References might still have been taken, so decred just in case */
+            Py_XDECREF(exc_type);
+            Py_XDECREF(exc);
+            Py_XDECREF(tb);
             return NULL;
         }
         else if (exc_type == PyExc_ValueError) {
+            Py_XDECREF(exc_type);
+            Py_XDECREF(exc);
+            Py_XDECREF(tb);
             goto out_of_range;
         }
         else {


### PR DESCRIPTION
Fix a reference leak in `ms_decode_bigint`, caused by improper handling of referenced obtained via `PyErr_Fetch`