### PR TITLE
Fix `yaml` and `toml` types, add negative checks

### DIFF
--- a/src/msgspec/__init__.pyi
+++ b/src/msgspec/__init__.pyi
@@ -201,7 +201,7 @@ def to_builtins(
     str_keys: bool = False,
     builtin_types: Iterable[type[Any]] | None = None,
     enc_hook: Callable[[Any], Any] | None = None,
-    order: Literal[None, "deterministic", "sorted"] = None,
+    order: Literal["deterministic", "sorted"] | None = None,
 ) -> Any: ...
 @overload
 def convert(

--- a/src/msgspec/msgpack.pyi
+++ b/src/msgspec/msgpack.pyi
@@ -96,5 +96,5 @@ def encode(
     /,
     *,
     enc_hook: _EncHookSig = None,
-    order: Literal[None, "deterministic", "sorted"] = None,
+    order: Literal["deterministic", "sorted"] | None = None,
 ) -> bytes: ...

--- a/src/msgspec/toml.py
+++ b/src/msgspec/toml.py
@@ -62,7 +62,7 @@ def encode(
     obj: Any,
     *,
     enc_hook: Callable[[Any], Any] | None = None,
-    order: Literal[None, "deterministic", "sorted"] = None,
+    order: Literal["deterministic", "sorted"] | None = None,
 ) -> bytes:
     """Serialize an object as TOML.
 
@@ -108,28 +108,17 @@ def encode(
     return toml.dumps(msg).encode("utf-8")
 
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
 @overload
 def decode(
     buf: Buffer | str,
     *,
+    type: type[_T],
     strict: bool = True,
-    dec_hook: Callable[[type, Any], Any] | None = None,
-) -> Any:
-    pass
-
-
-@overload
-def decode(
-    buf: Buffer | str,
-    *,
-    type: type[T] = ...,
-    strict: bool = True,
-    dec_hook: Callable[[type, Any], Any] | None = None,
-) -> T:
-    pass
+    dec_hook: Callable[[type[Any], Any], Any] | None = None,
+) -> _T: ...
 
 
 @overload
@@ -138,12 +127,17 @@ def decode(
     *,
     type: Any = ...,
     strict: bool = True,
-    dec_hook: Callable[[type, Any], Any] | None = None,
+    dec_hook: Callable[[type[Any], Any], Any] | None = None,
+) -> Any: ...
+
+
+def decode(
+    buf: Buffer | str,
+    *,
+    type: Any = Any,
+    strict: bool = True,
+    dec_hook: Callable[[type[Any], Any], Any] | None = None,
 ) -> Any:
-    pass
-
-
-def decode(buf, *, type=Any, strict=True, dec_hook=None):
     """Deserialize an object from TOML.
 
     Parameters

--- a/src/msgspec/yaml.py
+++ b/src/msgspec/yaml.py
@@ -41,7 +41,7 @@ def encode(
     obj: Any,
     *,
     enc_hook: Callable[[Any], Any] | None = None,
-    order: Literal[None, "deterministic", "sorted"] = None,
+    order: Literal["deterministic", "sorted"] | None = None,
 ) -> bytes:
     """Serialize an object as YAML.
 
@@ -101,42 +101,36 @@ def encode(
     )
 
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
 @overload
 def decode(
     buf: Buffer | str,
     *,
+    type: type[_T],
     strict: bool = True,
-    dec_hook: Callable[[type, Any], Any] | None = None,
-) -> Any:
-    pass
+    dec_hook: Callable[[type[Any], Any], Any] | None = None,
+) -> _T: ...
 
 
 @overload
 def decode(
-    buf: bytes | str,
-    *,
-    type: type[T] = ...,
-    strict: bool = True,
-    dec_hook: Callable[[type, Any], Any] | None = None,
-) -> T:
-    pass
-
-
-@overload
-def decode(
-    buf: bytes | str,
+    buf: Buffer | str,
     *,
     type: Any = ...,
     strict: bool = True,
-    dec_hook: Callable[[type, Any], Any] | None = None,
+    dec_hook: Callable[[type[Any], Any], Any] | None = None,
+) -> Any: ...
+
+
+def decode(
+    buf: Buffer | str,
+    *,
+    type: Any = Any,
+    strict: bool = True,
+    dec_hook: Callable[[type[Any], Any], Any] | None = None,
 ) -> Any:
-    pass
-
-
-def decode(buf, *, type=Any, strict=True, dec_hook=None):
     """Deserialize an object from YAML.
 
     Parameters

--- a/tests/typing/basic_typing_examples.py
+++ b/tests/typing/basic_typing_examples.py
@@ -81,6 +81,8 @@ def check_struct_field() -> None:
     Test(1, 2, 3, [4], 5)
     Test(1, 2, 3, [4], 5, [6])
 
+    msgspec.field(default=1, default_factory=int)  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue]  # pyrefly: ignore[no-matching-overload]
+
 
 def check_struct_kw_only() -> None:
     class Test(msgspec.Struct, kw_only=True):
