### PR TITLE
try reducing codspeed variance

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -18,6 +18,7 @@ env:
   # cross-run variance. See:
   # https://codspeed.io/blog/why-glibc-faster-github-actions#how-to-fix-it-
   GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512DQ,-AVX512_VBMI2,-AVX2,-AVX,-ERMS,-FSRM"
+  RANDOMLY_SEED: "3485796098"
 
 jobs:
   amd_benchmarks:
@@ -50,7 +51,7 @@ jobs:
       uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af  # v4.17.5
       with:
         mode: simulation
-        run: uv run --no-sync pytest tests/prof/perf --codspeed -k amd
+        run: uv run --no-sync pytest tests/prof/perf --randomly-seed="$RANDOMLY_SEED" --codspeed -k amd
 
   arm_benchmarks:
     name: arm benchmarks
@@ -82,7 +83,7 @@ jobs:
       uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af  # v4.17.5
       with:
         mode: simulation
-        run: uv run --no-sync pytest tests/prof/perf --codspeed -k arm
+        run: uv run --no-sync pytest tests/prof/perf --codspeed --randomly-seed="$RANDOMLY_SEED" -k arm
 
   memory_benchmarks:
     name: Memory benchmarks
@@ -114,4 +115,4 @@ jobs:
       uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af  # v4.17.5
       with:
         mode: memory
-        run: uv run --no-sync pytest tests/prof/perf --codspeed -k amd -m memory
+        run: uv run --no-sync pytest tests/prof/perf --randomly-seed="$RANDOMLY_SEED" --codspeed -k amd -m memory

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -13,6 +13,11 @@ permissions: {}
 
 env:
   UV_NO_EDITABLE: "true"
+  # cisable glibc CPU-feature detection (AVX2) so benchmarks use the same
+  # memory routines regardless of which CPU the runner lands on, reducing
+  # cross-run variance. See:
+  # https://codspeed.io/blog/why-glibc-faster-github-actions#how-to-fix-it-
+  GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX2"
 
 jobs:
   amd_benchmarks:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -17,7 +17,7 @@ env:
   # memory routines regardless of which CPU the runner lands on, reducing
   # cross-run variance. See:
   # https://codspeed.io/blog/why-glibc-faster-github-actions#how-to-fix-it-
-  GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX2"
+  GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512DQ,-AVX512_VBMI2,-AVX2,-AVX,-ERMS,-FSRM"
 
 jobs:
   amd_benchmarks:

--- a/tests/prof/perf/test_structs.py
+++ b/tests/prof/perf/test_structs.py
@@ -77,7 +77,7 @@ def test_define(benchmark: BenchmarkFixture, template: str):
         ns = {"Struct": msgspec.Struct}
         exec(code_obj, ns)
 
-    benchmark(fn)
+    benchmark.pedantic(fn, warmup_rounds=10)
 
 
 def test_defstruct(benchmark: BenchmarkFixture):
@@ -103,13 +103,16 @@ def test_defstruct(benchmark: BenchmarkFixture):
     def fn():
         return defstruct("SomeStruct", fields)
 
-    res = benchmark(fn)
+    res = benchmark.pedantic(fn, warmup_rounds=10)
     assert issubclass(res, msgspec.Struct)
 
 
 @pytest.mark.memory
 def test_create(benchmark):
-    benchmark(lambda: [Item(i, i, i, i, i) for i in range(N)])
+    benchmark.pedantic(
+        lambda: [Item(i, i, i, i, i) for i in range(N)],
+        warmup_rounds=10,
+    )
 
 
 @pytest.mark.memory

--- a/tests/prof/perf/test_structs.py
+++ b/tests/prof/perf/test_structs.py
@@ -46,12 +46,6 @@ class C{n}(Struct, order=True, tag_field="my_tag_field"):
 N = 1000
 
 
-@pytest.fixture()
-def _random() -> random.Random:
-    # new random instance with a fixed seed to reduce variance between runs
-    return random.Random(b"}\xf7\xab\xcc4\xec\x1d%j\xc1")
-
-
 class Item(msgspec.Struct, order=True):
     a: int
     b: int
@@ -116,16 +110,16 @@ def test_create(benchmark):
 
 
 @pytest.mark.memory
-def test_equality(benchmark, _random):
+def test_equality(benchmark):
     needle = Item(N - 1, N - 1, N - 1, N - 1, N - 1)
     haystack = [Item(i, i, i, i, i) for i in range(N)]
-    _random.shuffle(haystack)
+    random.shuffle(haystack)
     benchmark(haystack.index, needle)
 
 
 @pytest.mark.memory
-def test_order(benchmark: BenchmarkFixture, _random):
+def test_order(benchmark: BenchmarkFixture):
     haystack = [Item(i, i, i, i, i) for i in range(N)]
-    _random.shuffle(haystack)
+    random.shuffle(haystack)
 
     benchmark(sorted, haystack)

--- a/tests/prof/perf/test_structs.py
+++ b/tests/prof/perf/test_structs.py
@@ -46,6 +46,12 @@ class C{n}(Struct, order=True, tag_field="my_tag_field"):
 N = 1000
 
 
+@pytest.fixture()
+def _random() -> random.Random:
+    # new random instance with a fixed seed to reduce variance between runs
+    return random.Random(b"}\xf7\xab\xcc4\xec\x1d%j\xc1")
+
+
 class Item(msgspec.Struct, order=True):
     a: int
     b: int
@@ -107,16 +113,16 @@ def test_create(benchmark):
 
 
 @pytest.mark.memory
-def test_equality(benchmark):
+def test_equality(benchmark, _random):
     needle = Item(N - 1, N - 1, N - 1, N - 1, N - 1)
     haystack = [Item(i, i, i, i, i) for i in range(N)]
-    random.shuffle(haystack)
+    _random.shuffle(haystack)
     benchmark(haystack.index, needle)
 
 
 @pytest.mark.memory
-def test_order(benchmark: BenchmarkFixture):
+def test_order(benchmark: BenchmarkFixture, _random):
     haystack = [Item(i, i, i, i, i) for i in range(N)]
-    random.shuffle(haystack)
+    _random.shuffle(haystack)
 
     benchmark(sorted, haystack)


### PR DESCRIPTION
- Apply suggestions from https://codspeed.io/blog/why-glibc-faster-github-actions#how-to-fix-it-
- Use a fixed seed for `pytest-randomly`: This was actually a big source of variance in 2 of our tests
- Use warmup where necessary (had been disabled before per codspeed recommendation, but seems to make things more stable in a few cases)

Re-ran the benchmarks a couple of times now, and they seem more stable within this branch. Let's see if this also works across branches.