### PR TITLE
Fix profiling tests with pytest 9.1

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,25 +5,15 @@ from pathlib import Path
 
 
 def pytest_addoption(parser):
-    # Declaring additional command-line options within test suite-specific `conftest.py`
-    # files is documented as unsupported by pytest. See:
-    # https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_addoption.
-    #
-    # However, it seems to work in practice with the following limitations:
-    #   - The options only appear in the help text for suites that are configured in
-    #     the default `testpaths` configuration. This is undesirable because we don't
-    #     want a missing argument to trigger heavy tests like performance profiling.
-    #   - The options are parsed differently such that an equals sign is required for
-    #     options with a value rather than the more natural space-separated format.
-    #
-    # As a workaround, we parse the command line for options that match the patterns of
-    # the configurable test suites and add their options to the parser.
+    # Only register options for configurable test suites when those suites are selected.
+    # This keeps options for heavy tests like performance profiling out of normal test
+    # runs while still allowing their suites to be selected through `testpaths`.
     configurable_test_suites = {
         "tests/prof/perf": add_performance_profiling_options,
     }
 
     cwd = Path.cwd()
-    project_root = Path(__file__).parent.parent
+    project_root = Path(__file__).parent
     for test_suite_relpath, add_options_func in list(configurable_test_suites.items()):
         test_suite_path = project_root.joinpath(test_suite_relpath)
         if test_suite_path == cwd or test_suite_path in cwd.parents:


### PR DESCRIPTION
## Summary

Fixes #1066.

Move the conditional pytest option registration from `tests/conftest.py` to the repository-root `conftest.py`.

This restores profiling runs on pytest 9.1 while preserving the existing test recipe behavior where trailing positional arguments override, rather than extend, the recipe's default collection path.

## Root cause

pytest 9.1 no longer loads the nested `tests/conftest.py` early enough when profiling tests are selected indirectly through `-o testpaths=tests/prof/perf`.

## Testing

```console
❯  just test-perf all --collect-only -q
tests/prof/perf/test_basic.py::TestRoundtrip::test_encode
tests/prof/perf/test_basic.py::TestRoundtrip::test_decode

2 tests collected in 0.03s
❯  just test-perf all tests/prof/perf/test_basic.py::TestRoundtrip::test_encode --collect-only -q
tests/prof/perf/test_basic.py::TestRoundtrip::test_encode

1 test collected in 0.03s
❯  just check
warning: Ignored unexpected keys in `.pre-commit-config.yaml`: `local`, `local-manual`, `local-pre-commit`
Lint Python code (check-only)............................................Passed
Format Python code (check-only)..........................................Passed
Check for spelling errors................................................Passed
```