### PR TITLE
Extend CI benchmarking with microbenchmarks for individual types

### DIFF
--- a/tests/prof/perf/test_encode_decode.py
+++ b/tests/prof/perf/test_encode_decode.py
@@ -1,3 +1,10 @@
+import datetime
+import decimal
+import enum
+import random
+import uuid
+from typing import Literal
+
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
@@ -77,3 +84,222 @@ def test_roundtrip_memory(benchmark: BenchmarkFixture, encoder, decoder):
     res = benchmark(func, make_filesystem_data(1000))
 
     assert isinstance(res, Directory)
+
+
+class SomeEnum(enum.Enum):
+    FIELD_1 = enum.auto()
+    FIELD_2 = enum.auto()
+    FIELD_3 = enum.auto()
+    FIELD_4 = enum.auto()
+    FIELD_5 = enum.auto()
+    FIELD_6 = enum.auto()
+    FIELD_7 = enum.auto()
+    FIELD_8 = enum.auto()
+    FIELD_9 = enum.auto()
+    FIELD_10 = enum.auto()
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(msgspec.json, id="json"),
+        pytest.param(msgspec.msgpack, id="msgpack"),
+    ]
+)
+def proto(request):
+    return request.param
+
+
+sample_data_mark = pytest.mark.parametrize(
+    "make_data,target_type",
+    [
+        pytest.param(
+            lambda: random.sample(range(-100_000, 100_000), 10_000), list[int], id="int"
+        ),
+        pytest.param(
+            lambda: [random.uniform(-100_000.0, 100_000.0) for _ in range(10_000)],
+            list[float],
+            id="float",
+        ),
+        pytest.param(
+            lambda: [
+                decimal.Decimal(random.uniform(-100_000.0, 100_000.0))
+                for _ in range(10_000)
+            ],
+            list[decimal.Decimal],
+            id="decimal",
+        ),
+        pytest.param(
+            lambda: [
+                datetime.date(2000, 1, 1) + datetime.timedelta(days=i)
+                for i in range(1, 10_000)
+            ],
+            list[datetime.date],
+            id="date",
+        ),
+        pytest.param(
+            lambda: [
+                datetime.datetime(2000, 1, 1) + datetime.timedelta(seconds=i)
+                for i in range(1, 10_000)
+            ],
+            list[datetime.datetime],
+            id="datetime",
+        ),
+        pytest.param(
+            lambda: [
+                datetime.datetime(2000, 1, 1, tzinfo=datetime.UTC)
+                + datetime.timedelta(seconds=i)
+                for i in range(1, 10_000)
+            ],
+            list[datetime.datetime],
+            id="datetimetz",
+        ),
+        pytest.param(
+            lambda: [datetime.timedelta(seconds=i) for i in range(1, 10_000)],
+            list[datetime.timedelta],
+            id="timedelta",
+        ),
+        pytest.param(
+            lambda: [
+                datetime.time(h, m, s)
+                for h in range(24)
+                for m in range(60)
+                for s in range(60)
+            ],
+            list[datetime.time],
+            id="time",
+        ),
+        pytest.param(
+            lambda: [None for _ in range(10_000)],
+            list[None],
+            id="None",
+        ),
+        pytest.param(
+            lambda: [False for _ in range(10_000)],
+            list[Literal[False]],
+            id="False",
+        ),
+        pytest.param(
+            lambda: [True for _ in range(10_000)],
+            list[Literal[True]],
+            id="True",
+        ),
+        pytest.param(
+            lambda: random.randbytes(10_000),
+            bytes,
+            id="bytes",
+        ),
+        pytest.param(
+            lambda: random.randbytes(10_000),
+            bytearray,
+            id="bytearray",
+        ),
+        pytest.param(
+            lambda: random.randbytes(10_000).hex(),
+            str,
+            id="long_string",
+        ),
+        pytest.param(
+            lambda: [[] * 10_000],
+            list[list],
+            id="list",
+        ),
+        pytest.param(
+            lambda: tuple(() * 10_000),
+            tuple[tuple, ...],
+            id="tuple",
+        ),
+        pytest.param(
+            lambda: [set() for _ in range(10_000)],
+            list[set],
+            id="set",
+        ),
+        pytest.param(
+            lambda: [frozenset() for _ in range(10_000)],
+            list[frozenset],
+            id="frozenset",
+        ),
+        pytest.param(
+            lambda: {str(i): i for i in range(10_000)},
+            dict[str, int],
+            id="dict",
+        ),
+        pytest.param(
+            lambda: [
+                uuid.uuid5(uuid.NAMESPACE_DNS, f"test-{i}") for i in range(10_000)
+            ],
+            list[uuid.UUID],
+            id="uuid",
+        ),
+        pytest.param(
+            lambda: [random.choice(list(SomeEnum)) for _ in range(10_000)],
+            list[SomeEnum],
+            id="enum",
+        ),
+    ],
+)
+
+
+@sample_data_mark
+def test_decode_type(benchmark: BenchmarkFixture, proto, make_data, target_type):
+    data = make_data()
+    encoded = proto.encode(data)
+
+    res = benchmark.pedantic(
+        proto.decode,
+        args=(encoded,),
+        kwargs={"type": target_type},
+        warmup_rounds=10,
+    )
+
+    assert res == data
+
+
+@sample_data_mark
+def test_encode_type(benchmark: BenchmarkFixture, proto, make_data, target_type):
+    data = make_data()
+
+    res = benchmark.pedantic(
+        proto.encode,
+        args=(data,),
+        warmup_rounds=10,
+    )
+
+    assert res == proto.encode(data)
+
+
+@pytest.mark.parametrize(
+    "make_data,target_type",
+    [
+        pytest.param(
+            lambda: random.sample(range(-100_000, 100_000), 10_000), list[int], id="int"
+        ),
+        pytest.param(
+            lambda: [random.uniform(-100_000.0, 100_000.0) for _ in range(10_000)],
+            list[float],
+            id="float",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "encode,decode",
+    [
+        pytest.param(msgspec.json.encode, msgspec.json.decode, id="json"),
+        pytest.param(msgspec.msgpack.encode, msgspec.msgpack.decode, id="msgpack"),
+        pytest.param(lambda v: v, msgspec.convert, id="convert"),
+    ],
+)
+def test_decode_convert_type_non_strict(
+    benchmark: BenchmarkFixture, decode, encode, make_data, target_type
+):
+    data = make_data()
+
+    encoded = encode(data)
+
+    res = benchmark.pedantic(
+        decode,
+        args=(encoded,),
+        kwargs={"strict": False, "type": target_type},
+        warmup_rounds=10,
+    )
+
+    assert res == data

--- a/tests/prof/perf/test_encode_decode.py
+++ b/tests/prof/perf/test_encode_decode.py
@@ -194,6 +194,11 @@ sample_data_mark = pytest.mark.parametrize(
             id="bytearray",
         ),
         pytest.param(
+            lambda: random.randbytes(10_000),
+            memoryview,
+            id="memoryview",
+        ),
+        pytest.param(
             lambda: random.randbytes(10_000).hex(),
             str,
             id="long_string",

--- a/tests/prof/perf/test_module.py
+++ b/tests/prof/perf/test_module.py
@@ -1,13 +1,27 @@
 import subprocess
 import sys
 
+import pytest
 
-def test_import_time(benchmark):
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "msgspec",
+        "msgspec.structs",
+        "msgspec.json",
+        "msgspec.msgpack",
+        "msgspec.inspect",
+        "msgspec.yaml",
+        "msgspec.toml",
+    ],
+)
+def test_import_time(benchmark, module_name):
     # also measures interpreter startup etc., but is the best we can do now, since we
     # don't have a fully isolated module, and some per-process global state, so
     # re-importing purely within the current interpreter doesn't get reliable timings
     def do_import():
-        subprocess.run([sys.executable, "-c", "import msgspec"], check=True)
+        subprocess.run([sys.executable, "-c", f"import {module_name}"], check=True)
 
     do_import()  # execute once to reduce possibility of a super cold FS cache
 

--- a/tests/prof/perf/test_structs.py
+++ b/tests/prof/perf/test_structs.py
@@ -16,6 +16,11 @@ class C{n}(Struct, order=True):
     e: int
 """
 
+TEMPLATE_EMPTY = """
+class C{n}(Struct, order=True):
+    pass
+"""
+
 TEMPLATE_WITH_TAG_TRUE = """
 class C{n}(Struct, order=True, tag=True):
     a: int
@@ -54,9 +59,14 @@ class Item(msgspec.Struct, order=True):
     e: int
 
 
+class EmptyStruct(msgspec.Struct):
+    pass
+
+
 @pytest.mark.parametrize(
     "template",
     [
+        pytest.param(TEMPLATE_EMPTY, id="empty"),
         pytest.param(TEMPLATE, id="basic"),
         pytest.param(TEMPLATE_WITH_TAG_TRUE, id="tagged"),
         pytest.param(TEMPLATE_WITH_CUSTOM_TAG, id="custom_tag"),
@@ -105,6 +115,15 @@ def test_defstruct(benchmark: BenchmarkFixture):
 def test_create(benchmark):
     benchmark.pedantic(
         lambda: [Item(i, i, i, i, i) for i in range(N)],
+        warmup_rounds=10,
+    )
+
+
+@pytest.mark.memory
+def test_empty_struct_create(benchmark: BenchmarkFixture):
+    # empty struct to measure pure overhead without any type nodes
+    benchmark.pedantic(
+        lambda: [EmptyStruct() for _ in range(N)],
         warmup_rounds=10,
     )
 


### PR DESCRIPTION
Before, we only tested overall performance with mixed data. However, this can skew results a bit. 

This introduces targeted, isolated tests for builtin types we support, to make it easier to catch regressions / test improvements for individual type handling. 