### PR TITLE
Fix json.encode of a dict keyed by a plain str Enum

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -14153,9 +14153,20 @@ json_encode_enum(EncoderState *self, PyObject *obj, bool is_key)
     PyObject *value = PyObject_GetAttr(obj, self->mod->str__value_);
     if (value == NULL) return -1;
 
-    int status = (
-        is_key ? json_encode_dict_key_noinline(self, value) : json_encode(self, value)
-    );
+    int status;
+    if (is_key) {
+        /* A str value must be written as a JSON object key directly.
+         * json_encode_dict_key_noinline only handles non-str keys (str keys
+         * are fast-pathed in json_encode_dict_key), so recursing into it with
+         * a str value would wrongly raise "unsupported key" - e.g. for a plain
+         * Enum whose members have str values when used as a dict key. */
+        status = PyUnicode_Check(value)
+            ? json_encode_str(self, value)
+            : json_encode_dict_key_noinline(self, value);
+    }
+    else {
+        status = json_encode(self, value);
+    }
 
     Py_DECREF(value);
     return status;

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -2019,6 +2019,7 @@ class TestDict:
             1,
             1.5,
             FruitInt.APPLE,
+            FruitStr.APPLE,
             uuid.uuid4(),
             datetime.datetime.now(),
             datetime.date.today(),
@@ -2036,6 +2037,45 @@ class TestDict:
 
         msg2 = msgspec.json.decode(sol, type=dict[type(key), int])
         assert msg == msg2
+
+    def test_encode_dict_plain_enum_str_key(self):
+        # Regression: a plain `enum.Enum` with str values, used as a dict key.
+        # json.encode previously raised "Only dicts with str-like or
+        # number-like keys are supported", even though `dict[FruitStr, int]` is
+        # an accepted decode type and both msgpack and to_builtins handle it.
+        msg = {FruitStr.APPLE: 1, FruitStr.BANANA: 2}
+
+        res = msgspec.json.encode(msg)
+        assert res == b'{"apple":1,"banana":2}'
+
+        # JSON must agree with the msgpack encoder and with to_builtins.
+        expected = {"apple": 1, "banana": 2}
+        assert msgspec.msgpack.decode(msgspec.msgpack.encode(msg)) == expected
+        assert msgspec.to_builtins(msg, str_keys=True) == expected
+
+        # Full round-trip through the accepted decode type.
+        assert msgspec.json.decode(res, type=dict[FruitStr, int]) == msg
+
+    def test_encode_dict_plain_enum_str_key_nested(self):
+        # The same must hold when the dict is nested inside a Struct field.
+        class Rec(msgspec.Struct):
+            fruits: dict[FruitStr, int]
+
+        rec = Rec(fruits={FruitStr.APPLE: 5})
+        res = msgspec.json.encode(rec)
+        assert res == b'{"fruits":{"apple":5}}'
+        assert msgspec.json.decode(res, type=Rec) == rec
+
+    def test_encode_dict_plain_int_enum_key(self):
+        # A plain Enum with int values (not IntEnum) must keep round-tripping.
+        class IntVals(enum.Enum):
+            A = 1
+            B = 2
+
+        msg = {IntVals.A: 9, IntVals.B: 8}
+        res = msgspec.json.encode(msg)
+        assert res == b'{"1":9,"2":8}'
+        assert msgspec.json.decode(res, type=dict[IntVals, int]) == msg
 
     def test_decode_dict_int_enum_key(self):
         dec = msgspec.json.Decoder(dict[FruitInt, int])


### PR DESCRIPTION
### Problem

Encoding a dict whose keys are members of a plain `enum.Enum` with `str` values
raises, even though the same key type round-trips through every other path:

```python
import msgspec, enum

class Fruit(enum.Enum):
    APPLE = "apple"
    BANANA = "banana"

msgspec.json.decode(b'{"apple": 1}', type=dict[Fruit, int])  # ok
msgspec.msgpack.encode({Fruit.APPLE: 1})                     # ok
msgspec.to_builtins({Fruit.APPLE: 1})                        # ok -> {'apple': 1}
msgspec.json.encode({Fruit.APPLE: 1})
# TypeError: Only dicts with str-like or number-like keys are supported
```

`dict[Fruit, int]` is an accepted *decode* type and both `msgpack.encode` and
`to_builtins` handle the key, so `json.encode` rejecting it is a cross-codec
inconsistency.

### Cause

`json_encode_enum` routes a key's underlying value through
`json_encode_dict_key_noinline`, which only handles non-`str` keys (`str` keys
are fast-pathed in `json_encode_dict_key`). A plain `str`-valued enum therefore
hits the "unsupported key" error.

### Fix

When encoding an enum as a dict key, write a `str` value straight to the key
with `json_encode_str`; non-`str` values keep going through
`json_encode_dict_key_noinline` as before.

### Tests

`test_encode_dict_plain_enum_str_key` covers a plain str `Enum` used as a dict
key (encode output and encode/decode round-trip), and `FruitStr` is added to the
existing mixed-key-type dict test.

`pytest tests/unit/test_json.py` → 1786 passed.
