### PR TITLE
Narrow none_member in JSON schema union handling

### DIFF
--- a/src/msgspec/_json_schema.py
+++ b/src/msgspec/_json_schema.py
@@ -330,7 +330,6 @@ class _SchemaGenerator:
         elif isinstance(t, mi.UnionType):
             structs = {}
             other = []
-            has_none = False
             none_member = None
             tag_field = None
             for subtype in t.types:
@@ -341,7 +340,6 @@ class _SchemaGenerator:
                     tag_field = real_type.tag_field
                     structs[real_type.tag] = real_type
                 elif isinstance(real_type, mi.NoneType):
-                    has_none = True
                     none_member = subtype
                 else:
                     other.append(subtype)
@@ -359,21 +357,21 @@ class _SchemaGenerator:
                 }
                 if options:
                     options.append(struct_schema)
-                    if has_none:
+                    if none_member is not None:
                         options.append(self.to_schema(none_member))
                     schema["anyOf"] = options
-                elif has_none:
+                elif none_member is not None:
                     schema["anyOf"] = [struct_schema, self.to_schema(none_member)]
                 else:
                     schema.update(struct_schema)
             elif len(structs) == 1:
                 _, subtype = structs.popitem()
                 options.append(self.to_schema(subtype))
-                if has_none:
+                if none_member is not None:
                     options.append(self.to_schema(none_member))
                 schema["anyOf"] = options
             else:
-                if has_none:
+                if none_member is not None:
                     options.append(self.to_schema(none_member))
                 schema["anyOf"] = options
         elif isinstance(t, mi.LiteralType):


### PR DESCRIPTION
Follow-up to #1028.

#1028 introduced `none_member: mi.Type | None` in the union branch of `_json_schema.py` and guarded the `self.to_schema(none_member)` calls with a separate `has_none` boolean. mypy can't narrow `none_member` through the flag, so it errors:

```
_json_schema.py:363: error: Argument 1 to "to_schema" of "_SchemaGenerator" has incompatible type "Type | None"; expected "Type"  [arg-type]
```

This is not caught by current CI because the msgspec source is not type-checked there (only `tests/typing` is); #1116 (adding stubtest) is what surfaces it. Fixing it here so #1116 can go green.

The fix drops the redundant `has_none` flag and checks `none_member is not None` at the call sites, which gives mypy the narrowing. No runtime behavior change (`has_none` and `none_member` were always set together): `tests/unit/test_schema.py` still passes (115), and stubtest with mypy 2.2.0 is clean.