### PR TITLE
Limit decode nesting depth to prevent C stack overflow

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -14876,16 +14876,21 @@ typedef struct DecoderState {
     Py_ssize_t recursion_depth;
 } DecoderState;
 
-/* Maximum nesting depth allowed when decoding. The recursive decoders use a few
- * C stack frames per level, and CPython's recursion guard is tied to
+/* Bound nesting depth when decoding. The recursive decoders use a few C stack
+ * frames per level, and CPython's recursion guard is tied to
  * `sys.getrecursionlimit()` (or the C recursion limit), neither of which tracks
  * the actual remaining C stack. On systems with a small stack (or when the
  * recursion limit is raised) deeply nested input can overflow the C stack and
  * crash the process before the guard fires. A hard cap independent of the
  * recursion limit prevents that. The value sits below the default Python
  * recursion limit (so this cap, rather than a `RecursionError`, is what bounds
- * nesting consistently across Python versions) while staying far above any
- * realistic nesting depth. */
+ * nesting consistently across versions) while staying far above any realistic
+ * nesting depth.
+ *
+ * Python 3.14+ rewrote that guard to check the actual remaining C stack, so it
+ * already prevents the overflow there; the explicit cap is only needed on older
+ * versions. */
+#if PY_VERSION_HEX < 0x030E0000
 #define MS_MAX_DECODE_DEPTH 512
 
 /* Enter a recursive decode level, returning -1 (with a DecodeError set) if the
@@ -14908,6 +14913,18 @@ static MS_INLINE void
 ms_leave_recursive(Py_ssize_t *depth) {
     (*depth)--;
 }
+#else
+static MS_INLINE int
+ms_enter_recursive(Py_ssize_t *depth) {
+    (void)depth;
+    return 0;
+}
+
+static MS_INLINE void
+ms_leave_recursive(Py_ssize_t *depth) {
+    (void)depth;
+}
+#endif
 
 typedef struct Decoder {
     PyObject_HEAD

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -14882,8 +14882,11 @@ typedef struct DecoderState {
  * the actual remaining C stack. On systems with a small stack (or when the
  * recursion limit is raised) deeply nested input can overflow the C stack and
  * crash the process before the guard fires. A hard cap independent of the
- * recursion limit prevents that. Matches the limit used by orjson/simdjson. */
-#define MS_MAX_DECODE_DEPTH 1024
+ * recursion limit prevents that. The value sits below the default Python
+ * recursion limit (so this cap, rather than a `RecursionError`, is what bounds
+ * nesting consistently across Python versions) while staying far above any
+ * realistic nesting depth. */
+#define MS_MAX_DECODE_DEPTH 512
 
 /* Enter a recursive decode level, returning -1 (with a DecodeError set) if the
  * nesting limit would be exceeded, else 0. Each successful call must be paired

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -14877,25 +14877,21 @@ typedef struct DecoderState {
 } DecoderState;
 
 /* Bound nesting depth when decoding. The recursive decoders use a few C stack
- * frames per level, and CPython's recursion guard is tied to
- * `sys.getrecursionlimit()` (or the C recursion limit), neither of which tracks
- * the actual remaining C stack. On systems with a small stack (or when the
- * recursion limit is raised) deeply nested input can overflow the C stack and
- * crash the process before the guard fires. A hard cap independent of the
- * recursion limit prevents that. The value sits below the default Python
- * recursion limit (so this cap, rather than a `RecursionError`, is what bounds
- * nesting consistently across versions) while staying far above any realistic
- * nesting depth.
+ * frames per level, and CPython's recursion guard (tied to the recursion limit)
+ * doesn't track the actual remaining C stack, so on a small stack (or a raised
+ * recursion limit) deeply nested input can overflow the C stack and crash the
+ * process. A hard cap independent of the recursion limit prevents that. 512
+ * sits below the default recursion limit (so the cap, not a `RecursionError`,
+ * bounds nesting consistently across versions) yet far above any realistic
+ * depth. Python 3.14+ rewrote that guard to track the real C stack, so the cap
+ * is only needed on older versions.
  *
- * Python 3.14+ rewrote that guard to check the actual remaining C stack, so it
- * already prevents the overflow there; the explicit cap is only needed on older
- * versions. */
+ * `MS_DEPTH_WRAP_OBJ`/`_INT` wrap a recursive decode function `f`: the body is
+ * defined as `f_inner` and entered only after bumping `self->recursion_depth`,
+ * which is restored on return. On 3.14+ they expand to a plain definition. */
 #if PY_VERSION_HEX < 0x030E0000
 #define MS_MAX_DECODE_DEPTH 512
 
