### PR TITLE
Fix compilation warnings on Python 3.15

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -10171,7 +10171,7 @@ static bool
 ms_passes_big_int_constraints(PyObject *obj, TypeNode *type, PathNode *path) {
 #if PY314_PLUS
     /* obj is always a PyLong here, so PyLong_GetSign can't fail */
-    int sign;
+    int sign = 0;
     PyLong_GetSign(obj, &sign);
     bool neg = sign < 0;
 #else

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -3675,7 +3675,7 @@ _constr_as_i64(PyObject *obj, int64_t *target, int offset) {
     }
     /* Do offsets for lt/gt */
     if (offset == -1) {
-        if (x == (-1LL << 63)) {
+        if (x == INT64_MIN) {
             PyErr_SetString(PyExc_ValueError, "lt <= -2**63 is not supported");
             return false;
         }
@@ -10169,7 +10169,14 @@ ms_passes_int_constraints(uint64_t ux, bool neg, TypeNode *type, PathNode *path)
 /* Constraint checks for a PyLong that is known not to fit into a uint64/int64 */
 static bool
 ms_passes_big_int_constraints(PyObject *obj, TypeNode *type, PathNode *path) {
+#if PY314_PLUS
+    /* obj is always a PyLong here, so PyLong_GetSign can't fail */
+    int sign;
+    PyLong_GetSign(obj, &sign);
+    bool neg = sign < 0;
+#else
     bool neg = _PyLong_Sign(obj) < 0;
+#endif
 
     if (type->types & MS_CONSTR_INT_MIN) {
         if (neg) {
@@ -12000,7 +12007,7 @@ static bool
 double_as_int64(double x, int64_t *out) {
     if (fmod(x, 1.0) != 0.0) return false;
     if (x > (1LL << 53)) return false;
-    if (x < (-1LL << 53)) return false;
+    if (x < -(1LL << 53)) return false;
     *out = (int64_t)x;
     return true;
 }


### PR DESCRIPTION
Silences three compiler warnings seen on 3.15-dev (and reproducible on 3.14):

- `_constr_as_i64`: `(-1LL << 63)` is a left shift of a negative value (UB, `-Wshift-negative-value`). Replaced with `INT64_MIN`, which is the value it was computing.
- `double_as_int64`: `(-1LL << 53)` is the same UB. Replaced with `-(1LL << 53)` (negate a positive shift), keeping the exact `-2**53` bound.
- `ms_passes_big_int_constraints`: `_PyLong_Sign` is `Py_DEPRECATED(3.14)`. Use the public `PyLong_GetSign` on 3.14+ and keep `_PyLong_Sign` on older versions.

All three are behavior preserving. Built and ran the unit suite on both branches: 3.12 (`_PyLong_Sign`) and 3.14 (`PyLong_GetSign`), both green; the three warnings are gone under 3.14 headers.

Note: the reporter's paste also mentions "1 error" alongside the warnings. That is an `SSIZE_MAX undeclared` from CPython's 3.15 `pyport.h` when `_core.c` is compiled in isolation without `_GNU_SOURCE`; it doesn't reproduce under the normal build (CPython's `pyconfig.h` sets the feature-test macros), so it's out of scope here.

Closes #1048