### PR TITLE
Fix reference leak when decoding msgpack Ext payloads

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -16486,7 +16486,10 @@ mpack_decode_ext(
     else if (type->types & MS_TYPE_EXT) {
         data = PyBytes_FromStringAndSize(data_buf, size);
         if (data == NULL) return NULL;
-        return Ext_New(code, data);
+        /* Ext_New doesn't steal the reference to data */
+        out = Ext_New(code, data);
+        Py_DECREF(data);
+        return out;
     }
     else if (!(type->types & MS_TYPE_ANY)) {
         return ms_validation_error("ext", type, path);
@@ -16503,7 +16506,10 @@ mpack_decode_ext(
     else if (self->ext_hook == NULL) {
         data = PyBytes_FromStringAndSize(data_buf, size);
         if (data == NULL) return NULL;
-        return Ext_New(code, data);
+        /* Ext_New doesn't steal the reference to data */
+        out = Ext_New(code, data);
+        Py_DECREF(data);
+        return out;
     }
     else {
         pycode = PyLong_FromLong(code);

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -1339,6 +1339,16 @@ class TestExt:
         out = dec.decode(buf)
         assert out == ext
 
+    @pytest.mark.parametrize("type", [None, msgspec.msgpack.Ext])
+    def test_decode_ext_no_reference_leak(self, type):
+        """https://github.com/msgspec/msgspec/issues/1108"""
+        buf = msgspec.msgpack.encode(msgspec.msgpack.Ext(5, b"ext-leak-test-payload"))
+        kwargs = {} if type is None else {"type": type}
+        ext = msgspec.msgpack.decode(buf, **kwargs)
+        data = ext.data
+        del ext
+        assert sys.getrefcount(data) <= 2  # `data` + getrefcount argument
+
     def test_typed_decoder_skips_ext_hook(self):
         def ext_hook(code, data):
             assert False, "shouldn't ever get called"


### PR DESCRIPTION
Fixes #1108.

`Ext_New` doesn't steal the reference to `data` (it does its own `Py_INCREF`, matching the borrow contract expected by the `Ext` constructor). Both decode branches in `mpack_decode_ext` (typed `Ext` decode, and `Any` decode without an `ext_hook`) passed a fresh reference from `PyBytes_FromStringAndSize` and never released it, leaking one bytes object (the ext payload) per decoded Ext. The `datetime` (code -1) and `ext_hook` branches were not affected.

The fix releases the caller's reference after constructing the `Ext`, same pattern as the `Raw.copy()` leak fix (#709). Verified empirically: RSS delta over 200k decodes of a 1 KiB payload went from ~205 MiB to 0 on both affected branches; the new test fails before the fix (`sys.getrefcount` 3 vs 2) and passes after.

Thanks @K-ANOY for the precise report, the ownership analysis there was spot on.