-/* Enter a recursive decode level, returning -1 (with a DecodeError set) if the
- * nesting limit would be exceeded, else 0. Each successful call must be paired
- * with `ms_leave_recursive`. */
 static MS_INLINE int
 ms_enter_recursive(Py_ssize_t *depth) {
     if (MS_UNLIKELY(*depth >= MS_MAX_DECODE_DEPTH)) {
@@ -14909,22 +14905,22 @@ ms_enter_recursive(Py_ssize_t *depth) {
     return 0;
 }
 
-static MS_INLINE void
-ms_leave_recursive(Py_ssize_t *depth) {
-    (*depth)--;
-}
+#define MS_DEPTH_WRAP(ret, f, sig, args, err)                              \
+    static ret f##_inner sig;                                              \
+    static ret f sig {                                                     \
+        if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth)))       \
+            return err;                                                    \
+        ret _ms_res = f##_inner args;                                      \
+        self->recursion_depth--;                                           \
+        return _ms_res;                                                    \
+    }                                                                      \
+    static ret f##_inner sig
 #else
-static MS_INLINE int
-ms_enter_recursive(Py_ssize_t *depth) {
-    (void)depth;
-    return 0;
-}
-
-static MS_INLINE void
-ms_leave_recursive(Py_ssize_t *depth) {
-    (void)depth;
-}
+#define MS_DEPTH_WRAP(ret, f, sig, args, err) static ret f sig
 #endif
