### PR TITLE
Fix some minor style issues in docs

### DIFF
--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -71,7 +71,7 @@ The libraries we're comparing are the following:
 - pydantic_ (both 1.10.13 and 2.5.2)
 - cattrs_ (23.2.3)
 
-Each benchmark creates a message containing one or more ``File``/``Directory``
+Each benchmark creates a message containing one or more ``File`` / ``Directory``
 instances, then serializes, deserializes, and validates it in a loop.
 
 The full benchmark source can be found
@@ -118,7 +118,7 @@ JSON Serialization
 ------------------
 
 ``msgspec`` includes its own high performance JSON library, which may be used
-by itself as a replacement for the standard library's `json.dumps`/`json.loads`
+by itself as a replacement for the standard library's `json.dumps` / `json.loads`
 functions. Here we compare msgspec's JSON implementation against several other
 popular Python JSON libraries.
 
@@ -248,8 +248,8 @@ For each library, the following operations are benchmarked:
   boilerplate add overhead when defining classes, slowing import times for
   libraries that make use of these classes.
 - Time to create an instance of that class.
-- Time to compare two instances for equality (``==``/``!=``).
-- Time to compare two instances for order (``<``/``>``/``<=``/``>=``)
+- Time to compare two instances for equality (``==`` / ``!=``).
+- Time to compare two instances for order (``<`` / ``>`` / ``<=`` / ``>=``)
 
 The full benchmark source can be found `here
 <https://github.com/msgspec/msgspec/blob/main/benchmarks/bench_structs.py>`__.

--- a/docs/constraints.rst
+++ b/docs/constraints.rst
@@ -54,19 +54,18 @@ complete example enforcing the following constraints on a ``User`` struct:
 
 .. code-block:: python
 
-    from typing import Annotated
+    >>> from typing import Annotated
+    >>> from msgspec import Struct, Meta
 
-    from msgspec import Struct, Meta
+    >>> UnixName = Annotated[
+    ...     str, Meta(min_length=1, max_length=32, pattern="^[a-z_][a-z0-9_-]*$")
+    ... ]
 
-    UnixName = Annotated[
-        str, Meta(min_length=1, max_length=32, pattern="^[a-z_][a-z0-9_-]*$")
-    ]
-
-    class User(Struct):
-        name: UnixName
-        groups: Annotated[set[UnixName], Meta(max_length=16)] = set()
-        cpu_limit: Annotated[float, Meta(ge=0.1, le=8)] = 1
-        mem_limit: Annotated[int, Meta(ge=256, le=8192)] = 1024
+    >>> class User(Struct):
+    ...     name: UnixName
+    ...     groups: Annotated[set[UnixName], Meta(max_length=16)] = set()
+    ...     cpu_limit: Annotated[float, Meta(ge=0.1, le=8)] = 1
+    ...     mem_limit: Annotated[int, Meta(ge=256, le=8192)] = 1024
 
 As shown above, ``Annotated`` types can applied inline, or used to create type
 aliases and then reused elsewhere (as done with ``UnixName``).

--- a/docs/converters.rst
+++ b/docs/converters.rst
@@ -88,12 +88,12 @@ configuration options:
   string values exist. See :ref:`strict-vs-lax` for more information.
 
 - ``from_attributes``: `convert` only. If True, input objects may be coerced
-  to ``Struct``/``dataclass``/``attrs`` types by extracting attributes from the
+  to ``Struct`` / ``dataclass`` / ``attrs`` types by extracting attributes from the
   input matching fields in the output type. One use case is converting database
   query results (ORM or otherwise) to msgspec structured types. The default is
   False.
 
-- ``enc_hook``/``dec_hook``: the standard keyword arguments used for
+- ``enc_hook`` / ``dec_hook``: the standard keyword arguments used for
   :doc:`extending` msgspec to support additional types.
 
 -----

--- a/docs/examples/geojson.rst
+++ b/docs/examples/geojson.rst
@@ -8,7 +8,7 @@ implementing that specification using ``msgspec`` to handle the parsing and
 validation.
 
 The ``loads`` and ``dumps`` methods defined below work similar to the
