### PR TITLE
CI: don't run codspeed on all changes

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -7,6 +7,15 @@ on:
   pull_request:
     branches:
     - main
+    paths:
+      - src/*
+      - tests/prof/*
+      - benchmarks
+      - pyproject.toml
+      - uv.lock
+      - MANIFEST.in
+      - setup.py
+      - .pytest.toml
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Add a path filter to the `codspeed.yml` action, so it doesn't run on e.g. a docs change.