### PR TITLE
Extend struct performance tests

### DIFF
--- a/tests/prof/perf/test_structs.py
+++ b/tests/prof/perf/test_structs.py
@@ -219,7 +219,15 @@ def test_pickle_load(benchmark: BenchmarkFixture):
 @pytest.fixture(
     params=[
         "msgspec",
-        pytest.param("copy", marks=[pytest.mark.skipif("sys.version_info < (3, 13)")]),
+        pytest.param(
+            "copy",
+            marks=[
+                pytest.mark.skipif(
+                    "sys.version_info < (3, 13)",
+                    reason="only available on 3.13+",
+                )
+            ],
+        ),
     ]
 )
 def replace_fn(request):

--- a/tests/prof/perf/test_structs.py
+++ b/tests/prof/perf/test_structs.py
@@ -1,3 +1,5 @@
+import copy
+import pickle
 import random
 from typing import Annotated
 
@@ -5,7 +7,9 @@ import pytest
 from pytest_codspeed import BenchmarkFixture
 
 import msgspec
+import msgspec.structs
 from msgspec import defstruct
+from msgspec.structs import replace as msgspec_replace
 
 TEMPLATE = """
 class C{n}(Struct, order=True):
@@ -61,6 +65,44 @@ class Item(msgspec.Struct, order=True):
 
 class EmptyStruct(msgspec.Struct):
     pass
+
+
+class Point(msgspec.Struct, order=True):
+    x: int
+    y: int
+
+
+class Account(msgspec.Struct, order=True):
+    id: int
+    balance: float
+    active: bool
+
+
+class Address(msgspec.Struct, order=True):
+    street: str
+    city: str
+    location: Point
+
+
+class Person(msgspec.Struct, order=True):
+    name: str
+    age: int
+    address: Address
+    accounts: list[Account]
+
+
+def make_person(i: int) -> Person:
+    return Person(
+        name=f"person-{i}",
+        age=i,
+        address=Address(
+            street=f"{i} Main St", city="Springfield", location=Point(i, i)
+        ),
+        accounts=[
+            Account(id=i * 10 + j, balance=float(i), active=bool(j % 2))
+            for j in range(3)
+        ],
+    )
 
 
 @pytest.mark.parametrize(
@@ -136,9 +178,107 @@ def test_equality(benchmark):
     benchmark(haystack.index, needle)
 
 
+def test_equality_complex(benchmark: BenchmarkFixture):
+    needle = make_person(N - 1)
+    haystack = [make_person(i) for i in range(N)]
+    random.shuffle(haystack)
+    benchmark(haystack.index, needle)
+
+
 @pytest.mark.memory
 def test_order(benchmark: BenchmarkFixture):
     haystack = [Item(i, i, i, i, i) for i in range(N)]
     random.shuffle(haystack)
 
     benchmark(sorted, haystack)
+
+
+def test_pickle_dump(benchmark: BenchmarkFixture):
+    items = [Item(i, i, i, i, i) for i in range(N)]
+    res = benchmark.pedantic(
+        pickle.dumps,
+        args=(items,),
+        warmup_rounds=10,
+    )
+
+    assert pickle.loads(res) == items
+
+
+def test_pickle_load(benchmark: BenchmarkFixture):
+    items = [Item(i, i, i, i, i) for i in range(N)]
+    dumped = pickle.dumps(items)
+    res = benchmark.pedantic(
+        pickle.loads,
+        args=(dumped,),
+        warmup_rounds=10,
+    )
+
+    assert res == items
+
+
+@pytest.fixture(
+    params=[
+        "msgspec",
+        pytest.param("copy", marks=[pytest.mark.skipif("sys.version_info < (3, 13)")]),
+    ]
+)
+def replace_fn(request):
+    if request.param == "msgspec":
+        return msgspec_replace
+    return copy.replace
+
+
+def test_replace(benchmark: BenchmarkFixture, replace_fn):
+    item = Item(1, 2, 3, 4, 5)
+
+    res = benchmark.pedantic(
+        replace_fn,
+        args=(item,),
+        kwargs={"a": 0},
+        warmup_rounds=10,
+    )
+
+    assert res == Item(0, 2, 3, 4, 5)
+
+
+def test_copy(benchmark: BenchmarkFixture):
+    item = Item(1, 2, 3, 4, 5)
+
+    res = benchmark.pedantic(
+        copy.copy,
+        args=(item,),
+        warmup_rounds=10,
+    )
+
+    assert res == item
+
+
+def test_copy_complex(benchmark: BenchmarkFixture):
+    person = make_person(1)
+
+    res = benchmark.pedantic(
+        copy.copy,
+        args=(person,),
+        warmup_rounds=10,
+    )
+
+    assert res == person
+
+
+@pytest.mark.parametrize(
+    "cls_or_instance",
+    [
+        pytest.param(Item, id="class"),
+        pytest.param(Person, id="complex_class"),
+        pytest.param(Item(1, 2, 3, 4, 5), id="instance"),
+        pytest.param(make_person(1), id="complex_instance"),
+    ],
+)
+def test_fields(benchmark: BenchmarkFixture, cls_or_instance):
+    res = benchmark.pedantic(
+        msgspec.structs.fields,
+        args=(cls_or_instance,),
+        warmup_rounds=10,
+    )
+
+    assert res == msgspec.structs.fields(cls_or_instance)


### PR DESCRIPTION
Extend the continuous benchmarks for structs, to include more common struct operations, and complex structs.