### PR TITLE
Add missing members to `msgspec_clear` and `msgspec_traverse`

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -22364,6 +22364,7 @@ msgspec_clear(PyObject *m)
     Py_CLEAR(st->MsgspecError);
     Py_CLEAR(st->EncodeError);
     Py_CLEAR(st->DecodeError);
+    Py_CLEAR(st->ValidationError);
     Py_CLEAR(st->StructType);
     Py_CLEAR(st->EnumMetaType);
     Py_CLEAR(st->ABCMetaType);
@@ -22471,6 +22472,7 @@ msgspec_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(st->MsgspecError);
     Py_VISIT(st->EncodeError);
     Py_VISIT(st->DecodeError);
+    Py_VISIT(st->ValidationError);
     Py_VISIT(st->StructType);
     Py_VISIT(st->EnumMetaType);
     Py_VISIT(st->ABCMetaType);
@@ -22495,6 +22497,9 @@ msgspec_traverse(PyObject *m, visitproc visit, void *arg)
 #if PY312_PLUS
     Py_VISIT(st->typing_typealiastype);
 #endif
+    Py_VISIT(st->UUIDType);
+    Py_VISIT(st->uuid_safeuuid_unknown);
+    Py_VISIT(st->DecimalType);
     Py_VISIT(st->astimezone);
     Py_VISIT(st->re_compile);
     return 0;


### PR DESCRIPTION
Add missing members to `msgspec_clear` and `msgspec_traverse`:

- `ValidationError` was missing from both
- `UUIDType`, `uuid_safeuuid_unknown`, and `DecimalType` were missing from `msgspec_traverse`