### PR TITLE
Fix CodSpeed path filters

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -8,14 +8,15 @@ on:
     branches:
     - main
     paths:
-      - src/*
-      - tests/prof/*
-      - benchmarks
+      - src/**
+      - tests/prof/**
+      - benchmarks/**
       - pyproject.toml
       - uv.lock
       - MANIFEST.in
       - setup.py
       - .pytest.toml
+      - .github/workflows/codspeed.yml
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary
- Make the CodSpeed pull request path filters recursive for source, profiling test, and benchmark files.
- Include the CodSpeed workflow file itself so future workflow edits exercise the workflow.

## Root cause
#1085 added path filters to avoid running CodSpeed on unrelated changes, but patterns like `src/*`, `tests/prof/*`, and `benchmarks` only match direct root-level paths. They do not match files such as `src/msgspec/structs.py` or `tests/prof/perf/test_structs.py`, so performance-related PRs like #1005 can skip the benchmark workflow entirely.

## Validation
```text
git diff --check -- .github/workflows/codspeed.yml
go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/codspeed.yml
```