### PR TITLE
Fix dec_hook exception type in json.decode docstring

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,8 @@
   `msgspec.to_builtins` ({pr}`1025`).
 - Document that `omit_defaults` ignores fields with a custom
   `default_factory` ({pr}`1076`).
+- Fix the `msgspec.json.decode` docstring to say `dec_hook` should raise
+  `NotImplementedError` for unsupported types, not `TypeError` ({issue}`774`).
 - msgspec moved to the [msgspec GitHub organization](https://github.com/msgspec/msgspec);
   documentation now lives at [msgspec.dev](https://msgspec.dev) (repository
   references updated in {pr}`1045`).

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -19945,7 +19945,7 @@ PyDoc_STRVAR(msgspec_json_decode__doc__,
 "    signature ``dec_hook(type: Type, obj: Any) -> Any``, where ``type`` is the\n"
 "    expected message type, and ``obj`` is the decoded representation composed\n"
 "    of only basic JSON types. This hook should transform ``obj`` into type\n"
-"    ``type``, or raise a ``TypeError`` if unsupported.\n"
+"    ``type``, or raise a ``NotImplementedError`` if unsupported.\n"
 "\n"
 "Returns\n"
 "-------\n"


### PR DESCRIPTION
Fixes #774.

`json.decode` was the only `dec_hook` docstring telling users to raise a
`TypeError` for an unsupported type. `json.Decoder`, `msgpack.decode`,
`msgpack.Decoder`, and `convert` all say `NotImplementedError`, which is the
intended contract you confirmed in #774 (`TypeError`/`ValueError` are for a
value that doesn't match the type). This changes the one line to match.

Grepped the rest of the tree for the wording and this docstring was the only
copy, so there's nothing to fix in the docs or stubs. Added an `## Unreleased`
changelog entry. I pointed it at the issue with `{issue}`774`` since there was
no PR number when I wrote it; happy to swap it to `{pr}` with this PR's number.

Disclosure: I used AI assistance (Claude) to draft this change and reviewed the
result.
