### PR TITLE
Fix `msgspec.msgpack.Ext` types

### DIFF
--- a/src/msgspec/msgpack.pyi
+++ b/src/msgspec/msgpack.pyi
@@ -14,9 +14,9 @@ from typing_extensions import Buffer
 
 _T = TypeVar("_T")
 
-_enc_hook_sig: TypeAlias = Callable[[Any], Any] | None
-_ext_hook_sig: TypeAlias = Callable[[int, memoryview], Any] | None
-_dec_hook_sig: TypeAlias = Callable[[type, Any], Any] | None
+_EncHookSig: TypeAlias = Callable[[Any], Any] | None
+_ExtHookSig: TypeAlias = Callable[[int, memoryview], Any] | None
+_DecHookSig: TypeAlias = Callable[[type, Any], Any] | None
 
 @final
 class Ext:
@@ -28,15 +28,15 @@ class Ext:
 class Decoder(Generic[_T]):
     type: Type[_T]  # needed for mypy, because of the same name
     strict: bool
-    dec_hook: _dec_hook_sig
-    ext_hook: _ext_hook_sig
+    dec_hook: _DecHookSig
+    ext_hook: _ExtHookSig
     @overload
     def __init__(
         self: Decoder[Any],
         *,
         strict: bool = True,
-        dec_hook: _dec_hook_sig = None,
-        ext_hook: _ext_hook_sig = None,
+        dec_hook: _DecHookSig = None,
+        ext_hook: _ExtHookSig = None,
     ) -> None: ...
     @overload
     def __init__(
@@ -44,8 +44,8 @@ class Decoder(Generic[_T]):
         type: Type[_T] = ...,
         *,
         strict: bool = True,
-        dec_hook: _dec_hook_sig = None,
-        ext_hook: _ext_hook_sig = None,
+        dec_hook: _DecHookSig = None,
+        ext_hook: _ExtHookSig = None,
     ) -> None: ...
     @overload
     def __init__(
@@ -53,21 +53,21 @@ class Decoder(Generic[_T]):
         type: Any = ...,
         *,
         strict: bool = True,
-        dec_hook: _dec_hook_sig = None,
-        ext_hook: _ext_hook_sig = None,
+        dec_hook: _DecHookSig = None,
+        ext_hook: _ExtHookSig = None,
     ) -> None: ...
     def decode(self, buf: Buffer, /) -> _T: ...
 
 @final
 class Encoder:
-    enc_hook: _enc_hook_sig
+    enc_hook: _EncHookSig
     decimal_format: Literal["string", "number"]
     uuid_format: Literal["canonical", "hex", "bytes"]
     order: Literal["deterministic", "sorted"] | None
     def __init__(
         self,
         *,
-        enc_hook: _enc_hook_sig = None,
+        enc_hook: _EncHookSig = None,
         decimal_format: Literal["string", "number"] = "string",
         uuid_format: Literal["canonical", "hex", "bytes"] = "canonical",
         order: Literal["deterministic", "sorted"] | None = None,
@@ -83,8 +83,8 @@ def decode(
     /,
     *,
     strict: bool = True,
-    dec_hook: _dec_hook_sig = None,
-    ext_hook: _ext_hook_sig = None,
+    dec_hook: _DecHookSig = None,
+    ext_hook: _ExtHookSig = None,
 ) -> Any: ...
 @overload
 def decode(
@@ -93,8 +93,8 @@ def decode(
     *,
     type: type[_T] = ...,
     strict: bool = True,
-    dec_hook: _dec_hook_sig = None,
-    ext_hook: _ext_hook_sig = None,
+    dec_hook: _DecHookSig = None,
+    ext_hook: _ExtHookSig = None,
 ) -> _T: ...
 @overload
 def decode(
@@ -103,13 +103,13 @@ def decode(
     *,
     type: Any = ...,
     strict: bool = True,
-    dec_hook: _dec_hook_sig = None,
-    ext_hook: _ext_hook_sig = None,
+    dec_hook: _DecHookSig = None,
+    ext_hook: _ExtHookSig = None,
 ) -> Any: ...
 def encode(
     obj: Any,
     /,
     *,
-    enc_hook: _enc_hook_sig = None,
+    enc_hook: _EncHookSig = None,
     order: Literal[None, "deterministic", "sorted"] = None,
 ) -> bytes: ...

--- a/src/msgspec/msgpack.pyi
+++ b/src/msgspec/msgpack.pyi
@@ -12,40 +12,40 @@ from typing import (
 
 from typing_extensions import Buffer
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
-enc_hook_sig: TypeAlias = Callable[[Any], Any] | None
-ext_hook_sig: TypeAlias = Callable[[int, memoryview], Any] | None
-dec_hook_sig: TypeAlias = Callable[[type, Any], Any] | None
+_enc_hook_sig: TypeAlias = Callable[[Any], Any] | None
+_ext_hook_sig: TypeAlias = Callable[[int, memoryview], Any] | None
+_dec_hook_sig: TypeAlias = Callable[[type, Any], Any] | None
 
 @final
 class Ext:
     code: int
-    data: bytes | bytearray | memoryview
-    def __init__(self, code: int, data: bytes | bytearray | memoryview) -> None: ...
+    data: Buffer
+    def __init__(self, code: int, data: Buffer) -> None: ...
 
 @final
-class Decoder(Generic[T]):
-    type: Type[T]  # needed for mypy, because of the same name
+class Decoder(Generic[_T]):
+    type: Type[_T]  # needed for mypy, because of the same name
     strict: bool
-    dec_hook: dec_hook_sig
-    ext_hook: ext_hook_sig
+    dec_hook: _dec_hook_sig
+    ext_hook: _ext_hook_sig
     @overload
     def __init__(
         self: Decoder[Any],
         *,
         strict: bool = True,
-        dec_hook: dec_hook_sig = None,
-        ext_hook: ext_hook_sig = None,
+        dec_hook: _dec_hook_sig = None,
+        ext_hook: _ext_hook_sig = None,
     ) -> None: ...
     @overload
     def __init__(
-        self: Decoder[T],
-        type: Type[T] = ...,
+        self: Decoder[_T],
+        type: Type[_T] = ...,
         *,
         strict: bool = True,
-        dec_hook: dec_hook_sig = None,
-        ext_hook: ext_hook_sig = None,
+        dec_hook: _dec_hook_sig = None,
+        ext_hook: _ext_hook_sig = None,
     ) -> None: ...
     @overload
     def __init__(
@@ -53,25 +53,25 @@ class Decoder(Generic[T]):
         type: Any = ...,
         *,
         strict: bool = True,
-        dec_hook: dec_hook_sig = None,
-        ext_hook: ext_hook_sig = None,
+        dec_hook: _dec_hook_sig = None,
+        ext_hook: _ext_hook_sig = None,
     ) -> None: ...
-    def decode(self, buf: Buffer, /) -> T: ...
+    def decode(self, buf: Buffer, /) -> _T: ...
 
 @final
 class Encoder:
-    enc_hook: enc_hook_sig
+    enc_hook: _enc_hook_sig
     decimal_format: Literal["string", "number"]
     uuid_format: Literal["canonical", "hex", "bytes"]
-    order: Literal[None, "deterministic", "sorted"]
+    order: Literal["deterministic", "sorted"] | None
     def __init__(
         self,
         *,
-        enc_hook: enc_hook_sig = None,
+        enc_hook: _enc_hook_sig = None,
         decimal_format: Literal["string", "number"] = "string",
         uuid_format: Literal["canonical", "hex", "bytes"] = "canonical",
-        order: Literal[None, "deterministic", "sorted"] = None,
-    ): ...
+        order: Literal["deterministic", "sorted"] | None = None,
+    ) -> None: ...
     def encode(self, obj: Any, /) -> bytes: ...
     def encode_into(
         self, obj: Any, buffer: bytearray, offset: int | None = 0, /
@@ -83,19 +83,19 @@ def decode(
     /,
     *,
     strict: bool = True,
-    dec_hook: dec_hook_sig = None,
-    ext_hook: ext_hook_sig = None,
+    dec_hook: _dec_hook_sig = None,
+    ext_hook: _ext_hook_sig = None,
 ) -> Any: ...
 @overload
 def decode(
     buf: Buffer,
     /,
     *,
-    type: type[T] = ...,
+    type: type[_T] = ...,
     strict: bool = True,
-    dec_hook: dec_hook_sig = None,
-    ext_hook: ext_hook_sig = None,
-) -> T: ...
+    dec_hook: _dec_hook_sig = None,
+    ext_hook: _ext_hook_sig = None,
+) -> _T: ...
 @overload
 def decode(
     buf: Buffer,
@@ -103,13 +103,13 @@ def decode(
     *,
     type: Any = ...,
     strict: bool = True,
-    dec_hook: dec_hook_sig = None,
-    ext_hook: ext_hook_sig = None,
+    dec_hook: _dec_hook_sig = None,
+    ext_hook: _ext_hook_sig = None,
 ) -> Any: ...
 def encode(
     obj: Any,
     /,
     *,
-    enc_hook: enc_hook_sig = None,
+    enc_hook: _enc_hook_sig = None,
     order: Literal[None, "deterministic", "sorted"] = None,
 ) -> bytes: ...

--- a/tests/typing/basic_typing_examples.py
+++ b/tests/typing/basic_typing_examples.py
@@ -1,5 +1,6 @@
 # fmt: off
 from __future__ import annotations
+import array
 import decimal
 import pickle
 from typing import Annotated, Any, Final, Literal
@@ -736,7 +737,12 @@ def check_msgpack_decode_strict() -> None:
 def check_msgpack_Ext() -> None:
     ext = msgspec.msgpack.Ext(1, b"test")
     reveal_type(ext.code)  # assert "int" in typ
-    reveal_type(ext.data)  # assert "bytes" in typ
+    reveal_type(ext.data)  # assert "Buffer" in typ
+
+    # TODO: test that non buffers can be used:
+    msgspec.msgpack.Ext(1, bytearray())
+    msgspec.msgpack.Ext(1, memoryview(b''))
+    msgspec.msgpack.Ext(1, array.array('i', [1, 2, 3]))
 
 
 ##########################################################

--- a/tests/typing/basic_typing_examples.py
+++ b/tests/typing/basic_typing_examples.py
@@ -739,7 +739,7 @@ def check_msgpack_Ext() -> None:
     reveal_type(ext.code)  # assert "int" in typ
     reveal_type(ext.data)  # assert "Buffer" in typ
 
-    # TODO: test that non buffers can be used:
+    # TODO: test that non buffers can't be used:
     msgspec.msgpack.Ext(1, bytearray())
     msgspec.msgpack.Ext(1, memoryview(b''))
     msgspec.msgpack.Ext(1, array.array('i', [1, 2, 3]))

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import array
 import datetime
 import enum
 import gc
@@ -1296,8 +1297,24 @@ class TestExt:
     def test_serialize_other_types(self, typ):
         buf = b"test"
         a = msgspec.msgpack.encode(msgspec.msgpack.Ext(1, buf))
-        b = msgspec.msgpack.encode(msgspec.msgpack.Ext(1, typ(buf)))
+
+        ext = msgspec.msgpack.Ext(1, typ(buf))
+        assert isinstance(ext.data, typ)
+        b = msgspec.msgpack.encode(ext)
         assert a == b
+
+        decoded = msgspec.msgpack.decode(b)
+        assert isinstance(decoded.data, bytes)
+        assert decoded.data == buf
+
+    def test_other_buffers(self):
+        buf = array.array("i", [1, 2, 3, 4])
+        out = msgspec.msgpack.decode(
+            msgspec.msgpack.encode(msgspec.msgpack.Ext(1, buf)),
+        )
+
+        assert isinstance(out.data, bytes)
+        assert array.array("i", out.data) == buf
 
     @pytest.mark.parametrize("size", sorted({0, 1, 2, 4, 8, 16, *SIZES}))
     def test_roundtrip(self, size):


### PR DESCRIPTION
Several typing improvments:
1. `msgspec.msgpack.Enc` now accepts all buffers, not just `bytes | memoryview | bytearray`. I've added a runtime test to proove that
2. Renamed `T` and other typing-only utils to be protected names: `T` and `_enc_hook_sig` can't be imported from `msgspec.msgpack` in runtime