### PR TITLE
Support the PyEmscripten platform

### DIFF
--- a/.cibuildwheel.toml
+++ b/.cibuildwheel.toml
@@ -3,3 +3,8 @@ build = "cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
 build-frontend = "build[uv]"
 test-command = "pytest {project}/tests/unit"
 test-groups = ["test-unit"]
+
+[tool.cibuildwheel.pyodide]
+build = "cp314-*"
+# https://cibuildwheel.pypa.io/en/stable/platforms/#pyodide
+test-command = "python -m pytest {project}/tests/unit"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-wheels:
-    name: Build wheels on ${{ matrix.os }} for ${{ matrix.archs }}
+    name: Build ${{ matrix.target }}
     runs-on: "${{ matrix.os }}"
     permissions:
       actions: read
@@ -22,21 +22,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: ubuntu-24.04-arm
+        - target: Linux (aarch64)
+          os: ubuntu-24.04-arm
           archs: aarch64
-        - os: ubuntu-latest
+        - target: Linux (x86_64)
+          os: ubuntu-latest
           archs: x86_64
-        - os: macos-latest
+        - target: macOS (arm64)
+          os: macos-latest
           archs: arm64
-        - os: macos-15-intel
+        - target: macOS (x86_64)
+          os: macos-15-intel
           archs: x86_64
-        - os: windows-11-arm
+        - target: Windows (ARM64)
+          os: windows-11-arm
           archs: ARM64
-        - os: windows-latest
+        - target: Windows (AMD64)
+          os: windows-latest
           archs: AMD64
+        - target: Pyodide (wasm32)
+          os: ubuntu-latest
+          archs: wasm32
+          cibw_platform: pyodide
 
     env:
+      CIBW_ARCHS: "${{ matrix.archs }}"
+      CIBW_PLATFORM: "${{ matrix.cibw_platform || 'auto' }}"
       CIBW_SKIP: "${{ !inputs.build-all && '*-musllinux_*' || '' }}"
+      ARTIFACT_NAME: artifact-wheels-${{ matrix.cibw_platform || matrix.os }}-${{ matrix.archs }}
+      PACKAGE_DIR: dist/${{ inputs.sdist-name }}
 
     steps:
     - name: Checkout code
@@ -59,11 +73,8 @@ jobs:
     # incompatible with the repository's full-SHA pinning requirement.
     - name: Build & Test Wheels
       if: runner.os != 'Windows'
-      env:
-        CIBW_ARCHS: "${{ matrix.archs }}"
-        PACKAGE_DIR: "dist/${{ inputs.sdist-name }}"
       run: >-
-        uvx --from cibuildwheel==3.2.1
+        uvx --from cibuildwheel==4.1.0
         cibuildwheel
         --config-file .cibuildwheel.toml
         --output-dir wheelhouse
@@ -71,11 +82,8 @@ jobs:
 
     - name: Build & Test Wheels
       if: runner.os == 'Windows'
-      env:
-        CIBW_ARCHS: "${{ matrix.archs }}"
-        PACKAGE_DIR: "dist/${{ inputs.sdist-name }}"
       run: >-
-        uvx --from cibuildwheel==3.2.1
+        uvx --from cibuildwheel==4.1.0
         cibuildwheel
         --config-file .cibuildwheel.toml
         --output-dir wheelhouse
@@ -84,6 +92,6 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
       with:
-        name: artifact-wheels-${{ matrix.os }}-${{ matrix.archs }}
+        name: "${{ env.ARTIFACT_NAME }}"
         path: wheelhouse/*.whl
         if-no-files-found: error

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -81,6 +81,8 @@ jobs:
       if: inputs.version == ''
       uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
       with:
+        # Profiling only downloads native wheels, whose build artifacts use
+        # runner-and-architecture names.
         name: artifact-wheels-${{ matrix.os }}-${{ matrix.archs }}
         path: dist
         merge-multiple: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ keywords = [
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
+  "Environment :: WebAssembly :: Emscripten",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -1151,9 +1151,13 @@ static PyObject *
 IntLookup_GetInt64(IntLookup *self, int64_t key) {
     if (MS_LIKELY(self->compact)) {
         IntLookupCompact *lk = (IntLookupCompact *)self;
-        Py_ssize_t index = key - lk->offset;
-        if (index >= 0 && index < Py_SIZE(lk)) {
-            return lk->table[index];
+        /* Compute the dense-table index in 64-bit space so large offsets
+         * cannot wrap through Py_ssize_t on 32-bit builds. */
+        if (key >= lk->offset) {
+            uint64_t index = (uint64_t)key - (uint64_t)(lk->offset);
+            if (index < (uint64_t)Py_SIZE(lk)) {
+                return lk->table[(Py_ssize_t)index];
+            }
         }
         return NULL;
     }
