### PR TITLE
Document that omit_defaults ignores custom default_factory

### DIFF
--- a/docs/structs.rst
+++ b/docs/structs.rst
@@ -677,6 +677,23 @@ detection logic is as follows:
     ...         return True
     ...     return False
 
+This detection never calls a ``default_factory``. A field configured with a
+custom ``default_factory`` is only omitted when the factory is one of the
+builtin collection constructors (``list``, ``dict``, ``set``, ``tuple``, or
+``frozenset``). Any other callable (a user-defined function, a ``lambda``, or a
+``Struct``/``dataclass``/``attrs`` type) is treated as opaque, so the field is
+always encoded, even when the value it produces is empty. To omit an empty
+collection default, configure the builtin constructor directly:
+
+.. code-block:: python
+
+    >>> class Basket(msgspec.Struct, omit_defaults=True):
+    ...     items: list[int] = msgspec.field(default_factory=list)
+
+The field annotation supplies the element type, so ``default_factory=list``
+still type checks. Specifying ``default=[]`` works too: ``msgspec`` doesn't
+share mutable default values between instances.
+
 
 .. _forbid-unknown-fields:
 


### PR DESCRIPTION
`omit_defaults` only recognizes empty-collection defaults when the default is given by value or via a builtin collection constructor (`list`/`dict`/`set`/`tuple`/`frozenset`). A custom `default_factory` (a user function, `lambda`, or a `Struct`/`dataclass`/`attrs` type) is never called during detection, so its field is always encoded, even when the produced value is empty.

This is intentional: detection runs in the encode hot path and stays O(1) without invoking user code. The behavior wasn't documented though, so the `matches_default` section now spells out the `default_factory` limitation and points at `default_factory=list` (which type checks fine via the field annotation) as the supported way to omit an empty collection default.

Closes #1032
Closes #645