### PR TITLE
Fix inspect.type_info crashing on mixed-type Literals

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,7 +17,7 @@
 - Fix reference leaks in `typenode_collect_literal`, `Meta.__rich_repr__`,
   `ms_decode_bigint`, and `Encoder.__init__` ({pr}`1021`, {pr}`1022`,
   {pr}`1023`, {pr}`1040`).
-- Fix `msgspec.inspect.type_info` crashing on mixed-type `Literal`s such as `Literal[1, None]` ({pr}`1080`).
+- Fix `msgspec.inspect.type_info` and `msgspec.json.schema` crashing on mixed-type `Literal`s such as `Literal[1, None]` ({pr}`1080`).
 - Fix missing GC traversal and clearing of some module state members ({pr}`1060`).
 - Ensure an exception is always set on allocation failures ({pr}`1044`).
 - Fix compilation warnings on Python 3.15 ({pr}`1077`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@
 - Fix reference leaks in `typenode_collect_literal`, `Meta.__rich_repr__`,
   `ms_decode_bigint`, and `Encoder.__init__` ({pr}`1021`, {pr}`1022`,
   {pr}`1023`, {pr}`1040`).
+- Fix `msgspec.inspect.type_info` crashing on mixed-type `Literal`s such as `Literal[1, None]` ({pr}`1080`).
 - Fix missing GC traversal and clearing of some module state members ({pr}`1060`).
 - Ensure an exception is always set on allocation failures ({pr}`1044`).
 - Fix compilation warnings on Python 3.15 ({pr}`1077`).

--- a/src/msgspec/_json_schema.py
+++ b/src/msgspec/_json_schema.py
@@ -364,7 +364,11 @@ class _SchemaGenerator:
             else:
                 schema["anyOf"] = options
         elif isinstance(t, mi.LiteralType):
-            schema["enum"] = sorted(t.values)
+            # `t.values` may mix types (e.g. `Literal[1, None]`), which a plain
+            # `sorted` can't order; reuse the same type-aware sort as
+            # `inspect.type_info` so the two entry points agree and neither
+            # crashes.
+            schema["enum"] = list(mi._sort_literal_args(t.values))
         elif isinstance(t, mi.EnumType):
             schema.setdefault("title", t.cls.__name__)
             if doc := _get_doc(t):

--- a/src/msgspec/inspect.py
+++ b/src/msgspec/inspect.py
@@ -308,10 +308,11 @@ class LiteralType(Type):
     ----------
     values: tuple
         A tuple of possible values for this literal instance. Only `bool`,
-        `str`, or `int` literals are supported.
+        `str`, `int`, or `None` literals are supported, and a single literal
+        may mix these types (e.g. ``Literal[1, None]``).
     """
 
-    values: tuple[bool, ...] | tuple[str, ...] | tuple[int, ...]
+    values: tuple[bool | str | int | None, ...]
 
 
 class CustomType(Type):
@@ -694,6 +695,18 @@ def _origin_args_metadata(t):
     return origin, args, tuple(metadata)
 
 
+def _sort_literal_args(args):
+    # `Literal` may mix value types (e.g. `Literal[1, None]`), which a plain
+    # `sorted` can't order since Python 3 forbids comparing across types. Sort
+    # by type name first so members of the same type stay ordered as before,
+    # while mixed-type literals are grouped deterministically instead of
+    # crashing.
+    try:
+        return tuple(sorted(args, key=lambda x: (type(x).__name__, x)))
+    except TypeError:
+        return tuple(args)
+
+
 def _is_enum(t):
     return type(t) is enum.EnumMeta
 
@@ -909,7 +922,7 @@ class _Translator:
             args = tuple(self.translate(a) for a in args if a is not _UnsetType)
             return args[0] if len(args) == 1 else UnionType(args)
         elif t is Literal:
-            return LiteralType(tuple(sorted(args)))
+            return LiteralType(_sort_literal_args(args))
         elif _is_enum(t):
             return EnumType(t)
         elif is_struct_type(t):

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -370,6 +370,18 @@ def test_str_literal():
     assert mi.type_info(Literal["c", "a", "b"]) == mi.LiteralType(("a", "b", "c"))
 
 
+def test_bool_literal():
+    assert mi.type_info(Literal[True]) == mi.LiteralType((True,))
+    assert mi.type_info(Literal[True, False]) == mi.LiteralType((False, True))
+
+
+def test_mixed_literal():
+    # Literals may mix value types; `type_info` shouldn't crash trying to sort
+    # values of incomparable types (gh#1018).
+    assert mi.type_info(Literal[1, None]) == mi.LiteralType((None, 1))
+    assert mi.type_info(Literal[True, "yes"]) == mi.LiteralType((True, "yes"))
+
+
 def test_int_enum():
     class Example(enum.IntEnum):
         B = 3

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -315,6 +315,13 @@ def test_str_literal():
     assert msgspec.json.schema(Literal["c", "a", "b"]) == {"enum": ["a", "b", "c"]}
 
 
+def test_mixed_literal():
+    # A Literal may mix value types; building its schema must not crash trying
+    # to sort values of incomparable types (gh#1018).
+    assert msgspec.json.schema(Literal[1, None]) == {"enum": [None, 1]}
+    assert msgspec.json.schema(Literal[True, "yes"]) == {"enum": [True, "yes"]}
+
+
 def test_struct_object():
     class Point(msgspec.Struct, forbid_unknown_fields=True):
         x: int


### PR DESCRIPTION
Fixes #1018.

### Problem

`msgspec.inspect.type_info` crashes on mixed-type `Literal`s:

```python
msgspec.inspect.type_info(Literal[1, None])      # TypeError: '<' not supported between instances of 'NoneType' and 'int'
msgspec.inspect.type_info(Literal[True, "yes"])  # same
```

`type_info` does `tuple(sorted(args))` on the literal's values, and Python 3 forbids `<` between values of different types. The encoder/decoder already handle these mixed-type literals fine (e.g. `Literal[1, None]` decodes `1`/`null` and rejects `2`), so `type_info` failing on them is a contract violation.

### Fix

Sort the literal values with a `(type name, value)` key instead. This keeps existing same-type ordering identical (`Literal[3,1,2]` → `(1,2,3)`, `Literal[True,False]` → `(False,True)`) while grouping mixed-type literals deterministically rather than crashing, and a `try/except TypeError` falls back to the original order as a safety net. The `LiteralType.values` annotation is widened to allow mixed and `None` members.

### Tests

Added `test_mixed_literal` (`Literal[1, None]`, `Literal[True, "yes"]`) and `test_bool_literal`. Without the fix `test_mixed_literal` raises the `TypeError`; with it the full `test_inspect.py`/`test_schema.py` pass (276 passed, 13 skipped).

I'll add a `docs/changelog.md` entry referencing this PR number in a follow-up commit.

Disclosure: I used AI assistance (Claude) to help locate and draft this fix, under my direction and review.
