### PR TITLE
Add missing `__class_getitem__` methods to typing

### DIFF
--- a/src/msgspec/json.pyi
+++ b/src/msgspec/json.pyi
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Iterable
+from types import GenericAlias
 from typing import (
     Any,
     Generic,
@@ -67,6 +68,7 @@ class Decoder(Generic[_T]):
     ) -> None: ...
     def decode(self, buf: Buffer | str, /) -> _T: ...
     def decode_lines(self, buf: Buffer | str, /) -> list[_T]: ...
+    def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...
 
 @overload
 def decode(

--- a/src/msgspec/msgpack.pyi
+++ b/src/msgspec/msgpack.pyi
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from types import GenericAlias
 from typing import (
     Any,
     Generic,
@@ -49,6 +50,7 @@ class Decoder(Generic[_T]):
         ext_hook: _ExtHookSig = None,
     ) -> None: ...
     def decode(self, buf: Buffer, /) -> _T: ...
+    def __class_getitem__(cls, item: Any, /) -> GenericAlias: ...
 
 @final
 class Encoder:


### PR DESCRIPTION
Runtime:

```python
>>> import msgspec
>>> msgspec.json.Decoder.__class_getitem__((int,))
msgspec.json.Decoder[int]
```

Mypy:

```
» mypy -c 'import msgspec; msgspec.json.Decoder.__class_getitem__'
<string>:1: error: "type[Decoder[_T]]" has no attribute "__class_getitem__"  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```

Now this symbol would be defined. 
I used the same definition that we use in `typeshed`: https://github.com/python/typeshed/blob/7e3b6cd8101ec0b80eedffa9a0ffd949f3ea88ab/stdlib/queue.pyi#L49