@@ -15122,7 +15126,17 @@ static MS_INLINE Py_ssize_t
 mpack_decode_size4(DecoderState *self) {
     char *s = NULL;
     if (mpack_read(self, &s, 4) < 0) return -1;
+#if SIZEOF_VOID_P > 4
     return (Py_ssize_t)(_msgspec_load32(uint32_t, s));
+#else
+    uint32_t size = _msgspec_load32(uint32_t, s);
+    /* MessagePack uint32 sizes can exceed Py_ssize_t on 32-bit builds, so
+     * reject them before they become negative sentinel values. */
+    if (MS_UNLIKELY(size > PY_SSIZE_T_MAX)) {
+        return ms_err_truncated();
+    }
+    return (Py_ssize_t)size;
+#endif
 }
 
 static PyObject *

--- a/tests/unit/test_JSONTestSuite.py
+++ b/tests/unit/test_JSONTestSuite.py
@@ -8,6 +8,28 @@ import pytest
 
 import msgspec
 
+from .utils import emscripten_stack_limited
+
+
+def _max_container_depth(case):
+    depth = max_depth = 0
+    for char in case:
+        if char in (ord("["), ord("{")):
+            depth += 1
+            max_depth = max(depth, max_depth)
+        elif char in (ord("]"), ord("}")):
+            depth -= 1
+    return max_depth
+
+
+def _case_param(case):
+    # JSONTestSuite includes 100,000-deep invalid inputs; Pyodide hits
+    # the JS/Wasm stack before msgspec can raise RecursionError.
+    if _max_container_depth(case) > 1000:
+        return pytest.param(case, marks=emscripten_stack_limited)
+    return case
+
+
 valid_cases = [
     b"[1e-2]",
     b'["\\uD834\\uDd1e"]',
@@ -296,6 +318,8 @@ invalid_cases = [
     b'["x",,]',
     b'{"a":',
 ]
+
+invalid_cases = [_case_param(case) for case in invalid_cases]
 
 
 @pytest.mark.parametrize("case", valid_cases, ids=itertools.count())

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -31,7 +31,7 @@ from typing import (
 
 import pytest
 
-from .utils import max_call_depth, temp_module
+from .utils import emscripten_stack_limited, max_call_depth, temp_module
 
 try:
     import attrs
@@ -4706,6 +4706,7 @@ class TestTypeAlias:
             "type Temp[T] = tuple[T, Ex[T]]; type Ex[T] = tuple[Temp[T], T];",
         ],
     )
+    @emscripten_stack_limited
     def test_recursive_typealias_errors(self, src):
         """Eventually we should support this, but for now just test that it
         errors cleanly"""

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -15,7 +15,7 @@ import pytest
 import msgspec
 from msgspec import Meta, Struct, ValidationError, convert, to_builtins
 
-from .utils import max_call_depth, temp_module
+from .utils import emscripten_stack_limited, max_call_depth, temp_module
 
 try:
     import attrs
@@ -1097,6 +1097,7 @@ class TestNamedTuple:
         with pytest.raises(ValidationError, match="Expected `array`, got `object`"):
             convert({"a": 1, "b": "two"}, Example)
 