-standard library's ``json.loads``/``json.dumps``, but:
+standard library's ``json.loads`` / ``json.dumps``, but:
 
 - Will result in high-level `msgspec.Struct` objects representing GeoJSON types
 - Will error nicely if a field is missing or the wrong type

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -3,7 +3,7 @@ Extending
 
 To allow encoding/decoding types other than those :doc:`natively supported
 <supported-types>`, ``msgspec`` provides a few callbacks to
-``Encoder``/``Decoder``.
+``Encoder`` / ``Decoder``.
 
 - ``enc_hook``, for transforming custom types into values
   that ``msgspec``:doc:`natively supports <supported-types>`.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-``msgspec`` may be installed via ``pip`` or ``conda``. Note that Python >= 3.8
+``msgspec`` may be installed via ``pip`` or ``conda``. Note that Python >= 3.10
 is required. The basic install has no required dependencies.
 
 **pip**

--- a/docs/perf-tips.rst
+++ b/docs/perf-tips.rst
@@ -45,18 +45,18 @@ Use Structs
 They're :ref:`fast to encode/decode <json-benchmark>` and :ref:`fast to use
 <struct-benchmark>`. If you have data with a known schema, we recommend
 defining a `msgspec.Struct` type (or types) for your schema and preferring that
-over other types like `dict`/`dataclasses`/...
+over other types like `dict` / `dataclasses` / etc.
 
 
 Avoid Encoding Default Values
 -----------------------------
 
-By default, ``msgspec`` encodes all fields in a Struct type, including optional
+By default, ``msgspec`` encodes all fields in a ``Struct`` type, including optional
 fields (those configured with a default value). If the default values are known
 on the decoding end (making serializing them redundant), it may be beneficial
 to omit default values from the encoded message. This can be done by
-configuring ``omit_defaults=True`` as part of the Struct definition Omitting
-defaults reduces the size of the encoded message, and often also improves
+configuring ``omit_defaults=True`` as part of the ``Struct`` definition.
+Omitting defaults reduces the size of the encoded message, and often also improves
 encoding and decoding performance (since there's less work to do).
 
 For more information, see :ref:`omit_defaults`.
@@ -116,12 +116,12 @@ For a more in-depth example of this technique, see the
 Reduce Allocations
 ------------------
 
-Every call to ``encode``/``Encoder.encode`` allocates a new `bytes` object for
+Every call to ``encode`` / ``Encoder.encode`` allocates a new `bytes` object for
 the output. ``msgspec`` exposes an alternative ``Encoder.encode_into`` (e.g.
 `msgspec.json.Encoder.encode_into`) that writes into a pre-allocated
 `bytearray` instead (possibly reallocating to increase capacity).
 
-This has a few uses:
+This has the following uses.
 
 Reusing an output buffer
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -209,7 +209,7 @@ Some protocols require prepending a prefix to an encoded message. This comes up
 in `Length-prefix framing
 <https://eli.thegreenplace.net/2011/08/02/length-prefix-framing-for-protocol-buffers>`__
 , where every message is prefixed by its length stored as a fixed-width integer
-(e.g. a big-endian uint32). Like line-delimited JSON above, this is more
+(e.g. a big-endian ``uint32``). Like line-delimited JSON above, this is more
 efficient to do using ``Encoder.encode_into`` to avoid excessive copying.
 
 .. code-block:: python
@@ -253,8 +253,8 @@ allocate a large number of objects at once may suffer reduced performance due
 to Python's garbage collector (GC). By default, `msgspec.Struct` types
 implement a few optimizations to reduce the load on the GC (and thus reduce the
 frequency and duration of a GC pause). If you find that GC is still a problem,
-and **are certain** that your Struct types may never participate in a reference
-cycle, then you **may** benefit from setting ``gc=False`` on your Struct
+and **are certain** that your ``Struct`` types may never participate in a reference
+cycle, then you **may** benefit from setting ``gc=False`` on your ``Struct``
 types.  Depending on workload, this can result in a measurable decrease in
 pause time and frequency due to GC passes. See :ref:`struct-gc` for more
 details.

--- a/docs/porting/orjson.rst
+++ b/docs/porting/orjson.rst
@@ -98,7 +98,7 @@ Option mapping
 --------------
 
 ``orjson`` uses bitwise ``OPT_*`` flags. ``msgspec`` uses keyword arguments on
