### PR TITLE
fix: raise ValidationError for out-of-range int→float in convert

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -20937,7 +20937,16 @@ convert_int(
         return ms_decode_int_enum_or_literal_pyint(obj, type, path);
     }
     else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(PyLong_AsDouble(obj), type, path);
+        /* PyLong_AsDouble raises OverflowError for ints outside the finite
+         * double range. Surface that as ValidationError so callers matching
+         * json.decode's contract (``Number out of range``) catch it instead
+         * of a leaked SystemError from an unchecked C exception. */
+        double x = PyLong_AsDouble(obj);
+        if (x == -1.0 && PyErr_Occurred()) {
+            PyErr_Clear();
+            return ms_error_with_path("Number out of range%U", path);
+        }
+        return ms_decode_float(x, type, path);
     }
     else if (
         type->types & MS_TYPE_DECIMAL

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -429,6 +429,17 @@ class TestFloat:
         with pytest.raises(ValidationError, match="Expected `float`, got `null`"):
             convert(None, float)
 
+    def test_float_from_out_of_range_int(self):
+        # Ints beyond the finite float range must raise ValidationError
+        # (matching json.decode), not leak SystemError from PyLong_AsDouble.
+        big = 10**400
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert(big, float)
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert({"v": big}, dict[str, float])
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert(-big, float)
+
     @pytest.mark.parametrize(
         "meta, good, bad",
         [


### PR DESCRIPTION
## Summary

`msgspec.convert(big_int, float)` for integers outside the finite double range leaked a `SystemError` (`<built-in function convert> returned a result with an exception set`) instead of raising `msgspec.ValidationError`.

Root cause: `convert_int` called `PyLong_AsDouble(obj)` and passed the result into `ms_decode_float` without checking `PyErr_Occurred()`. When the C conversion overflows, Python sets `OverflowError` but the unchecked path still returns a value, and the interpreter surfaces that as `SystemError`.

`json.decode` already reports the same case as `ValidationError: Number out of range`.

## Fix

In `convert_int`'s `MS_TYPE_FLOAT` branch:

1. Capture `PyLong_AsDouble(obj)`
2. If `x == -1.0 && PyErr_Occurred()`, clear the exception and return `ms_error_with_path("Number out of range%U", path)`
3. Otherwise decode the float as before

## Test plan

- [x] `pytest tests/unit/test_convert.py::TestFloat -q` → **8 passed**
- [x] Manual: `convert(10**400, float)` and nested `dict[str, float]` raise `ValidationError: Number out of range`
- [x] Manual: in-range `convert(5, float) == 5.0` still works
- [x] Matches `json.decode(str(10**400).encode(), type=float)` error class/message

Fixes #1122