@@ -461,6 +463,8 @@ def check_replace() -> None:
     assert_type(msgspec.structs.replace(struct, x=1), Test)
     assert_type(msgspec.structs.replace(struct, struct=1), Test)
 
+    msgspec.structs.replace(object(), x=1)  # type: ignore[type-var]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-specialization]
+
 
 def check_asdict() -> None:
     class Test(msgspec.Struct):
@@ -734,10 +738,12 @@ def check_msgpack_Ext() -> None:
     assert_type(ext.code, int)
     assert_type(ext.data, Buffer)
 
-    # TODO: test that non buffers can't be used:
-    msgspec.msgpack.Ext(1, bytearray())
-    msgspec.msgpack.Ext(1, memoryview(b''))
-    msgspec.msgpack.Ext(1, array.array('i', [1, 2, 3]))
+    assert_type(msgspec.msgpack.Ext(1, bytearray()), msgspec.msgpack.Ext)
+    assert_type(msgspec.msgpack.Ext(1, memoryview(b'')), msgspec.msgpack.Ext)
+    assert_type(msgspec.msgpack.Ext(1, array.array('i', [1, 2, 3])), msgspec.msgpack.Ext)
+
+    # Non buffers:
+    msgspec.msgpack.Ext(1, {})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]
 
 
 ##########################################################
@@ -931,13 +937,18 @@ def check_yaml_encode() -> None:
 
 
 def check_yaml_decode_any() -> None:
-    o = msgspec.yaml.decode(b"[1, 2, 3]")
-    assert_type(o, Any)
+    assert_type(msgspec.yaml.decode(b"[1, 2, 3]"), Any)
+    assert_type(msgspec.yaml.decode("[1, 2, 3]"), Any)
+    assert_type(msgspec.yaml.decode(bytearray()), Any)
+    assert_type(msgspec.yaml.decode(memoryview(b'')), Any)
+
+    # Not buffers:
+    msgspec.yaml.decode([])  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]
 
 
 def check_yaml_decode_typed() -> None:
-    o = msgspec.yaml.decode(b"[1, 2, 3]", type=list[int])
-    assert_type(o, list[int])
+    assert_type(msgspec.yaml.decode(b"[1, 2, 3]", type=list[int]), list[int])
+    assert_type(msgspec.yaml.decode("[]", type=list[str]), list[str])
 
 
 def check_yaml_decode_typed_union() -> None:
@@ -949,10 +960,6 @@ def check_yaml_decode_from_str() -> None:
     msgspec.yaml.decode("[1, 2, 3]")
     o = msgspec.yaml.decode("[1, 2, 3]", type=list[int])
     assert_type(o, list[int])
-
-
-def check_yaml_decode_from_buffer() -> None:
-    assert_type(msgspec.yaml.decode(memoryview(b"[1, 2, 3]")), Any)
 
 
 def check_yaml_encode_enc_hook() -> None:
@@ -1004,7 +1011,11 @@ def check_toml_decode_from_str() -> None:
 
 
 def check_toml_decode_from_buffer() -> None:
+    assert_type(msgspec.toml.decode(bytearray()), Any)
     assert_type(msgspec.toml.decode(memoryview(b"a = 1")), Any)
+
+    # Non buffers:
+    msgspec.toml.decode({})  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]  # pyrefly: ignore[bad-argument-type]
 
 
 def check_toml_encode_enc_hook() -> None:


### PR DESCRIPTION
Changes:
- Removed extra overloads from `.yaml` and `.toml`
- Fixed missing generics in `type` type
- Added negative type assertions to tests