-``Encoder``/``Decoder`` or the ``encode``/``decode`` functions.
+``Encoder`` / ``Decoder`` or the ``encode`` / ``decode`` functions.
 
 Sorting keys
 ^^^^^^^^^^^^
@@ -313,7 +313,7 @@ through other means:
    * - orjson
      - msgspec workaround
    * - ``OPT_NON_STR_KEYS``
-     - Use ``enc_hook``/``dec_hook`` or ``msgspec.to_builtins(obj, str_keys=True)``
+     - Use ``enc_hook`` / ``dec_hook`` or ``msgspec.to_builtins(obj, str_keys=True)``
    * - ``OPT_OMIT_MICROSECONDS``
      - Convert before encoding: ``dt.replace(microsecond=0)``. ``enc_hook`` cannot
        be used here because ``datetime`` is a natively supported type.

--- a/docs/structs.rst
+++ b/docs/structs.rst
@@ -65,7 +65,7 @@ annotations:
     >>> alice == User("alice", groups={"admin", "engineering"})
     True
 
-Note that it is forbidden to override ``__init__``/``__new__`` in a struct
+Note that it is forbidden to override ``__init__`` / ``__new__`` in a struct
 definition, but other methods can be overridden or added as needed. If you need
 to customize the generated ``__init__``, see :ref:`struct-post-init`.
 

--- a/docs/supported-types.rst
+++ b/docs/supported-types.rst
@@ -105,7 +105,7 @@ information.
 ``bool``
 --------
 
-Booleans map to their corresponding ``true``/``false`` values in both all
+Booleans map to their corresponding ``true`` / ``false`` values in both all
 supported protocols.
 
 .. code-block:: python
@@ -116,9 +116,9 @@ supported protocols.
     >>> msgspec.json.decode(b'true')
     True
 
-If ``strict=False`` is specified, values of ``"true"``/``"1"``/``1`` or
-``"false"``/``"0"``/``0`` (case insensitive for strings) may also be coerced to
-``True``/``False`` respectively. See :ref:`strict-vs-lax` for more information.
+If ``strict=False`` is specified, values of ``"true"`` / ``"1"`` / ``1`` or
+``"false"`` / ``"0"`` / ``0`` (case insensitive for strings) may also be coerced to
+``True`` / ``False`` respectively. See :ref:`strict-vs-lax` for more information.
 
 .. code-block:: python
 
@@ -193,9 +193,9 @@ provided, the `int` will be automatically converted.
     123.0
 
 If ``strict=False`` is specified, string values may also be coerced to floats.
-Note that in this case the strings ``"nan"``, ``"inf"``/``"infinity"``,
-``"-inf"``/``"-infinity"`` (case insensitive) will coerce to
-``nan``/``inf``/``-inf``. See :ref:`strict-vs-lax` for more information.
+Note that in this case the strings ``"nan"``, ``"inf"`` / ``"infinity"``,
+``"-inf"`` / ``"-infinity"`` (case insensitive) will coerce to
+``nan`` / ``inf`` / ``-inf``. See :ref:`strict-vs-lax` for more information.
 
 .. code-block:: python
 


### PR DESCRIPTION
1. Some small issues were fixed like `3.8` -> `3.10`, typos, missing dots, missing code highlight, etc.
2. I fixed all places where backticks were combined with `/` char, because it was rather hard to read.

Before:

<img width="785" height="62" alt="Снимок экрана 2026-06-12 в 13 43 27" src="https://github.com/user-attachments/assets/de50f3cc-be5b-40a1-a432-8ee609ee1707" />
<img width="261" height="33" alt="Снимок экрана 2026-06-12 в 13 42 43" src="https://github.com/user-attachments/assets/1f92c677-0535-412c-b568-467d65d6edf7" />

After:

<img width="860" height="63" alt="Снимок экрана 2026-06-12 в 13 43 46" src="https://github.com/user-attachments/assets/a966bf71-22ea-4d88-9ba3-fbd075bb93eb" />
<img width="267" height="30" alt="Снимок экрана 2026-06-12 в 13 42 34" src="https://github.com/user-attachments/assets/91cf4350-a2dd-4a92-94fa-800960906994" />

3. I converted one python code example to doctest, so we check it during a build