+    @emscripten_stack_limited
     def test_namedtuple_cyclic_recursion(self):
         source = """
         from __future__ import annotations

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -19,6 +19,8 @@ import pytest
 
 import msgspec
 
+from .utils import emscripten_stack_limited
+
 UTC = datetime.timezone.utc
 
 
@@ -176,6 +178,7 @@ class TestEncoderMisc:
         return o
 
     @pytest.mark.parametrize("case", [1, 2, 3, 4])
+    @emscripten_stack_limited
     def test_encode_infinite_recursive_object_errors(self, case):
         enc = msgspec.json.Encoder()
         o = getattr(self, "rec_obj%d" % case)()
@@ -238,6 +241,7 @@ class TestEncoderMisc:
         res = json.loads(msg)
         assert res == {"type": "Node", "a": {"type": "Node", "a": 1}}
 
+    @emscripten_stack_limited
     def test_encode_enc_hook_recursion_error(self):
         enc = msgspec.json.Encoder(enc_hook=lambda x: x)
 
@@ -2136,6 +2140,12 @@ class TestDict:
 
         with pytest.raises(TypeError):
             msgspec.json.encode({Custom("x"): 1}, enc_hook=enc_hook)
+
+    @emscripten_stack_limited
+    def test_encode_dict_custom_key_recursion_error(self):
+        class Custom:
+            def __init__(self, value):
+                self.value = value
 
         with pytest.raises(RecursionError):
             msgspec.json.encode({Custom("x"): 1}, enc_hook=lambda x: x)

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -25,6 +25,8 @@ import pytest
 
 import msgspec
 
+from .utils import emscripten_stack_limited
+
 UTC = datetime.timezone.utc
 
 
@@ -308,6 +310,7 @@ class TestEncoderMisc:
         return o
 
     @pytest.mark.parametrize("case", [1, 2, 3, 4])
+    @emscripten_stack_limited
     def test_encode_infinite_recursive_object_errors(self, case):
         enc = msgspec.msgpack.Encoder()
         o = getattr(self, "rec_obj%d" % case)()
@@ -373,6 +376,7 @@ class TestEncoderMisc:
         res = msgspec.msgpack.decode(msg)
         assert res == {"type": "Node", "a": {"type": "Node", "a": 1}}
 
+    @emscripten_stack_limited
     def test_encode_enc_hook_recursion_error(self):
         enc = msgspec.msgpack.Encoder(enc_hook=lambda x: x)
 

--- a/tests/unit/test_raw.py
+++ b/tests/unit/test_raw.py
@@ -8,9 +8,9 @@ import pytest
 
 import msgspec
 
-emscripten = pytest.mark.skipif(
-    sys.platform == "emscripten",
-    reason="Emscripten does not support subprocesses",
+requires_subprocess = pytest.mark.skipif(
+    not getattr(subprocess, "_can_fork_exec", True),
+    reason="subprocess support required",
 )
 
 
@@ -76,7 +76,7 @@ def test_raw_copy():
     assert ref() is None
 
 
-@emscripten
+@requires_subprocess
 def test_raw_copy_doesnt_leak():
     """See https://github.com/msgspec/msgspec/pull/709"""
     script = textwrap.dedent(

--- a/tests/unit/test_raw.py
+++ b/tests/unit/test_raw.py
@@ -8,6 +8,11 @@ import pytest
 
 import msgspec
 
+emscripten = pytest.mark.skipif(
+    sys.platform == "emscripten",
+    reason="Emscripten does not support subprocesses",
+)
+
 
 def test_raw_noargs():
     r = msgspec.Raw()
@@ -71,6 +76,7 @@ def test_raw_copy():
     assert ref() is None
 
 
+@emscripten
 def test_raw_copy_doesnt_leak():
     """See https://github.com/msgspec/msgspec/pull/709"""
     script = textwrap.dedent(

--- a/tests/unit/test_to_builtins.py
+++ b/tests/unit/test_to_builtins.py
@@ -13,6 +13,8 @@ import pytest
 
 from msgspec import UNSET, Struct, UnsetType, defstruct, to_builtins
 
+from .utils import emscripten_stack_limited
+
 PY311 = sys.version_info[:2] >= (3, 11)
 
 py311_plus = pytest.mark.skipif(not PY311, reason="3.11+ only")
@@ -73,6 +75,7 @@ class TestToBuiltins:
         assert to_builtins(1, enc_hook=None) == 1
 
     @pytest.mark.parametrize("case", [1, 2, 3, 4, 5])
+    @emscripten_stack_limited
     def test_to_builtins_recursive(self, case):
         if case == 1:
             o = []

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -5,6 +5,13 @@ import types
 import uuid
 from contextlib import contextmanager
 
+import pytest
+
+emscripten_stack_limited = pytest.mark.skipif(
+    sys.platform == "emscripten",
+    reason="Pyodide can overflow the JS/Wasm stack before raising RecursionError",
+)
+
 
 @contextmanager
 def temp_module(code):


### PR DESCRIPTION
Resolves #1089

### Notes

- The errors that were resolved by the extension changes can be seen in [this run](https://github.com/msgspec/msgspec/actions/runs/27709337400/job/81966407071?pr=1083#step:5:633).
- Some tests for this platform are skipped to avoid crashes such as the one in [this run](https://github.com/msgspec/msgspec/actions/runs/27705230550/job/81952236488?pr=1083#step:5:521). For context, see:
    - https://github.com/pyodide/pyodide/issues/5959
    - https://github.com/pyodide/pyodide/issues/5987
- I also refactored the matrix to allow for defining the target platform rather than just architecture. After this is merged, #987 should be implemented as a new matrix member rather than an entirely separate job.

### References

- https://pyodide.org/en/stable/development/abi.html
- https://cibuildwheel.pypa.io/en/stable/platforms/#pyodide
- https://pyodide.org/en/stable/usage/packages-in-pyodide.html
- https://peps.python.org/pep-0783/

### AI use

I collaborated with GPT-5.5 on Extra High for the following:

- The initial scaffolding for the CI changes (which are mostly no longer present because I disliked the separate job approach).
- The extension changes, primarily for understanding the root cause in order to simplify the logic and create informative code comments.
- A loop to determine if lowering the recursion limit would remove the need to skip some tests but it didn't help for any of them.