+
+#define MS_DEPTH_WRAP_OBJ(f, sig, args) MS_DEPTH_WRAP(PyObject *, f, sig, args, NULL)
+#define MS_DEPTH_WRAP_INT(f, sig, args) MS_DEPTH_WRAP(int, f, sig, args, -1)
 
 typedef struct Decoder {
     PyObject_HEAD
@@ -15322,18 +15318,7 @@ mpack_decode_datetime(
 
 static int mpack_skip(DecoderState *self);
 
-static int mpack_skip_array_inner(DecoderState *self, Py_ssize_t size);
-
-static int
-mpack_skip_array(DecoderState *self, Py_ssize_t size) {
-    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return -1;
-    int out = mpack_skip_array_inner(self, size);
-    ms_leave_recursive(&self->recursion_depth);
-    return out;
-}
-
-static int
-mpack_skip_array_inner(DecoderState *self, Py_ssize_t size) {
+MS_DEPTH_WRAP_INT(mpack_skip_array, (DecoderState *self, Py_ssize_t size), (self, size)) {
     int status = -1;
     Py_ssize_t i;
     if (size < 0) return -1;
@@ -16005,23 +15990,10 @@ mpack_decode_struct_array_union(
     return mpack_decode_struct_array_inner(self, size, true, info, path, is_key);
 }
 
-static PyObject *mpack_decode_array_inner(
-    DecoderState *self, Py_ssize_t size, TypeNode *type, PathNode *path, bool is_key
-);
-
-static PyObject *
-mpack_decode_array(
-    DecoderState *self, Py_ssize_t size, TypeNode *type, PathNode *path, bool is_key
-) {
-    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return NULL;
-    PyObject *res = mpack_decode_array_inner(self, size, type, path, is_key);
-    ms_leave_recursive(&self->recursion_depth);
-    return res;
-}
-
-static PyObject *
-mpack_decode_array_inner(
-    DecoderState *self, Py_ssize_t size, TypeNode *type, PathNode *path, bool is_key
+MS_DEPTH_WRAP_OBJ(
+    mpack_decode_array,
+    (DecoderState *self, Py_ssize_t size, TypeNode *type, PathNode *path, bool is_key),
+    (self, size, type, path, is_key)
 ) {
     if (MS_UNLIKELY(!ms_passes_array_constraints(size, type, path))) return NULL;
 
@@ -16370,26 +16342,10 @@ mpack_decode_struct_union(
     return NULL;
 }
 
-static PyObject *mpack_decode_map_inner(
-    DecoderState *self, Py_ssize_t size, TypeNode *type,
-    PathNode *path, bool is_key
-);
-
-static PyObject *
-mpack_decode_map(
-    DecoderState *self, Py_ssize_t size, TypeNode *type,
-    PathNode *path, bool is_key
-) {
-    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return NULL;
-    PyObject *res = mpack_decode_map_inner(self, size, type, path, is_key);
-    ms_leave_recursive(&self->recursion_depth);
-    return res;
-}
-
-static PyObject *
-mpack_decode_map_inner(
-    DecoderState *self, Py_ssize_t size, TypeNode *type,
-    PathNode *path, bool is_key
+MS_DEPTH_WRAP_OBJ(
+    mpack_decode_map,
+    (DecoderState *self, Py_ssize_t size, TypeNode *type, PathNode *path, bool is_key),
+    (self, size, type, path, is_key)
 ) {
     if (type->types & MS_TYPE_STRUCT) {
         StructInfo *info = TypeNode_get_struct_info(type);
@@ -18538,23 +18494,10 @@ json_decode_struct_array_union(
     return json_decode_struct_array_inner(self, info, path, 1);
 }
 
-static PyObject *json_decode_array_inner(
-    JSONDecoderState *self, TypeNode *type, PathNode *path
-);
-
-static PyObject *
-json_decode_array(
-    JSONDecoderState *self, TypeNode *type, PathNode *path
-) {
-    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return NULL;
-    PyObject *res = json_decode_array_inner(self, type, path);
-    ms_leave_recursive(&self->recursion_depth);
-    return res;
-}
-
-static PyObject *
-json_decode_array_inner(
-    JSONDecoderState *self, TypeNode *type, PathNode *path
+MS_DEPTH_WRAP_OBJ(
+    json_decode_array,
+    (JSONDecoderState *self, TypeNode *type, PathNode *path),
+    (self, type, path)
 ) {
     if (type->types & MS_TYPE_ANY) {
         TypeNode type_any = {MS_TYPE_ANY};
@@ -19058,23 +19001,10 @@ json_decode_struct_union(
     return NULL;
 }
 
-static PyObject *json_decode_object_inner(
-    JSONDecoderState *self, TypeNode *type, PathNode *path
-);
-
-static PyObject *
-json_decode_object(
-    JSONDecoderState *self, TypeNode *type, PathNode *path
-) {
-    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return NULL;
-    PyObject *res = json_decode_object_inner(self, type, path);
-    ms_leave_recursive(&self->recursion_depth);
-    return res;
-}
-
-static PyObject *
-json_decode_object_inner(
-    JSONDecoderState *self, TypeNode *type, PathNode *path
+MS_DEPTH_WRAP_OBJ(
+    json_decode_object,
+    (JSONDecoderState *self, TypeNode *type, PathNode *path),
+    (self, type, path)
 ) {
     if (type->types & MS_TYPE_ANY) {
         TypeNode type_any = {MS_TYPE_ANY};
@@ -19174,18 +19104,7 @@ json_skip_ident(JSONDecoderState *self, const char *ident, size_t len) {
     return 0;
 }
 
-static int json_skip_array_inner(JSONDecoderState *self);
-
-static int
-json_skip_array(JSONDecoderState *self) {
-    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return -1;
-    int out = json_skip_array_inner(self);
-    ms_leave_recursive(&self->recursion_depth);
-    return out;
-}
-
-static int
-json_skip_array_inner(JSONDecoderState *self) {
+MS_DEPTH_WRAP_INT(json_skip_array, (JSONDecoderState *self), (self)) {
     unsigned char c;
     bool first = true;
     int out = -1;
@@ -19222,18 +19141,7 @@ json_skip_array_inner(JSONDecoderState *self) {
     return out;
 }
 
-static int json_skip_object_inner(JSONDecoderState *self);
-
-static int
-json_skip_object(JSONDecoderState *self) {
-    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return -1;
-    int out = json_skip_object_inner(self);
-    ms_leave_recursive(&self->recursion_depth);
-    return out;
-}
-
-static int
-json_skip_object_inner(JSONDecoderState *self) {
+MS_DEPTH_WRAP_INT(json_skip_object, (JSONDecoderState *self), (self)) {
     unsigned char c;
     bool first = true;
     int out = -1;

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -14873,7 +14873,38 @@ typedef struct DecoderState {
     char *input_start;
     char *input_pos;
     char *input_end;
+    Py_ssize_t recursion_depth;
 } DecoderState;
+
+/* Maximum nesting depth allowed when decoding. The recursive decoders use a few
+ * C stack frames per level, and CPython's recursion guard is tied to
+ * `sys.getrecursionlimit()` (or the C recursion limit), neither of which tracks
+ * the actual remaining C stack. On systems with a small stack (or when the
+ * recursion limit is raised) deeply nested input can overflow the C stack and
+ * crash the process before the guard fires. A hard cap independent of the
+ * recursion limit prevents that. Matches the limit used by orjson/simdjson. */
+#define MS_MAX_DECODE_DEPTH 1024
+
+/* Enter a recursive decode level, returning -1 (with a DecodeError set) if the
+ * nesting limit would be exceeded, else 0. Each successful call must be paired
+ * with `ms_leave_recursive`. */
+static MS_INLINE int
+ms_enter_recursive(Py_ssize_t *depth) {
+    if (MS_UNLIKELY(*depth >= MS_MAX_DECODE_DEPTH)) {
+        PyErr_SetString(
+            msgspec_get_global_state()->DecodeError,
+            "Input data is too deeply nested"
+        );
+        return -1;
+    }
+    (*depth)++;
+    return 0;
+}
+
+static MS_INLINE void
+ms_leave_recursive(Py_ssize_t *depth) {
+    (*depth)--;
+}
 
 typedef struct Decoder {
     PyObject_HEAD
@@ -15271,8 +15302,18 @@ mpack_decode_datetime(
 
 static int mpack_skip(DecoderState *self);
 
+static int mpack_skip_array_inner(DecoderState *self, Py_ssize_t size);
+
 static int
 mpack_skip_array(DecoderState *self, Py_ssize_t size) {
+    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return -1;
+    int out = mpack_skip_array_inner(self, size);
+    ms_leave_recursive(&self->recursion_depth);
+    return out;
+}
+
+static int
+mpack_skip_array_inner(DecoderState *self, Py_ssize_t size) {
     int status = -1;
     Py_ssize_t i;
     if (size < 0) return -1;
@@ -15944,8 +15985,22 @@ mpack_decode_struct_array_union(
     return mpack_decode_struct_array_inner(self, size, true, info, path, is_key);
 }
 
+static PyObject *mpack_decode_array_inner(
+    DecoderState *self, Py_ssize_t size, TypeNode *type, PathNode *path, bool is_key
+);
+
 static PyObject *
 mpack_decode_array(
+    DecoderState *self, Py_ssize_t size, TypeNode *type, PathNode *path, bool is_key
+) {
+    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return NULL;
+    PyObject *res = mpack_decode_array_inner(self, size, type, path, is_key);
+    ms_leave_recursive(&self->recursion_depth);
+    return res;
+}
+
+static PyObject *
+mpack_decode_array_inner(
     DecoderState *self, Py_ssize_t size, TypeNode *type, PathNode *path, bool is_key
 ) {
     if (MS_UNLIKELY(!ms_passes_array_constraints(size, type, path))) return NULL;
@@ -16295,8 +16350,24 @@ mpack_decode_struct_union(
     return NULL;
 }
 
+static PyObject *mpack_decode_map_inner(
+    DecoderState *self, Py_ssize_t size, TypeNode *type,
+    PathNode *path, bool is_key
+);
+
 static PyObject *
 mpack_decode_map(
+    DecoderState *self, Py_ssize_t size, TypeNode *type,
+    PathNode *path, bool is_key
+) {
+    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return NULL;
+    PyObject *res = mpack_decode_map_inner(self, size, type, path, is_key);
+    ms_leave_recursive(&self->recursion_depth);
+    return res;
+}
+
+static PyObject *
+mpack_decode_map_inner(
     DecoderState *self, Py_ssize_t size, TypeNode *type,
     PathNode *path, bool is_key
 ) {
@@ -16798,6 +16869,7 @@ typedef struct JSONDecoderState {
     unsigned char *input_start;
     unsigned char *input_pos;
     unsigned char *input_end;
+    Py_ssize_t recursion_depth;
 } JSONDecoderState;
 
 typedef struct JSONDecoder {
@@ -18446,8 +18518,22 @@ json_decode_struct_array_union(
     return json_decode_struct_array_inner(self, info, path, 1);
 }
 
+static PyObject *json_decode_array_inner(
+    JSONDecoderState *self, TypeNode *type, PathNode *path
+);
+
 static PyObject *
 json_decode_array(
+    JSONDecoderState *self, TypeNode *type, PathNode *path
+) {
+    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return NULL;
+    PyObject *res = json_decode_array_inner(self, type, path);
+    ms_leave_recursive(&self->recursion_depth);
+    return res;
+}
+
+static PyObject *
+json_decode_array_inner(
     JSONDecoderState *self, TypeNode *type, PathNode *path
 ) {
     if (type->types & MS_TYPE_ANY) {
@@ -18952,8 +19038,22 @@ json_decode_struct_union(
     return NULL;
 }
 
+static PyObject *json_decode_object_inner(
+    JSONDecoderState *self, TypeNode *type, PathNode *path
+);
+
 static PyObject *
 json_decode_object(
+    JSONDecoderState *self, TypeNode *type, PathNode *path
+) {
+    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return NULL;
+    PyObject *res = json_decode_object_inner(self, type, path);
+    ms_leave_recursive(&self->recursion_depth);
+    return res;
+}
+
+static PyObject *
+json_decode_object_inner(
     JSONDecoderState *self, TypeNode *type, PathNode *path
 ) {
     if (type->types & MS_TYPE_ANY) {
@@ -19054,8 +19154,18 @@ json_skip_ident(JSONDecoderState *self, const char *ident, size_t len) {
     return 0;
 }
 
+static int json_skip_array_inner(JSONDecoderState *self);
+
 static int
 json_skip_array(JSONDecoderState *self) {
+    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return -1;
+    int out = json_skip_array_inner(self);
+    ms_leave_recursive(&self->recursion_depth);
+    return out;
+}
+
+static int
+json_skip_array_inner(JSONDecoderState *self) {
     unsigned char c;
     bool first = true;
     int out = -1;
@@ -19092,8 +19202,18 @@ json_skip_array(JSONDecoderState *self) {
     return out;
 }
 
+static int json_skip_object_inner(JSONDecoderState *self);
+
 static int
 json_skip_object(JSONDecoderState *self) {
+    if (MS_UNLIKELY(ms_enter_recursive(&self->recursion_depth))) return -1;
+    int out = json_skip_object_inner(self);
+    ms_leave_recursive(&self->recursion_depth);
+    return out;
+}
+
+static int
+json_skip_object_inner(JSONDecoderState *self) {
     unsigned char c;
     bool first = true;
     int out = -1;

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -3158,40 +3158,47 @@ class TestFormat:
             msgspec.json.format(msg)
 
 
+requires_depth_cap = pytest.mark.skipif(
+    sys.version_info >= (3, 14),
+    reason="explicit depth cap only applies before Python 3.14",
+)
+
+
 class TestRecursionLimit:
-    """The decoder caps nesting depth to avoid overflowing the C stack on
-    deeply nested input (see #1033). The cap is independent of
-    ``sys.getrecursionlimit``."""
+    """Deeply nested input must never crash the process (see #1033). Before
+    Python 3.14 the decoder enforces an explicit nesting cap independent of
+    ``sys.getrecursionlimit``; on 3.14+ CPython's own stack-aware recursion
+    guard handles it."""
 
-    def test_deeply_nested_array(self):
-        data = b"[" * 5000 + b"]" * 5000
-        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
-            msgspec.json.decode(data)
+    def test_deeply_nested_array_no_crash(self):
+        # Deeper than any reasonable C stack, so this errors on every version
+        # (the cap before 3.14, CPython's stack guard on 3.14+) without crashing.
+        with pytest.raises((msgspec.DecodeError, RecursionError)):
+            msgspec.json.decode(b"[" * 1_000_000 + b"]" * 1_000_000)
 
-    def test_deeply_nested_object(self):
-        data = b'{"a":' * 5000 + b"0" + b"}" * 5000
-        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
-            msgspec.json.decode(data)
+    def test_deeply_nested_object_no_crash(self):
+        with pytest.raises((msgspec.DecodeError, RecursionError)):
+            msgspec.json.decode(b'{"a":' * 1_000_000 + b"0" + b"}" * 1_000_000)
 
-    def test_raised_recursion_limit_no_crash(self):
-        # Raising the recursion limit must not let deep input overflow the C
-        # stack: the hard cap still applies.
-        orig = sys.getrecursionlimit()
-        sys.setrecursionlimit(40000)
-        try:
-            data = b"[" * 20000 + b"]" * 20000
-            with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
-                msgspec.json.decode(data)
-        finally:
-            sys.setrecursionlimit(orig)
-
-    def test_nesting_at_limit_ok(self):
-        # Nesting up to the limit decodes fine; one level deeper errors.
+    @requires_depth_cap
+    def test_depth_cap(self):
+        # Nesting up to the cap decodes; one level deeper raises a DecodeError.
         msgspec.json.decode(b"[" * 512 + b"]" * 512)
         with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
             msgspec.json.decode(b"[" * 513 + b"]" * 513)
 
-    def test_skip_path(self):
+    @requires_depth_cap
+    def test_depth_cap_independent_of_recursion_limit(self):
+        orig = sys.getrecursionlimit()
+        sys.setrecursionlimit(40000)
+        try:
+            with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+                msgspec.json.decode(b"[" * 20000 + b"]" * 20000)
+        finally:
+            sys.setrecursionlimit(orig)
+
+    @requires_depth_cap
+    def test_depth_cap_skip_path(self):
         # The "skip unknown field" path recurses too and must error cleanly.
         class Ex(msgspec.Struct):
             x: int
@@ -3200,8 +3207,8 @@ class TestRecursionLimit:
         with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
             msgspec.json.decode(data, type=Ex)
 
-    def test_decoder_reused_after_overflow(self):
-        # The depth counter is reset between decodes.
+    @requires_depth_cap
+    def test_depth_cap_decoder_reuse(self):
         dec = msgspec.json.Decoder()
         with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
             dec.decode(b"[" * 5000 + b"]" * 5000)

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -3187,9 +3187,9 @@ class TestRecursionLimit:
 
     def test_nesting_at_limit_ok(self):
         # Nesting up to the limit decodes fine; one level deeper errors.
-        msgspec.json.decode(b"[" * 1024 + b"]" * 1024)
+        msgspec.json.decode(b"[" * 512 + b"]" * 512)
         with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
-            msgspec.json.decode(b"[" * 1025 + b"]" * 1025)
+            msgspec.json.decode(b"[" * 513 + b"]" * 513)
 
     def test_skip_path(self):
         # The "skip unknown field" path recurses too and must error cleanly.

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -3156,3 +3156,53 @@ class TestFormat:
     def test_format_malformed(self, msg, err):
         with pytest.raises(msgspec.DecodeError, match=err):
             msgspec.json.format(msg)
+
+
+class TestRecursionLimit:
+    """The decoder caps nesting depth to avoid overflowing the C stack on
+    deeply nested input (see #1033). The cap is independent of
+    ``sys.getrecursionlimit``."""
+
+    def test_deeply_nested_array(self):
+        data = b"[" * 5000 + b"]" * 5000
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            msgspec.json.decode(data)
+
+    def test_deeply_nested_object(self):
+        data = b'{"a":' * 5000 + b"0" + b"}" * 5000
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            msgspec.json.decode(data)
+
+    def test_raised_recursion_limit_no_crash(self):
+        # Raising the recursion limit must not let deep input overflow the C
+        # stack: the hard cap still applies.
+        orig = sys.getrecursionlimit()
+        sys.setrecursionlimit(40000)
+        try:
+            data = b"[" * 20000 + b"]" * 20000
+            with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+                msgspec.json.decode(data)
+        finally:
+            sys.setrecursionlimit(orig)
+
+    def test_nesting_at_limit_ok(self):
+        # Nesting up to the limit decodes fine; one level deeper errors.
+        msgspec.json.decode(b"[" * 1024 + b"]" * 1024)
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            msgspec.json.decode(b"[" * 1025 + b"]" * 1025)
+
+    def test_skip_path(self):
+        # The "skip unknown field" path recurses too and must error cleanly.
+        class Ex(msgspec.Struct):
+            x: int
+
+        data = b'{"y":' + b"[" * 5000 + b"]" * 5000 + b',"x":1}'
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            msgspec.json.decode(data, type=Ex)
+
+    def test_decoder_reused_after_overflow(self):
+        # The depth counter is reset between decodes.
+        dec = msgspec.json.Decoder()
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            dec.decode(b"[" * 5000 + b"]" * 5000)
+        assert dec.decode(b"[1, 2, 3]") == [1, 2, 3]

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -2040,39 +2040,48 @@ class TestRaw:
         assert res == Test(Custom(1, 2))
 
 
+requires_depth_cap = pytest.mark.skipif(
+    sys.version_info >= (3, 14),
+    reason="explicit depth cap only applies before Python 3.14",
+)
+
+
 class TestRecursionLimit:
-    """The decoder caps nesting depth to avoid overflowing the C stack on
-    deeply nested input (see #1033). The cap is independent of
-    ``sys.getrecursionlimit``."""
+    """Deeply nested input must never crash the process (see #1033). Before
+    Python 3.14 the decoder enforces an explicit nesting cap independent of
+    ``sys.getrecursionlimit``; on 3.14+ CPython's own stack-aware recursion
+    guard handles it."""
 
-    def test_deeply_nested_array(self):
-        # N nested 1-element arrays (fixarray-1 = 0x91), nil (0xc0) at the bottom
-        data = b"\x91" * 5000 + b"\xc0"
-        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
-            msgspec.msgpack.decode(data)
+    def test_deeply_nested_array_no_crash(self):
+        # N nested 1-element arrays (fixarray-1 = 0x91), nil (0xc0) at the bottom.
+        # Deeper than any reasonable C stack, so this errors on every version
+        # (the cap before 3.14, CPython's stack guard on 3.14+) without crashing.
+        with pytest.raises((msgspec.DecodeError, RecursionError)):
+            msgspec.msgpack.decode(b"\x91" * 1_000_000 + b"\xc0")
 
-    def test_deeply_nested_map(self):
-        # N nested 1-pair maps (fixmap-1 = 0x81) with a 1-char key, nil at the bottom
-        data = b"\x81\xa1k" * 5000 + b"\xc0"
-        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
-            msgspec.msgpack.decode(data)
+    def test_deeply_nested_map_no_crash(self):
+        # N nested 1-pair maps (fixmap-1 = 0x81) with a 1-char key, nil at bottom
+        with pytest.raises((msgspec.DecodeError, RecursionError)):
+            msgspec.msgpack.decode(b"\x81\xa1k" * 1_000_000 + b"\xc0")
 
-    def test_raised_recursion_limit_no_crash(self):
-        orig = sys.getrecursionlimit()
-        sys.setrecursionlimit(40000)
-        try:
-            data = b"\x91" * 20000 + b"\xc0"
-            with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
-                msgspec.msgpack.decode(data)
-        finally:
-            sys.setrecursionlimit(orig)
-
-    def test_nesting_at_limit_ok(self):
+    @requires_depth_cap
+    def test_depth_cap(self):
         msgspec.msgpack.decode(b"\x91" * 512 + b"\xc0")
         with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
             msgspec.msgpack.decode(b"\x91" * 513 + b"\xc0")
 
-    def test_skip_path(self):
+    @requires_depth_cap
+    def test_depth_cap_independent_of_recursion_limit(self):
+        orig = sys.getrecursionlimit()
+        sys.setrecursionlimit(40000)
+        try:
+            with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+                msgspec.msgpack.decode(b"\x91" * 20000 + b"\xc0")
+        finally:
+            sys.setrecursionlimit(orig)
+
+    @requires_depth_cap
+    def test_depth_cap_skip_path(self):
         # The "skip unknown field" path recurses too and must error cleanly.
         class Ex(msgspec.Struct):
             x: int
@@ -2082,7 +2091,8 @@ class TestRecursionLimit:
         with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
             msgspec.msgpack.decode(data, type=Ex)
 
-    def test_decoder_reused_after_overflow(self):
+    @requires_depth_cap
+    def test_depth_cap_decoder_reuse(self):
         dec = msgspec.msgpack.Decoder()
         with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
             dec.decode(b"\x91" * 5000 + b"\xc0")

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -2068,9 +2068,9 @@ class TestRecursionLimit:
             sys.setrecursionlimit(orig)
 
     def test_nesting_at_limit_ok(self):
-        msgspec.msgpack.decode(b"\x91" * 1024 + b"\xc0")
+        msgspec.msgpack.decode(b"\x91" * 512 + b"\xc0")
         with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
-            msgspec.msgpack.decode(b"\x91" * 1025 + b"\xc0")
+            msgspec.msgpack.decode(b"\x91" * 513 + b"\xc0")
 
     def test_skip_path(self):
         # The "skip unknown field" path recurses too and must error cleanly.

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -2038,3 +2038,52 @@ class TestRaw:
         s = msgspec.msgpack.encode({"x": [1, 2]})
         res = msgspec.msgpack.decode(s, type=Test, dec_hook=dec_hook)
         assert res == Test(Custom(1, 2))
+
+
+class TestRecursionLimit:
+    """The decoder caps nesting depth to avoid overflowing the C stack on
+    deeply nested input (see #1033). The cap is independent of
+    ``sys.getrecursionlimit``."""
+
+    def test_deeply_nested_array(self):
+        # N nested 1-element arrays (fixarray-1 = 0x91), nil (0xc0) at the bottom
+        data = b"\x91" * 5000 + b"\xc0"
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            msgspec.msgpack.decode(data)
+
+    def test_deeply_nested_map(self):
+        # N nested 1-pair maps (fixmap-1 = 0x81) with a 1-char key, nil at the bottom
+        data = b"\x81\xa1k" * 5000 + b"\xc0"
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            msgspec.msgpack.decode(data)
+
+    def test_raised_recursion_limit_no_crash(self):
+        orig = sys.getrecursionlimit()
+        sys.setrecursionlimit(40000)
+        try:
+            data = b"\x91" * 20000 + b"\xc0"
+            with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+                msgspec.msgpack.decode(data)
+        finally:
+            sys.setrecursionlimit(orig)
+
+    def test_nesting_at_limit_ok(self):
+        msgspec.msgpack.decode(b"\x91" * 1024 + b"\xc0")
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            msgspec.msgpack.decode(b"\x91" * 1025 + b"\xc0")
+
+    def test_skip_path(self):
+        # The "skip unknown field" path recurses too and must error cleanly.
+        class Ex(msgspec.Struct):
+            x: int
+
+        # {"y": <deeply nested>, "x": 1} as a 2-pair map
+        data = b"\x82\xa1y" + b"\x91" * 5000 + b"\xc0" + b"\xa1x\x01"
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            msgspec.msgpack.decode(data, type=Ex)
+
+    def test_decoder_reused_after_overflow(self):
+        dec = msgspec.msgpack.Decoder()
+        with pytest.raises(msgspec.DecodeError, match="too deeply nested"):
+            dec.decode(b"\x91" * 5000 + b"\xc0")
+        assert dec.decode(msgspec.msgpack.encode([1, 2, 3])) == [1, 2, 3]


### PR DESCRIPTION
Closes #1033.

The JSON and MessagePack decoders recurse once per nesting level, using a few C stack frames each. The only guard is `Py_EnterRecursiveCall`, which on Python < 3.14 is tied to `sys.getrecursionlimit()` (or the C recursion limit) and does not track the actual remaining C stack. So deeply nested input can overflow the C stack and crash the process (SIGSEGV, no catchable exception) before the guard fires, either on a thread with a small stack or when the recursion limit has been raised. This is a DoS vector for code decoding untrusted input (same class as orjson's CVE-2024-27454).

This adds a hard nesting-depth cap (`MS_MAX_DECODE_DEPTH = 512`) independent of `sys.getrecursionlimit()`, raising a `DecodeError` instead of recursing further. It covers both decoders and the unknown-field skip paths.

Python 3.14 rewrote the recursion guard to check the actual remaining C stack, so it already prevents the overflow there. The explicit cap is therefore only applied on Python < 3.14; on 3.14+ the decoder defers to CPython's guard and the cap is compiled out.

On the cap value: 512 sits below the default Python recursion limit (~1000), so on the affected versions this cap, rather than a `RecursionError`, is what bounds nesting consistently. It's also low enough to keep a realistic small stack (e.g. a default 1 MB Windows main thread) safe, while staying far above any real-world nesting depth. orjson/simdjson use 1024, but that assumes a large server stack; the point of #1033 is that a recursion-limit-tied guard is insufficient on small stacks, so a lower fixed cap is used here. Happy to adjust the value.

Note: TOML/YAML decode goes through pure-Python `tomllib`/PyYAML, not this C path, so they're unaffected (and have their own limits).
