### PR TITLE
Fix `__struct_encode_fields__` check in CI

### DIFF
--- a/src/msgspec/__init__.pyi
+++ b/src/msgspec/__init__.pyi
@@ -90,6 +90,7 @@ def field(*, name: str | None = None) -> Any: ...
 class Struct(metaclass=StructMeta):
     __struct_fields__: ClassVar[tuple[str, ...]]
     __struct_config__: ClassVar[structs.StructConfig]
+    __struct_encode_fields__: ClassVar[tuple[str, ...]]
     __match_args__: ClassVar[tuple[str, ...]]
     # A default __init__ so that Structs with unknown field types (say
     # constructed by `defstruct`) won't error on every call to `__init__`


### PR DESCRIPTION
```python
>>> import msgspec
>>> class S(msgspec.Struct):
...     i: int
...     
>>> S(i=1).__struct_encode_fields__
('i',)
```

For some reason CI in https://github.com/msgspec/msgspec/pull/813 passed 🤔 